### PR TITLE
Ground industry term extraction and definitions in company context

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from db.persistence import (
 )
 from nlp.embedder import get_embeddings
 from services.llm import stream_chat
+from db.repositories import AnalysisRepository
 
 # ------------- Configuration -------------
 
@@ -63,7 +64,7 @@ def auto_migrate():
                         installed_at TIMESTAMPTZ DEFAULT now()
                     );
                 """)
-                cur.execute("INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;")
+                cur.execute("INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;")
             conn.commit()
             
         # Version check
@@ -144,11 +145,22 @@ def handle_explain_click(ticker: str, term: str, current_exp: str):
         st.session_state[f"show_exp_{ticker}_{term}"] = True
 
 def generate_definition(ticker: str, term: str) -> bool:
-    """Call the LLM to generate a general dictionary definition, then save it."""
+    """Call the LLM to generate a company-grounded definition, then save it."""
     with st.spinner(f"Defining {term}..."):
         try:
-            system_prompt = "You are a precise financial dictionary. Define the provided term generally in 1-2 sentences. Return ONLY the definition text."
-            messages = [{"role": "user", "content": f"Term: {term}"}]
+            repo = AnalysisRepository(CONN_STR)
+            company_name, industry = repo.get_company_info(ticker)
+            if company_name and industry:
+                context = f"{company_name} ({ticker}) — {industry}"
+            elif company_name:
+                context = f"{company_name} ({ticker})"
+            else:
+                context = ticker
+            system_prompt = (
+                f"You are a precise financial analyst. Define the provided term in the context of "
+                f"{context}. Return ONLY the definition, 1-2 sentences."
+            )
+            messages = [{"role": "user", "content": f"Company: {context}\nTerm: {term}"}]
             
             definition = ""
             for chunk in stream_chat(messages, system_prompt, model="sonar-pro"):

--- a/core/models.py
+++ b/core/models.py
@@ -34,6 +34,8 @@ class CallRecord:
     prepared_len: int
     qa_len: int
     id: UUID = field(default_factory=uuid4)
+    company_name: str = ""
+    industry: str = ""
 
 
 @dataclass

--- a/db/migrations/002_add_industry_to_calls.sql
+++ b/db/migrations/002_add_industry_to_calls.sql
@@ -1,0 +1,3 @@
+-- Migration 002: Add industry column to calls table
+ALTER TABLE calls ADD COLUMN IF NOT EXISTS industry TEXT;
+INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -11,7 +11,7 @@ class OutdatedSchemaError(Exception):
     """Exception raised when the database schema is out of date."""
     pass
 
-REQUIRED_SCHEMA_VERSION = 1
+REQUIRED_SCHEMA_VERSION = 2
 
 
 def reset_all_data(conn_str: str) -> None:
@@ -58,6 +58,22 @@ class SchemaRepository:
 class CallRepository:
     def __init__(self, conn_str: str):
         self.conn_str = conn_str
+
+    def get_company_info(self, ticker: str) -> tuple[str, str]:
+        """Return (company_name, industry) for a ticker, or empty strings if not found."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT company_name, industry FROM calls WHERE ticker = %s LIMIT 1",
+                        (ticker,),
+                    )
+                    row = cur.fetchone()
+                    if row:
+                        return (row[0] or "", row[1] or "")
+        except Exception as e:
+            logger.warning(f"Could not fetch company info for {ticker}: {e}")
+        return ("", "")
 
     def get_all_calls(self) -> list[tuple[str, str]]:
         calls = []
