### PR TITLE
:bug: Fail fast during transcript ingestion if schema is out of date

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,18 +47,40 @@ def load_transcripts():
 
 @st.cache_data
 def auto_migrate():
-    """Ensure database schema is up to date."""
+    """Ensure database schema is up to date and check version."""
     try:
         import psycopg
+        from db.repositories import SchemaRepository
+        
+        # Original simple migration
         with psycopg.connect(CONN_STR) as conn:
             with conn.cursor() as cur:
                 cur.execute("ALTER TABLE extracted_terms ADD COLUMN IF NOT EXISTS explanation TEXT DEFAULT '';")
+                # Also ensure schema_version table exists for version 1 initialization
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS schema_version (
+                        version     INTEGER PRIMARY KEY,
+                        installed_at TIMESTAMPTZ DEFAULT now()
+                    );
+                """)
+                cur.execute("INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;")
             conn.commit()
+            
+        # Version check
+        schema_repo = SchemaRepository(CONN_STR)
+        is_ok, error_msg = schema_repo.check_health()
+        if not is_ok:
+            st.error(f"⚠️ {error_msg}")
+            # We don't st.stop() here because the user might just want to browse existing data,
+            # but ingestion should still fail if they try it.
+            return False
+        return True
     except Exception as e:
-        print(f"Auto-migrate failed: {e}")
+        st.warning(f"Auto-migrate/Health check failed: {e}")
+        return False
 
-# Run migration once per Streamlit session
-auto_migrate()
+# Run migration and check once per Streamlit session
+schema_is_ok = auto_migrate()
 
 @st.cache_data
 def load_speakers(ticker: str) -> list[tuple[str, str, str | None, str | None]]:

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -1,10 +1,18 @@
 import uuid
 import logging
 import psycopg
+import psycopg.errors
 from pgvector.psycopg import register_vector
 from core.models import CallAnalysis
 
 logger = logging.getLogger(__name__)
+
+class OutdatedSchemaError(Exception):
+    """Exception raised when the database schema is out of date."""
+    pass
+
+REQUIRED_SCHEMA_VERSION = 1
+
 
 def reset_all_data(conn_str: str) -> None:
     """Delete all application data from the database, preserving the schema."""
@@ -15,6 +23,36 @@ def reset_all_data(conn_str: str) -> None:
             cur.execute("DELETE FROM learning_sessions")
             cur.execute("DELETE FROM calls")
         conn.commit()
+
+
+class SchemaRepository:
+    def __init__(self, conn_str: str):
+        self.conn_str = conn_str
+
+    def get_current_version(self) -> int:
+        """Get the current schema version from the database. Returns 0 if table missing or empty."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT version FROM schema_version ORDER BY installed_at DESC LIMIT 1")
+                    row = cur.fetchone()
+                    return row[0] if row else 0
+        except psycopg.errors.UndefinedTable:
+            return 0
+        except Exception as e:
+            logger.warning(f"Error checking schema version: {e}")
+            return 0
+
+    def check_health(self) -> tuple[bool, str]:
+        """Check if the database schema is up to date."""
+        current_version = self.get_current_version()
+        if current_version < REQUIRED_SCHEMA_VERSION:
+            if current_version == 0:
+                msg = "Database schema version table is missing. Re-initialize the database."
+            else:
+                msg = f"Database schema is outdated (current: {current_version}, required: {REQUIRED_SCHEMA_VERSION})."
+            return False, f"{msg} Run 'python migrate.py' or './reset_db.sh' to update."
+        return True, "Database schema is up to date."
 
 
 class CallRepository:

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -7,6 +7,15 @@
 
 CREATE EXTENSION IF NOT EXISTS vector;
 
