### PR TITLE
Fix wrong repository class and refactor shared context builder

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,8 @@ from db.persistence import (
 )
 from nlp.embedder import get_embeddings
 from services.llm import stream_chat
-from db.repositories import AnalysisRepository
+from db.repositories import AnalysisRepository, CallRepository
+from ingestion.pipeline import _build_company_context
 
 # ------------- Configuration -------------
 
@@ -148,14 +149,9 @@ def generate_definition(ticker: str, term: str) -> bool:
     """Call the LLM to generate a company-grounded definition, then save it."""
     with st.spinner(f"Defining {term}..."):
         try:
-            repo = AnalysisRepository(CONN_STR)
+            repo = CallRepository(CONN_STR)
             company_name, industry = repo.get_company_info(ticker)
-            if company_name and industry:
-                context = f"{company_name} ({ticker}) — {industry}"
-            elif company_name:
-                context = f"{company_name} ({ticker})"
-            else:
-                context = ticker
+            context = _build_company_context(ticker, company_name, industry)
             system_prompt = (
                 f"You are a precise financial analyst. Define the provided term in the context of "
                 f"{context}. Return ONLY the definition, 1-2 sentences."

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -201,26 +201,28 @@ def create_chunks_from_analysis(analysis: CallAnalysis, max_chars: int = 4000, o
             
     return chunks
 
+def _build_company_context(ticker: str, company_name: str, industry: str) -> str:
+    """Return a human-readable company context string for LLM prompts."""
+    if company_name and industry:
+        return f"{company_name} ({ticker}) — {industry}"
+    if company_name:
+        return f"{company_name} ({ticker})"
+    return ticker
+
+
 class IngestionPipeline:
     def __init__(self, tier1_threshold: int = 6):
         self.tier1_threshold = tier1_threshold
         # Initialize the LLM client wrapper
         from services.llm import AgenticExtractor
         self.extractor = AgenticExtractor()
-        self.company_context: str = ""
 
     def process(self, analysis: CallAnalysis) -> List[TranscriptChunk]:
         """Run the full ingestion pipeline on a parsed CallAnalysis."""
         logger.info(f"Starting agentic ingestion for {analysis.call.ticker}")
 
-        # Build company context string for LLM prompts
         call = analysis.call
-        if call.company_name and call.industry:
-            self.company_context = f"{call.company_name} ({call.ticker}) — {call.industry}"
-        elif call.company_name:
-            self.company_context = f"{call.company_name} ({call.ticker})"
-        else:
-            self.company_context = call.ticker
+        company_context = _build_company_context(call.ticker, call.company_name, call.industry)
 
         chunks = create_chunks_from_analysis(analysis)
         prep_count = sum(1 for c in chunks if c.chunk_type == 'prepared')

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -2,6 +2,7 @@ import json
 import os
 import logging
 from parsing.loader import read_text_file, extract_transcript_text
+from services.company_info import fetch_company_info
 from nlp.analysis import clean_text, tokenize
 from nlp.keywords import extract_keywords
 from nlp.themes import extract_themes
@@ -42,7 +43,6 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     raw_text = extract_transcript_text(content)
 
     # Look up company name and industry from SEC EDGAR using the CIK in the transcript JSON
-    from services.company_info import fetch_company_info
     cik = json.loads(content).get("cik", "")
     company_name, industry = fetch_company_info(cik) if cik else ("", "")
 

--- a/tests/services/test_llm.py
+++ b/tests/services/test_llm.py
@@ -100,6 +100,7 @@ def test_agentic_extractor_tier1_no_company_context_header(mocker, monkeypatch):
     user_message = call_kwargs[1]["messages"][0]["content"]
     assert "### Company:" not in user_message
 
+
 def test_agentic_extractor_tier2_failure(mocker, monkeypatch):
     import anthropic as anthropic_lib
     monkeypatch.setenv("ANTHROPIC_API_KEY", "fake_key")

--- a/tests/unit/services/test_company_info.py
+++ b/tests/unit/services/test_company_info.py
@@ -39,6 +39,18 @@ def test_fetch_company_info_network_error(mocker):
     assert industry == ""
 
 
+def test_fetch_company_info_http_error(mocker):
+    import requests as requests_lib
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = requests_lib.HTTPError("404 Not Found")
+    mocker.patch("services.company_info.requests.get", return_value=mock_response)
+
+    company_name, industry = fetch_company_info("000000")
+
+    assert company_name == ""
+    assert industry == ""
+
+
 def test_fetch_company_info_integer_cik(mocker):
     mock_response = MagicMock()
     mock_response.json.return_value = {"name": "Tesla, Inc.", "sicDescription": "Motor Vehicles & Passenger Car Bodies"}


### PR DESCRIPTION
Follow-up fixes from Python code review of #18.

## Summary
- **Bug fix**: `generate_definition` was calling `get_company_info` on `AnalysisRepository` instead of `CallRepository` — would have raised `AttributeError` on every Define button click in the web UI
- **Refactor**: Extracted `_build_company_context` helper in `ingestion/pipeline.py` and reused it in `app.py`, eliminating duplicated logic that could have diverged
- **Cleanup**: Removed redundant `self.company_context` instance attribute from `IngestionPipeline` (was also threaded as a parameter, making the instance state unnecessary and potentially unsafe under concurrent use)
- **Cleanup**: Moved `fetch_company_info` import to module level in `orchestrator.py`
- **Tests**: Added test for HTTP 404 error path in `fetch_company_info`; fixed missing PEP 8 blank line between test functions

## Test plan
- [ ] 11 tests pass: `pytest tests/services/test_llm.py tests/unit/services/test_company_info.py`