### PR TITLE
Day One: project hygiene, docs, and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ env/
 
 # Unit test / coverage reports
 .coverage
+coverage.xml
 .pytest_cache/
 htmlcov/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md — Earnings Transcript Teacher
+
+This file is read automatically by Claude Code at the start of every session. It describes the project and the conventions Claude should follow when working here.
+
+---
+
+## Project overview
+
+**Earnings Transcript Teacher** is a Python pipeline that parses financial earnings call transcripts and teaches their content interactively.
+
+Two interfaces:
+- **Console UI** — `main.py` (entry point) + `cli/` (display, interactive menu)
+- **Web UI** — `app.py` (Streamlit; run with `streamlit run app.py`)
+
+Core pipeline: `parsing/` → `nlp/` → `services/orchestrator.py` → `db/`
+
+Tests: `pytest` (test suite in `tests/`).
+
+---
+
+## How to run
+
+```bash
+# Console (interactive menu)
+python3 main.py
+
+# Console (direct analysis)
+python3 main.py AAPL --save
+
+# Web UI
+streamlit run app.py
+
+# Tests
+pytest
+pytest --cov=.
+```
+
+---
+
+## Code conventions
+
+### Language and style
+- **Python 3.10+**
+- Follow **PEP 8**: 4-space indentation, snake_case names, max line length ~100 chars.
+- Add **type hints** on all new function signatures (e.g., `def foo(x: str) -> list[str]:`).
+- Add a **one-line docstring** to every new function or class explaining what it does.
+- Prefer **explicit over implicit**: clear variable names over terse ones.
+
+### Architecture rules
+- Keep modules single-responsibility. NLP logic belongs in `nlp/`, DB logic in `db/`, etc.
+- Do not import from `cli/` or `app.py` in core pipeline modules — those are output layers only.
+- Database access goes through `db/repositories.py`, not via raw psycopg calls scattered elsewhere.
+- New dataclasses should go in `core/models.py`.
+
+### Testing
+- Use **pytest** for all tests.
+- Unit tests go in `tests/unit/`, integration tests in `tests/integration/`.
+- Mirror the source tree: tests for `nlp/keywords.py` → `tests/unit/nlp/test_keywords.py`.
+- When adding a new function, add at least one test for the happy path.
+
+---
+
+## How Claude should behave when editing this repo
+
+- **Make small, focused diffs.** One logical change per edit. Don't clean up surrounding code unless asked.
+- **Explain each change** in plain language — the owner is experienced in software engineering but new to Python.
+- **Always read a file before editing it.** Never propose changes to code you haven't seen.
+- **Prefer editing existing files** over creating new ones.
+- **Ask before making architectural changes** (e.g., renaming modules, restructuring packages).
+- **Don't add error handling for impossible cases.** Only validate at real boundaries (user input, external API calls).
+- **No docstrings or comments on code you didn't touch.**
+
+---
+
+## Key dependencies
+
+| Package | Purpose |
+|---|---|
+| `scikit-learn` | TF-IDF, NMF, cosine similarity |
+| `psycopg[binary]` | PostgreSQL driver |
+| `voyageai` | Semantic embeddings (`voyage-finance-2`) |
+| `pgvector` | Vector similarity search in Postgres |
+| `perplexityai` | Feynman learning chat (streaming) |
+| `streamlit` | Web UI framework |
+| `pytest` | Test runner |
+
+---
+
+## Environment variables required
+
+```
+API_NINJAS_KEY        # transcript download
+VOYAGE_API_KEY        # semantic embeddings
+PERPLEXITY_API_KEY    # Feynman chat
+DATABASE_URL          # optional (default: dbname=earnings_teacher)
+ANTHROPIC_API_KEY     # optional (Claude-based ingestion tiers)
+```
+
+---
+
+## Session naming suggestions
+
+Name Claude Code sessions descriptively so you can find them later:
+- `feat: add X feature` — for new features
+- `fix: describe the bug` — for bug fixes
+- `refactor: module name` — for refactoring work
+- `test: module name` — for writing tests
+- `docs: readme/cleanup` — for documentation
+
+Each session should have a **single, well-scoped goal**. If a conversation grows large (500+ lines), start a new session for the next feature.

--- a/README.md
+++ b/README.md
@@ -1,98 +1,177 @@
 # Earnings Transcript Teacher
 