@@ -438,15 +454,16 @@ class AnalysisRepository:
         cur.execute(
             """
             INSERT INTO calls (
-                id, ticker, company_name, fiscal_quarter, call_date,
+                id, ticker, company_name, industry, fiscal_quarter, call_date,
                 transcript_json, transcript_text, token_count,
                 prepared_len, qa_len
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 str(call.id),
                 call.ticker,
-                None,  # company_name
+                call.company_name or None,
+                call.industry or None,
                 fiscal_quarter,
                 None,  # call_date
                 call.transcript_json,

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE schema_version (
 );
 
 -- Initialize version
-INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;
 
 
 -- One row per earnings call
@@ -22,6 +22,7 @@ CREATE TABLE calls (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     ticker          TEXT NOT NULL,
     company_name    TEXT,
+    industry        TEXT,
     fiscal_quarter  TEXT,                              -- e.g. 'Q3 2025'
     call_date       DATE,
     transcript_json TEXT,                              -- raw API response

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -207,11 +207,21 @@ class IngestionPipeline:
         # Initialize the LLM client wrapper
         from services.llm import AgenticExtractor
         self.extractor = AgenticExtractor()
+        self.company_context: str = ""
 
     def process(self, analysis: CallAnalysis) -> List[TranscriptChunk]:
         """Run the full ingestion pipeline on a parsed CallAnalysis."""
         logger.info(f"Starting agentic ingestion for {analysis.call.ticker}")
-        
+
+        # Build company context string for LLM prompts
+        call = analysis.call
+        if call.company_name and call.industry:
+            self.company_context = f"{call.company_name} ({call.ticker}) — {call.industry}"
+        elif call.company_name:
+            self.company_context = f"{call.company_name} ({call.ticker})"
+        else:
+            self.company_context = call.ticker
+
         chunks = create_chunks_from_analysis(analysis)
         prep_count = sum(1 for c in chunks if c.chunk_type == 'prepared')
         qa_count = sum(1 for c in chunks if c.chunk_type == 'qa')
@@ -226,7 +236,7 @@ class IngestionPipeline:
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Map chunk indices to future objects so we know which is which when completed
             future_to_chunk = {
-                executor.submit(self._process_single_chunk, chunk, i, len(chunks)): chunk 
+                executor.submit(self._process_single_chunk, chunk, i, len(chunks), self.company_context): chunk
                 for i, chunk in enumerate(chunks, 1)
             }
             
@@ -277,14 +287,14 @@ class IngestionPipeline:
         print("✅ Agentic ingestion complete.\n")
         return chunks
         
-    def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int) -> None:
+    def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int, company_context: str = "") -> None:
         """Helper method to process a single chunk, designed to run in a thread."""
         logger.info(f"Processing chunk {chunk.chunk_id} [{index}/{total_chunks}]")
         # print relies on thread-safety of the built-in print, but might interleave slightly in stdout.
         # This is usually fine for a simple UI, but could be logged instead.
         print(f"  [{index}/{total_chunks}] Analysing {chunk.chunk_id}... ")
-        
-        t1_usage = self._run_tier1(chunk)
+
+        t1_usage = self._run_tier1(chunk, company_context)
         if t1_usage:
             logger.info(f"Chunk {chunk.chunk_id} - Tier 1 usage: {t1_usage}")
             # print(f"    ↳ Tier 1 [Model: {t1_usage['model']} | In: {t1_usage['prompt_tokens']} | Out: {t1_usage['completion_tokens']}]")
@@ -300,9 +310,9 @@ class IngestionPipeline:
             logger.info(f"Chunk {chunk.chunk_id} - Skipping Tier 2 (Score: {getattr(chunk, 'tier1_score', 0)})")
             # print(f"    ↳ Skipping Tier 2 for {chunk.chunk_id} (Score: {getattr(chunk, 'tier1_score', 0)}).")
         
-    def _run_tier1(self, chunk: TranscriptChunk) -> Optional[Dict[str, Any]]:
+    def _run_tier1(self, chunk: TranscriptChunk, company_context: str = "") -> Optional[Dict[str, Any]]:
         """Run Tier 1 extraction: LLM for industry terms + CSV scan for financial terms."""
-        tier1_data = self.extractor.extract_tier1(chunk.text, chunk.chunk_type)
+        tier1_data = self.extractor.extract_tier1(chunk.text, chunk.chunk_type, company_context)
 
         industry_terms = [
             {**t, "category": "industry"}

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -3,19 +3,29 @@ import json
 TIER_1_SYSTEM_PROMPT = """You are an expert financial analyst assistant.
 Your task is to analyze a chunk of an earnings call transcript and extract structured metadata.
 
+The transcript chunk will include a ### Company header that identifies the company and its industry. \
+Use this context when deciding whether a term qualifies as genuine jargon for that company and sector.
+
 Follow these instructions:
 1. Identify industry-specific or company-specific jargon: proprietary product names, company-coined metrics, \
 industry acronyms, or technical terms a general audience would not know. \
+Use the provided company and industry context to judge relevance — a term that is jargon for an EV manufacturer \
+may be generic language in another sector. \
 Do NOT include general financial terms that appear in a standard financial dictionary \
-(e.g. GAAP, EBITDA, EPS, CapEx, gross margin, free cash flow, guidance, headwinds) — those are handled separately.
-2. Identify the core concepts (1-3 sentences or bullet points) that summarize the most strategic topics discussed in this chunk.
-3. Score the strategic importance/complexity of this chunk on a scale of 1 to 10 (1 = total boilerplate/pleasantries, 10 = critical financial guidance, deep strategic debate, or major product announcements).
-4. Decide if this chunk requires deeper pedagogical analysis (requires_deep_analysis). Set to true if the score is >= 6.
+(e.g. GAAP, EBITDA, EPS, CapEx, gross margin, free cash flow, guidance, headwinds) — those are handled separately. \
+Do NOT extract: generic superlatives or adjective phrases (e.g. "Amazing Abundance", "Incredible Journey"), \
+motivational or mission-statement language, names of individual people, city or state names unless part of a \
+product name, or vague strategic phrases with no specific technical content.
+2. For each extracted term, provide a one-sentence definition grounded in the company and industry context — \
+not a generic dictionary definition.
+3. Identify the core concepts (1-3 sentences or bullet points) that summarize the most strategic topics discussed in this chunk.
+4. Score the strategic importance/complexity of this chunk on a scale of 1 to 10 (1 = total boilerplate/pleasantries, 10 = critical financial guidance, deep strategic debate, or major product announcements).
+5. Decide if this chunk requires deeper pedagogical analysis (requires_deep_analysis). Set to true if the score is >= 6.
 
 Respond ONLY with valid JSON matching this schema:
 {
   "extracted_terms": [
-    {"term": "string"}
+    {"term": "string", "definition": "string"}
   ],
   "core_concepts": [
     "string"

--- a/services/company_info.py
+++ b/services/company_info.py
@@ -1,0 +1,25 @@
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+_EDGAR_URL = "https://data.sec.gov/submissions/CIK{cik:010d}.json"
+
+
+def fetch_company_info(cik: str | int) -> tuple[str, str]:
+    """Return (company_name, industry) from the SEC EDGAR API using the CIK.
+
+    Falls back to empty strings on any error so ingestion is never blocked.
+    """
+    try:
+        cik_int = int(cik)
+        url = _EDGAR_URL.format(cik=cik_int)
+        response = requests.get(url, headers={"User-Agent": "earnings-transcript-teacher"}, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        company_name = data.get("name", "")
+        industry = data.get("sicDescription", "")
+        return (company_name, industry)
+    except Exception as e:
+        logger.warning(f"Could not fetch company info for CIK {cik} from SEC EDGAR: {e}")
+        return ("", "")

--- a/services/llm.py
+++ b/services/llm.py
@@ -154,9 +154,10 @@ class AgenticExtractor:
         retry=retry_if_exception_type(anthropic.APIStatusError),
         reraise=True
     )
-    def extract_tier1(self, text: str, chunk_type: str) -> Dict[str, Any]:
+    def extract_tier1(self, text: str, chunk_type: str, company_context: str = "") -> Dict[str, Any]:
         """Run Tier 1 extraction for glossary, core concepts, and complexity score."""
-        user_prompt = f"### Chunk Type: {chunk_type}\n### Transcript Text:\n{text}\n\nExtract the requested JSON metadata."
+        company_header = f"### Company: {company_context}\n" if company_context else ""
+        user_prompt = f"{company_header}### Chunk Type: {chunk_type}\n### Transcript Text:\n{text}\n\nExtract the requested JSON metadata."
         self.rate_limiter.wait()
         message = self.client.messages.create(
             model=self.tier1_model,

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -1,3 +1,4 @@
+import json
 import os
 import logging
 from parsing.loader import read_text_file, extract_transcript_text
@@ -39,6 +40,11 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     file_path = f"./transcripts/{ticker}.json"
     content = read_text_file(file_path)
     raw_text = extract_transcript_text(content)
+
+    # Look up company name and industry from SEC EDGAR using the CIK in the transcript JSON
+    from services.company_info import fetch_company_info
+    cik = json.loads(content).get("cik", "")
+    company_name, industry = fetch_company_info(cik) if cik else ("", "")
 
     # Basic stats
     tokens = tokenize(clean_text(raw_text))
@@ -87,6 +93,8 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
         token_count=len(tokens),
         prepared_len=len(prepared_remarks),
         qa_len=len(qa),
+        company_name=company_name,
+        industry=industry,
     )
 
     # Speakers

--- a/tests/services/test_llm.py
+++ b/tests/services/test_llm.py
@@ -55,6 +55,51 @@ def test_agentic_extractor_tier1(mocker, monkeypatch):
     assert result["tier1_score"] == 8
     assert result["requires_deep_analysis"] is True
 
+
+def test_agentic_extractor_tier1_includes_company_context(mocker, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_key")
+
+    mock_anthropic = mocker.patch("services.llm.anthropic.Anthropic")
+    mock_instance = MagicMock()
+    mock_anthropic.return_value = mock_instance
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text='{"tier1_score": 5, "requires_deep_analysis": false}')]
+    mock_message.model = "claude-haiku-4-5-20251001"
+    mock_message.usage.input_tokens = 100
+    mock_message.usage.output_tokens = 50
+    mock_instance.messages.create.return_value = mock_message
+
+    extractor = AgenticExtractor()
+    extractor.extract_tier1("Some transcript text", "prepared_remarks", company_context="Tesla, Inc. (TSLA) — Motor Vehicles")
+
+    call_kwargs = mock_instance.messages.create.call_args
+    user_message = call_kwargs[1]["messages"][0]["content"]
+    assert "### Company: Tesla, Inc. (TSLA) — Motor Vehicles" in user_message
+
+
+def test_agentic_extractor_tier1_no_company_context_header(mocker, monkeypatch):
+    """When company_context is empty, no ### Company header should appear."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_key")
+
+    mock_anthropic = mocker.patch("services.llm.anthropic.Anthropic")
+    mock_instance = MagicMock()
+    mock_anthropic.return_value = mock_instance
+
+    mock_message = MagicMock()
+    mock_message.content = [MagicMock(text='{"tier1_score": 3, "requires_deep_analysis": false}')]
+    mock_message.model = "claude-haiku-4-5-20251001"
+    mock_message.usage.input_tokens = 50
+    mock_message.usage.output_tokens = 20
+    mock_instance.messages.create.return_value = mock_message
+
+    extractor = AgenticExtractor()
+    extractor.extract_tier1("Some transcript text", "prepared_remarks")
+
+    call_kwargs = mock_instance.messages.create.call_args
+    user_message = call_kwargs[1]["messages"][0]["content"]
+    assert "### Company:" not in user_message
+
 def test_agentic_extractor_tier2_failure(mocker, monkeypatch):
     import anthropic as anthropic_lib
     monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_key")

--- a/tests/unit/services/test_company_info.py
+++ b/tests/unit/services/test_company_info.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import MagicMock
+from services.company_info import fetch_company_info
+
+
+def test_fetch_company_info_success(mocker):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "name": "Apple Inc.",
+        "sicDescription": "Electronic Computers",
+    }
+    mock_get = mocker.patch("services.company_info.requests.get", return_value=mock_response)
+
+    company_name, industry = fetch_company_info("320193")
+
+    assert company_name == "Apple Inc."
+    assert industry == "Electronic Computers"
+    mock_get.assert_called_once()
+    assert "CIK0000320193" in mock_get.call_args[0][0]
+
+
+def test_fetch_company_info_missing_fields(mocker):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {}
+    mocker.patch("services.company_info.requests.get", return_value=mock_response)
+
+    company_name, industry = fetch_company_info("320193")
+
+    assert company_name == ""
+    assert industry == ""
+
+
+def test_fetch_company_info_network_error(mocker):
+    mocker.patch("services.company_info.requests.get", side_effect=Exception("timeout"))
+
+    company_name, industry = fetch_company_info("320193")
+
+    assert company_name == ""
+    assert industry == ""
+
+
+def test_fetch_company_info_integer_cik(mocker):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"name": "Tesla, Inc.", "sicDescription": "Motor Vehicles & Passenger Car Bodies"}
+    mock_get = mocker.patch("services.company_info.requests.get", return_value=mock_response)
+
+    company_name, industry = fetch_company_info(1318605)
+
+    assert company_name == "Tesla, Inc."
+    assert "CIK0001318605" in mock_get.call_args[0][0]


### PR DESCRIPTION
Closes #17

## Summary
- **SEC EDGAR lookup at ingestion time**: When a transcript is ingested, the CIK already present in the transcript JSON is used to fetch the company name and industry from the free SEC EDGAR API. This is stored in two columns on the `calls` table (`company_name`, which was already there but always NULL, and `industry`, which is new).
- **Grounded Tier 1 extraction**: The company name and industry are threaded into the Tier 1 LLM prompt so the model knows it is analysing a Tesla EV call vs. a retail call. The prompt now explicitly rejects flowery language, superlatives, and mission-statement phrases (the "Amazing Abundance" class of false positives). Extracted terms now include a company-grounded one-sentence definition at extraction time.
- **Grounded `Define` feature**: `generate_definition` in `app.py` now looks up the stored company context from the DB and injects it into both the system prompt and user message, replacing the previous context-free "financial dictionary" prompt.
- **Bug fix**: `auto_migrate()` in `app.py` was hardcoding `INSERT INTO schema_version VALUES (1)`, causing a false outdated-schema banner after the migration to version 2. Fixed to insert version 2.

## Schema change
Migration `db/migrations/002_add_industry_to_calls.sql` adds an `industry TEXT` column to the `calls` table. Run it against existing databases:
```
psql dbname=earnings_teacher -f db/migrations/002_add_industry_to_calls.sql
```

## Test plan
- [ ] Run `pytest tests/services/test_llm.py tests/unit/services/test_company_info.py` — all 10 tests pass
- [ ] Ingest a new transcript (e.g. `python3 main.py AAPL --save`) and confirm the `calls` row now has `company_name` and `industry` populated
- [ ] Open the web UI, navigate to Industry Terms for a previously-ingested ticker, click Define on a term, and verify the definition references the correct company/industry context