+-- Schema versioning
+CREATE TABLE schema_version (
+    version     INTEGER PRIMARY KEY,
+    installed_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Initialize version
+INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;
+
 
 -- One row per earnings call
 CREATE TABLE calls (

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import sys
 import argparse
 import os
 
-from services.orchestrator import analyze
+from services.orchestrator import analyze, OutdatedSchemaError
 from cli.display import display
 from cli.menu import interactive_menu
 
@@ -50,8 +50,12 @@ if __name__ == "__main__":
     else:
         # Legacy CLI direct-analysis mode
     
-        result = analyze(args.ticker)
-        display(result)
+        try:
+            result = analyze(args.ticker)
+            display(result)
+        except OutdatedSchemaError as e:
+            print(f"\n❌ ERROR: {e}", file=sys.stderr)
+            sys.exit(1)
     
         if args.save:
             from db.persistence import save_analysis

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -21,11 +21,19 @@ from core.models import (
 )
 from nlp.embedder import get_embeddings
 from db.persistence import fetch_existing_embeddings
+from db.repositories import SchemaRepository, OutdatedSchemaError
 
 logger = logging.getLogger(__name__)
 
 def analyze(ticker: str = "MSFT") -> CallAnalysis:
     """Run the full analysis pipeline and return structured results."""
+    # Safety Check: Fail fast if schema is out of date
+    conn_str = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
+    schema_repo = SchemaRepository(conn_str)
+    is_ok, error_msg = schema_repo.check_health()
+    if not is_ok:
+        raise OutdatedSchemaError(error_msg)
+
     ticker = ticker.upper()
     file_path = f"./transcripts/{ticker}.json"
     content = read_text_file(file_path)

--- a/tests/integration/db/test_schema_version.py
+++ b/tests/integration/db/test_schema_version.py
@@ -1,0 +1,86 @@
+import pytest
+import psycopg
+import psycopg.errors
+from unittest.mock import MagicMock, patch
+from db.repositories import SchemaRepository, REQUIRED_SCHEMA_VERSION
+
+def test_get_current_version_success():
+    m_connect = MagicMock()
+    m_cursor = MagicMock()
+    m_connect.__enter__.return_value = m_connect
+    m_cursor.__enter__.return_value = m_cursor
+    m_connect.cursor.return_value = m_cursor
+    m_cursor.fetchone.return_value = (1,)
+    
+    with patch('psycopg.connect', return_value=m_connect):
+        repo = SchemaRepository("fake_conn")
+        version = repo.get_current_version()
+        
+    assert version == 1
+
+def test_get_current_version_missing_table():
+    m_connect = MagicMock()
+    m_cursor = MagicMock()
+    m_connect.__enter__.return_value = m_connect
+    m_cursor.__enter__.return_value = m_cursor
+    m_connect.cursor.return_value = m_cursor
+    m_cursor.execute.side_effect = psycopg.errors.UndefinedTable("Table not found")
+    
+    with patch('psycopg.connect', return_value=m_connect):
+        repo = SchemaRepository("fake_conn")
+        version = repo.get_current_version()
+        
+    assert version == 0
+
+def test_check_health_ok():
+    m_connect = MagicMock()
+    m_cursor = MagicMock()
+    m_connect.__enter__.return_value = m_connect
+    m_cursor.__enter__.return_value = m_cursor
+    m_connect.cursor.return_value = m_cursor
+    m_cursor.fetchone.return_value = (REQUIRED_SCHEMA_VERSION,)
+    
+    with patch('psycopg.connect', return_value=m_connect):
+        repo = SchemaRepository("fake_conn")
+        is_ok, msg = repo.check_health()
+    
+    assert is_ok is True
+    assert "up to date" in msg
+
+def test_check_health_outdated():
+    m_connect = MagicMock()
+    m_cursor = MagicMock()
+    m_connect.__enter__.return_value = m_connect
+    m_cursor.__enter__.return_value = m_cursor
+    m_connect.cursor.return_value = m_cursor
+    # Explicitly set the version to 0 to trigger the "outdated" branch (if version < REQUIRED_SCHEMA_VERSION)
+    m_cursor.fetchone.return_value = (0,)
+    
+    with patch('psycopg.connect', return_value=m_connect):
+        repo = SchemaRepository("fake_conn")
+        is_ok, msg = repo.check_health()
+    
+    assert is_ok is False
+    # If version is 0 and REQUIRED_SCHEMA_VERSION is 1, it should say "missing" or "outdated" 
+    # based on our logic in repositories.py:
+    # if current_version < REQUIRED_SCHEMA_VERSION:
+    #     if current_version == 0: msg = "... missing ..."
+    assert "missing" in msg
+
+def test_check_health_explicit_outdated():
+    # Test the case where version is > 0 but < REQUIRED
+    m_connect = MagicMock()
+    m_cursor = MagicMock()
+    m_connect.__enter__.return_value = m_connect
+    m_cursor.__enter__.return_value = m_cursor
+    m_connect.cursor.return_value = m_cursor
+    
+    # We need to temporarily mock REQUIRED_SCHEMA_VERSION to 2 to test this
+    with patch('db.repositories.REQUIRED_SCHEMA_VERSION', 2):
+        m_cursor.fetchone.return_value = (1,)
+        with patch('psycopg.connect', return_value=m_connect):
+            repo = SchemaRepository("fake_conn")
+            is_ok, msg = repo.check_health()
+            
+    assert is_ok is False
+    assert "outdated" in msg


### PR DESCRIPTION
closes #11 

# PR Description: Fail fast during ingestion (#11)
## Summary
This PR implements a "fail fast" mechanism for transcript ingestion. The application now verifies the database schema version before starting any expensive LLM-based analysis or API calls (embeddings, agentic ingestion). If the schema is outdated, the process fails immediately with clear instructions for the user on how to update their database.