-A robust Python pipeline for analyzing, structuring, and persisting financial earnings call transcripts. It extracts key insights using classical NLP models (TF-IDF, NMF, TextRank) alongside modern semantic search (Voyage AI + `pgvector`), saving all structured data to a local PostgreSQL database.
+A Python pipeline that downloads, parses, and teaches earnings call transcripts. It extracts structured insights using classical NLP (TF-IDF, NMF, TextRank) and modern semantic search (Voyage AI + `pgvector`), stores everything in PostgreSQL, and surfaces it through two interfaces:
+
+- **Console UI** (`main.py`) — interactive terminal menu and direct analysis
+- **Web UI** (`app.py`) — Streamlit browser app with live chat and metadata exploration
+
+---
 
 ## Features
 
-- **Structural Parsing**: Automatically splits raw transcripts into _Prepared Remarks_ and _Q&A_, identifies speakers by role (Executive, Analyst, Operator), and links questions to their corresponding answers.
-- **Key Takeaways (TextRank)**: Extracts the most central, highly-connected sentences from the call using graph-based ranking.
-- **Theme Extraction (NMF)**: Discovers core topics discussed during the call using Non-Negative Matrix Factorization.
-- **Keyword Extraction (TF-IDF)**: Identifies the most statistically significant terms unique to the transcript.
-- **Semantic Search (Voyage AI + pgvector)**: Embeds every speaker turn using `voyage-finance-2` and stores vectors in Postgres.
-- **Feynman Learning Loop**: An interactive, multi-turn AI chat session guided by a strict pedagogical prompt (powered by Perplexity/OpenAI and RAG over the transcript) to help users deeply master the material.
-- **Smart Caching**: Seamlessly caches Voyage AI embeddings in Postgres to eliminate redundant API calls on subsequent runs.
+- **Structural Parsing** — splits raw transcripts into *Prepared Remarks* and *Q&A*, identifies speakers by role (Executive, Analyst, Operator), and links questions to answers.
+- **Key Takeaways (TextRank)** — extracts the most central sentences using graph-based ranking.
+- **Theme Extraction (NMF)** — discovers core topics via Non-Negative Matrix Factorization.
+- **Keyword Extraction (TF-IDF)** — identifies statistically significant terms unique to the transcript.
+- **Semantic Search (Voyage AI + pgvector)** — embeds every speaker turn and stores vectors in Postgres for natural language search.
+- **Feynman Learning Loop** — a multi-turn AI chat session guided by a 5-step pedagogical flow to help you deeply understand the material.
+- **Smart Caching** — reuses cached Voyage AI embeddings from Postgres to avoid redundant API calls.
+
+---
 
 ## Prerequisites
 
-- **Python 3.10+**
-- **PostgreSQL** (with the `pgvector` extension installed)
-- **API Ninjas Key** (for downloading new transcripts)
-- **Voyage AI API Key** (for semantic vector generation)
-- **Perplexity API Key** (for the Feynman learning chat session)
+| Requirement | Notes |
+|---|---|
+| Python 3.10+ | Check with `python3 --version` |
+| PostgreSQL (with `pgvector`) | `brew install pgvector` on macOS |
+| API Ninjas Key | For downloading transcripts |
+| Voyage AI API Key | For generating semantic embeddings |
+| Perplexity API Key | For the Feynman learning chat |
+
+---
 
 ## Setup
 
-1. **Clone and setup the virtual environment:**
+### 1. Create and activate a virtual environment
 
-   ```bash
-   python3 -m venv .venv
-   source .venv/bin/activate
-   pip install -r requirements.txt
-   ```
+A virtual environment keeps this project's Python packages isolated from your system Python. Think of it as a project-scoped package sandbox.
 
-2. **Setup PostgreSQL & pgvector:**
-   Ensure PostgreSQL is running on your machine and you have installed the `pgvector` extension (e.g., `brew install pgvector` on macOS).
+```bash
+python3 -m venv .venv          # create the environment (one-time)
+source .venv/bin/activate      # activate it (every new terminal session)
+```
 
-3. **Initialize the Database:**
-   Create a database called `earnings_teacher` (or set a custom `DATABASE_URL` environment variable) and apply the schema:
+Your prompt will show `(.venv)` when the environment is active. To deactivate: `deactivate`.
 
-   ```bash
-   createdb earnings_teacher
-   psql -d earnings_teacher -f db/schema.sql
-   ```
+### 2. Install dependencies
 
-4. **Set your API Keys:**
-   Export your keys into your environment:
-   ```bash
-   export API_NINJAS_KEY="your-api-ninjas-key"
-   export VOYAGE_API_KEY="your-voyage-api-key"
-   export PERPLEXITY_API_KEY="your-perplexity-api-key"
-   ```
+```bash
+pip install -r requirements.txt
+```
 
-## Usage
+This installs all packages listed in `requirements.txt`. Re-run this whenever the file changes.
 
-### 1. Download a Transcript
+### 3. Set up PostgreSQL and pgvector
 
-Use the provided shell script to download raw earning transcripts directly from the API Ninjas endpoint into the `transcripts/` directory.
+Ensure PostgreSQL is running and create the database:
+
+```bash
+createdb earnings_teacher
+psql -d earnings_teacher -f db/schema.sql
+```
+
+> **macOS tip:** Install pgvector with `brew install pgvector`, then enable it in your DB: `psql -d earnings_teacher -c "CREATE EXTENSION vector;"`.
+
+### 4. Configure API keys
+
+Export your keys as environment variables. The easiest way is to add these lines to your shell profile (`~/.zshrc` or `~/.bash_profile`) so they're set automatically:
+
+```bash
+export API_NINJAS_KEY="your-api-ninjas-key"
+export VOYAGE_API_KEY="your-voyage-api-key"
+export PERPLEXITY_API_KEY="your-perplexity-api-key"
+export DATABASE_URL="dbname=earnings_teacher"   # optional — this is the default
+```
+
+Reload your shell with `source ~/.zshrc` (or open a new terminal).
+
+---
+
+## Running the app
+
+### Console UI (interactive terminal menu)
+
+```bash
+python3 main.py
+```
+
+This launches the interactive menu where you can download transcripts, run analysis, chat with the Feynman learning loop, and run semantic search.
+
+### Console UI (direct analysis, no menu)
+
+```bash
+python3 main.py AAPL            # analyze and print results
+python3 main.py AAPL --save     # analyze and save to PostgreSQL
+```
+
+### Web UI (Streamlit browser app)
+
+```bash
+streamlit run app.py
+```
+
+Open `http://localhost:8501` in your browser. The web UI shows themes, takeaways, keywords, and vocabulary on the left; a live AI chat panel on the right.
+
+You can also launch the web UI from the console menu by choosing `--mode gui`:
+
+```bash
+python3 main.py --mode gui
+```
+
+---
+
+## Running tests
+
+```bash
+pytest                      # run all tests
+pytest tests/unit/          # run only unit tests
+pytest -v                   # verbose output (shows each test name)
+pytest --cov=.              # run with coverage report
+```
+
+---
+
+## Downloading a transcript
 
 ```bash
 ./download_transcript.sh MSFT
 ```
 
-### 2. Analyze a Transcript
+This calls the API Ninjas endpoint and saves the raw JSON to `transcripts/MSFT.json`. The `transcripts/` directory is git-ignored (local data only).
 
-The main script reads `.json` transcripts from the `transcripts/` directory, processes them through the NLP pipeline, and displays the results in the terminal.
+---
 
-```bash
-# Analyze the Microsoft (MSFT) transcript and print insights
-python3 main.py MSFT
-```
+## Semantic search
 
-### 3. Persist to Postgres
-
-Use the `--save` flag to insert all extracted data (calls, speakers, spans, Q&A pairs, topics, keywords, and semantic embeddings) into your local `earnings_teacher` Postgres database.
+Once transcripts are saved with `--save`, search across all of them:
 
 ```bash
-# Analyze and save to the database
-python3 main.py AAPL --save
-```
-
-_Note: If a transcript's embeddings already exist in the database, the pipeline will automatically load them from the cache instead of querying the Voyage API._
-
-### 4. Semantic Search
-
-Once you have persisted transcripts into the database with embeddings, you can run natural language searches across all ingested calls using the `search.py` utility.
-
-```bash
-# Search across all saved spans using cosine similarity
 python3 db/search.py "AI infrastructure capital expenditures" -k 5
 ```
 
+---
+
 ## Architecture
 
-The project is broken down into modular components:
+```
+earnings-transcript-teacher/
+├── main.py             # Console UI entry point
+├── app.py              # Web UI entry point (Streamlit)
+├── requirements.txt    # Python dependencies
+│
+├── core/               # Shared dataclasses (CallAnalysis, SpanRecord, etc.)
+├── parsing/            # Transcript loading and regex-based section extraction
+├── nlp/                # NLP algorithms (TF-IDF keywords, NMF themes, TextRank takeaways)
+├── services/           # Orchestration and LLM integration
+│   ├── orchestrator.py # Main analysis pipeline — wires all modules together
+│   └── llm.py          # Perplexity/Claude API client with rate limiting
+├── ingestion/          # Agentic chunking pipeline for LLM enrichment
+├── cli/                # Console UI display and interactive menu
+├── db/                 # PostgreSQL access layer and semantic search
+├── utils/              # Shared utilities (timing decorator)
+├── prompts/feynman/    # Pedagogical prompt files for the Feynman learning loop
+└── tests/              # pytest test suite (unit + integration)
+```
 
-- `download_transcript.sh`: Bash script for fetching raw transcripts from API Ninjas.
-- `transcript/`: Core NLP pipeline modules (`models.py`, `sections.py`, `keywords.py`, `themes.py`, `takeaways.py`, `embedder.py`).
-- `db/`: Database layer (`schema.sql`, `persistence.py`, `search.py`).
-- `main.py`: Orchestrator script that ties the pipeline together.
+---
+
+## Environment variable reference
+
+| Variable | Required | Description |
+|---|---|---|
+| `API_NINJAS_KEY` | Yes (download) | API key for fetching raw transcripts |
+| `VOYAGE_API_KEY` | Yes (embeddings) | Voyage AI key for semantic vector generation |
+| `PERPLEXITY_API_KEY` | Yes (chat) | Perplexity key for Feynman learning chat |
+| `DATABASE_URL` | No | PostgreSQL connection string (default: `dbname=earnings_teacher`) |
+| `ANTHROPIC_API_KEY` | No | Anthropic key for Claude-based LLM tiers in ingestion |

--- a/app.py
+++ b/app.py
@@ -7,7 +7,6 @@ from db.persistence import (
     get_takeaways_for_ticker,
     get_keywords_for_ticker,
     get_extracted_terms_for_ticker,
-    get_extracted_terms_for_ticker,
     update_term_definition,
     update_term_explanation,
     search_spans
@@ -299,7 +298,7 @@ with right_col:
                 # Inject jargon if user asked about it
                 if any(w in prompt.lower() for w in ["jargon", "vocabulary", "terms"]):
                     if jargon:
-                        jargon_str = "Extracted Jargon:\n" + "\n".join([f"- {t}: {d}" for t, d in jargon])
+                        jargon_str = "Extracted Jargon:\n" + "\n".join([f"- {t}: {d}" for t, d, _ in jargon])
                         context_spans.append(jargon_str)
                         
                 # Format final API messages

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import subprocess
 
@@ -15,6 +16,11 @@ from nlp.embedder import get_embeddings
 from services.llm import stream_chat
 from services.orchestrator import analyze
 from cli.display import display
+
+def _validate_ticker(ticker: str) -> bool:
+    """Return True if ticker is 1-5 uppercase alphabetical characters (e.g. AAPL, MSFT)."""
+    return bool(re.match(r'^[A-Z]{1,5}$', ticker))
+
 
 def interactive_menu() -> None:
     """Run the interactive CLI menu loop."""
@@ -36,7 +42,8 @@ def interactive_menu() -> None:
         
         if choice == "1":
             ticker = input("Enter the ticker symbol (e.g. MSFT): ").strip().upper()
-            if not ticker:
+            if not _validate_ticker(ticker):
+                print("Invalid ticker. Please enter 1-5 letters (e.g. MSFT, AAPL).")
                 continue
                 
             print(f"\nDownloading transcript for {ticker}...")
@@ -67,13 +74,15 @@ def interactive_menu() -> None:
                     
         elif choice == "4":
             ticker = input("Enter the ticker symbol to study: ").strip().upper()
-            if ticker:
+            if not _validate_ticker(ticker):
+                print("Invalid ticker. Please enter 1-5 letters (e.g. MSFT, AAPL).")
+            else:
                 calls = get_all_calls(conn_str)
                 saved_tickers = [c[0] for c in calls]
                 
                 if ticker not in saved_tickers:
-                     print(f"\nTranscript for {ticker} not found in the database.")
-                     print("Please use Option 1 to download and ingest it first.")
+                    print(f"\nTranscript for {ticker} not found in the database.")
+                    print("Please use Option 1 to download and ingest it first.")
                 else:
                     print(f"\nStarting Feynman session on {ticker}...")
                     
@@ -274,13 +283,15 @@ def interactive_menu() -> None:
                         
         elif choice == "5":
             ticker = input("Enter the ticker symbol to view: ").strip().upper()
-            if ticker:
+            if not _validate_ticker(ticker):
+                print("Invalid ticker. Please enter 1-5 letters (e.g. MSFT, AAPL).")
+            else:
                 calls = get_all_calls(conn_str)
                 saved_tickers = [c[0] for c in calls]
                 
                 if ticker not in saved_tickers:
-                     print(f"\nTranscript for {ticker} not found in the database.")
-                     print("Please use Option 1 to download and ingest it first.")
+                    print(f"\nTranscript for {ticker} not found in the database.")
+                    print("Please use Option 1 to download and ingest it first.")
                 else:
                     themes = get_themes_for_ticker(conn_str, ticker)
                     takeaways = get_takeaways_for_ticker(conn_str, ticker)
@@ -312,13 +323,15 @@ def interactive_menu() -> None:
                         
         elif choice == "3":
             ticker = input("Enter the ticker symbol to study: ").strip().upper()
-            if ticker:
+            if not _validate_ticker(ticker):
+                print("Invalid ticker. Please enter 1-5 letters (e.g. MSFT, AAPL).")
+            else:
                 calls = get_all_calls(conn_str)
                 saved_tickers = [c[0] for c in calls]
                 
                 if ticker not in saved_tickers:
-                     print(f"\nTranscript for {ticker} not found in the database.")
-                     print("Please use Option 1 to download and ingest it first.")
+                    print(f"\nTranscript for {ticker} not found in the database.")
+                    print("Please use Option 1 to download and ingest it first.")
                 else:
                     print(f"\nStarting Interactive Q&A on {ticker}...")
                     

--- a/tests/unit/cli/test_menu.py
+++ b/tests/unit/cli/test_menu.py
@@ -1,0 +1,18 @@
+from cli.menu import _validate_ticker
+
+
+def test_valid_tickers():
+    assert _validate_ticker("AAPL") is True
+    assert _validate_ticker("MSFT") is True
+    assert _validate_ticker("A") is True       # single-letter tickers are valid (e.g. A = Agilent)
+    assert _validate_ticker("GOOGL") is True   # 5-letter ticker
+
+
+def test_invalid_tickers():
+    assert _validate_ticker("") is False                # empty string
+    assert _validate_ticker("TOOLONG") is False         # more than 5 chars
+    assert _validate_ticker("123") is False             # digits only
+    assert _validate_ticker("AAP1") is False            # contains a digit
+    assert _validate_ticker("aapl") is False            # lowercase (must already be uppercased by caller)
+    assert _validate_ticker("AAPL Q3") is False         # spaces not allowed
+    assert _validate_ticker("AAPL.") is False           # punctuation not allowed


### PR DESCRIPTION
## Summary

- **README.md** — full rewrite with beginner-friendly setup instructions, Streamlit run command, env var reference table, and updated architecture diagram (old version referenced a `transcript/` module that no longer exists)
- **CLAUDE.md** — new file that Claude Code reads automatically; defines project conventions (PEP 8, type hints, docstrings), coding rules, and session naming guidance
- **.gitignore** — adds `coverage.xml` (was being generated by pytest-cov but not ignored)
- **cli/menu.py** — adds `_validate_ticker()` helper (regex `^[A-Z]{1,5}$`) wired into all four ticker input points, catching invalid inputs (digits, long strings, spaces) before they reach the download script; fixes 21→20 space indentation inconsistency on three `if`-block bodies
- **app.py** — removes duplicate `get_extracted_terms_for_ticker` import; fixes a `ValueError` bug where jargon 3-tuples were unpacked as 2-tuples in the General Q&A jargon injection path
- **tests/unit/cli/test_menu.py** — new test file with 7 cases covering `_validate_ticker` (valid and invalid inputs)

## Test plan

- [ ] `pytest tests/unit/ -v` — all 24 unit tests pass (including 2 new ones)
- [ ] Run `python3 main.py`, enter invalid ticker (e.g. `123`, `TOOLONG`) — should show validation message instead of calling download script
- [ ] Run `streamlit run app.py`, ask about "jargon" in General Q&A — should no longer raise ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)