### PR TITLE
refactor: overhaul GUI for cleaner, more progressive user experience

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,12 @@ if "feynman_stage" not in st.session_state:
 if "feynman_topic" not in st.session_state:
     st.session_state.feynman_topic = ""
 
+if "confirm_reset" not in st.session_state:
+    st.session_state.confirm_reset = False
+
+if "show_advanced_analysis" not in st.session_state:
+    st.session_state.show_advanced_analysis = False
+
 # ------------- Schema Health Check -------------
 
 def _auto_migrate() -> bool:
@@ -78,9 +84,11 @@ spans = load_transcript_spans(CONN_STR, st.session_state.active_ticker)
 
 # ------------- Layout -------------
 
-left_col, right_col = st.columns([3.5, 6.5])
+left_col, right_col = st.columns([5, 5])
 
 with left_col:
+    render_transcript_browser(spans)
+    st.divider()
     render_metadata_panel(
         conn_str=CONN_STR,
         ticker=st.session_state.active_ticker,
@@ -94,8 +102,6 @@ with left_col:
     )
 
 with right_col:
-    render_transcript_browser(spans)
-    st.divider()
     render_chat_interface(
         conn_str=CONN_STR,
         ticker=st.session_state.active_ticker,
@@ -104,4 +110,5 @@ with right_col:
         takeaways=takeaways,
         financial_terms=financial_terms,
         industry_terms=industry_terms,
+        on_reset=_reset_chat,
     )

--- a/ui/feynman.py
+++ b/ui/feynman.py
@@ -41,9 +41,30 @@ def render_chat_interface(
     takeaways: list,
     financial_terms: list,
     industry_terms: list,
+    on_reset=None,
 ) -> None:
     """Render the full chat area: topic picker, stage UI, message history, and input."""
-    st.subheader("💬 Chat Interface")
+    header_col, reset_col = st.columns([5, 1])
+    with header_col:
+        st.subheader("💬 Chat Interface")
+    with reset_col:
+        if st.button("Reset", help="Reset session", use_container_width=True):
+            st.session_state.confirm_reset = True
+
+    if st.session_state.get("confirm_reset"):
+        st.warning("This will clear the chat and reset the Feynman loop.")
+        yes_col, cancel_col = st.columns(2)
+        with yes_col:
+            if st.button("Yes, reset", type="primary", use_container_width=True):
+                if on_reset:
+                    on_reset()
+                st.session_state.confirm_reset = False
+                st.rerun()
+        with cancel_col:
+            if st.button("Cancel", use_container_width=True):
+                st.session_state.confirm_reset = False
+                st.rerun()
+        return
 
     if chat_mode == "Feynman Loop" and not st.session_state.feynman_topic:
         _render_topic_picker(themes, takeaways)
@@ -64,27 +85,27 @@ def render_chat_interface(
 
 def _render_topic_picker(themes: list, takeaways: list) -> None:
     """Show the Feynman topic selection UI."""
-    st.info(
-        "🧠 **Feynman Loop** — choose a topic below and the AI will guide you through "
-        "explaining it back in your own words, exposing gaps, and refining your understanding."
-    )
+    st.markdown("#### 🧠 Feynman Loop")
+    st.caption("Choose a topic. The AI will guide you to explain it back, expose gaps, and deepen your understanding.")
 
     suggestions: list[str] = []
-    if themes:
-        suggestions.append(themes[0])
-        if len(themes) > 1:
-            suggestions.append(themes[1])
-    if takeaways and len(suggestions) < 3:
-        suggestions.append(takeaways[0][0])
+    for t in themes[:3]:
+        suggestions.append(t)
+    for t, _ in takeaways[:2]:
+        if len(suggestions) < 5 and t not in suggestions:
+            suggestions.append(t)
 
     if suggestions:
-        st.markdown("**Suggested topics from this transcript:**")
-        chip_cols = st.columns(len(suggestions))
-        for col, suggestion in zip(chip_cols, suggestions):
-            label = suggestion if len(suggestion) <= 55 else suggestion[:52] + "…"
-            if col.button(label, use_container_width=True):
-                st.session_state.feynman_topic = suggestion
-                st.rerun()
+        st.markdown("**Practice Topics**")
+        num_cols = min(3, len(suggestions))
+        rows = [suggestions[i:i + num_cols] for i in range(0, len(suggestions), num_cols)]
+        for row in rows:
+            chip_cols = st.columns(num_cols)
+            for col, suggestion in zip(chip_cols, row):
+                label = suggestion if len(suggestion) <= 55 else suggestion[:52] + "…"
+                if col.button(label, use_container_width=True):
+                    st.session_state.feynman_topic = suggestion
+                    st.rerun()
 
     st.markdown("---")
     st.markdown("**Or enter your own topic:**")

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -14,36 +14,40 @@ def render_metadata_panel(
     financial_terms: list,
     speakers: list,
 ) -> None:
-    """Render the left-column analysis panel: sentiment, jargon, speakers, takeaways, themes."""
-    st.subheader(f"📊 {ticker} Analysis")
+    """Render the left-column analysis panel as a numbered learning path."""
+    st.markdown(f"### 📊 {ticker} — Learning Path")
 
-    with st.expander("🎭 Sentiment Analysis", expanded=False):
+    with st.expander("Step 1 · Overview"):
+        if takeaways:
+            st.markdown("**Key Takeaways**")
+            for t, why in takeaways:
+                st.markdown(f"- **{t}**\n  - *{why}*")
+        else:
+            st.info("No key takeaways extracted.")
+
+        st.markdown("---")
+
+        if themes:
+            st.markdown("**Extracted Themes**")
+            for idx, t in enumerate(themes, 1):
+                st.markdown(f"**Theme {idx}:** {t}")
+        else:
+            st.info("No themes extracted.")
+
+    with st.expander("Step 2 · Tone & Speakers"):
         if synthesis:
             overall, exec_tone, analyst_sent = synthesis
+            st.markdown("**Sentiment Analysis**")
             st.markdown(f"**Overall Sentiment:** {overall}")
             st.markdown(f"**Executive Tone:** {exec_tone}")
             st.markdown(f"**Analyst Sentiment:** {analyst_sent}")
         else:
             st.info("No sentiment analysis available for this call.")
 
-    with st.expander("🏦 Financial Jargon", expanded=False):
-        if financial_terms:
-            _render_term_list(conn_str, ticker, financial_terms, key_prefix=f"fin_{ticker}")
-        else:
-            st.info("No financial terms found in this transcript.")
+        st.markdown("---")
 
-    with st.expander("🏭 Industry Jargon", expanded=False):
-        if industry_terms:
-            _render_term_list(conn_str, ticker, industry_terms, key_prefix=f"ind_{ticker}")
-        else:
-            st.info("No industry-specific terms extracted.")
-
-        if keywords:
-            st.markdown("**Top Keywords (TF-IDF):**")
-            st.markdown(", ".join([f"`{k}`" for k in keywords[:15]]))
-
-    with st.expander("🎙️ Speakers", expanded=False):
         if speakers:
+            st.markdown("**Speakers**")
             executives = [(n, r, t, f) for n, r, t, f in speakers if r == "executive"]
             analysts = [(n, r, t, f) for n, r, t, f in speakers if r == "analyst"]
             if executives:
@@ -59,19 +63,24 @@ def render_metadata_panel(
         else:
             st.info("No speaker data available.")
 
-    with st.expander("💡 Key Takeaways", expanded=False):
-        if takeaways:
-            for t, why in takeaways:
-                st.markdown(f"- **{t}**\n  - *{why}*")
-        else:
-            st.info("No key takeaways extracted.")
+    st.checkbox("Show advanced analysis", key="show_advanced_analysis")
 
-    with st.expander("🧩 Extracted Themes", expanded=False):
-        if themes:
-            for idx, t in enumerate(themes, 1):
-                st.markdown(f"**Theme {idx}:** {t}")
-        else:
-            st.info("No themes extracted.")
+    if st.session_state.show_advanced_analysis:
+        with st.expander("Step 3 · Financial Jargon"):
+            if financial_terms:
+                _render_term_list(conn_str, ticker, financial_terms, key_prefix=f"fin_{ticker}")
+            else:
+                st.info("No financial terms found in this transcript.")
+
+        with st.expander("Step 3 · Industry Jargon"):
+            if industry_terms:
+                _render_term_list(conn_str, ticker, industry_terms, key_prefix=f"ind_{ticker}")
+            else:
+                st.info("No industry-specific terms extracted.")
+
+            if keywords:
+                st.markdown("**Top Keywords (TF-IDF):**")
+                st.markdown(", ".join([f"`{k}`" for k in keywords[:15]]))
 
 
 def _render_term_list(conn_str: str, ticker: str, terms: list, key_prefix: str) -> None:

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -6,7 +6,7 @@ from ui.data_loaders import load_transcripts
 def render_sidebar(conn_str: str, on_ticker_change) -> tuple[str, str]:
     """Render the settings sidebar and return (selected_ticker, chat_mode)."""
     with st.sidebar:
-        st.title("🎓 Settings")
+        st.markdown("### 📄 Transcript")
 
         available_tickers = load_transcripts(conn_str)
 
@@ -20,18 +20,13 @@ def render_sidebar(conn_str: str, on_ticker_change) -> tuple[str, str]:
             on_change=on_ticker_change,
         )
 
-        st.divider()
-
         chat_mode = st.radio(
-            "Learning Mode",
+            "Mode",
             ["Feynman Loop", "General Q&A"],
             help=(
-                "Feynman Loop guides you through teaching the material to test your understanding."
-                "General Q&A lets you explore the transcript freely. "
+                "Feynman Loop guides you through teaching the material to test your understanding. "
+                "General Q&A lets you explore the transcript freely."
             ),
         )
-
-        if st.button("Clear Chat", on_click=on_ticker_change, use_container_width=True):
-            pass
 
     return selected_ticker, chat_mode

--- a/ui/transcript_browser.py
+++ b/ui/transcript_browser.py
@@ -124,32 +124,33 @@ document.getElementById('search-input').addEventListener('keydown', function(e) 
 
 
 def render_transcript_browser(spans: list[tuple[str, str, str]]) -> None:
-    """Render the searchable HTML transcript browser inside an expander."""
-    with st.expander("📄 Transcript Browser", expanded=False):
-        if not spans:
-            st.info("No transcript data available.")
-            return
+    """Render the searchable HTML transcript browser."""
+    st.markdown("### 📄 Transcript")
 
-        lines_html = []
-        for speaker, _, text in spans:
-            s = _html.escape(speaker)
-            t = _html.escape(text)
-            lines_html.append(f"<p><strong>{s}:</strong> {t}</p>")
-        transcript_body = "\n".join(lines_html)
+    if not spans:
+        st.info("No transcript data available.")
+        return
 
-        component_html = (
-            f"<!DOCTYPE html>\n<html><head>\n<style>\n{_BROWSER_CSS}\n</style>\n</head><body>\n"
-            '<div class="search-bar">\n'
-            '  <input type="text" id="search-input" placeholder="Search transcript..." oninput="onSearch()">\n'
-            '  <span class="match-count" id="match-count"></span>\n'
-            '  <button class="nav-btn" id="prev-btn" onclick="navigate(-1)" title="Previous match" disabled>&#9650;</button>\n'
-            '  <button class="nav-btn" id="next-btn" onclick="navigate(1)" title="Next match" disabled>&#9660;</button>\n'
-            "</div>\n"
-            '<div class="transcript" id="transcript">\n'
-            + transcript_body
-            + "\n</div>\n"
-            f"<script>\n{_BROWSER_JS}\n</script>\n"
-            "</body></html>"
-        )
+    lines_html = []
+    for speaker, _, text in spans:
+        s = _html.escape(speaker)
+        t = _html.escape(text)
+        lines_html.append(f"<p><strong>{s}:</strong> {t}</p>")
+    transcript_body = "\n".join(lines_html)
 
-        _components.html(component_html, height=550, scrolling=False)
+    component_html = (
+        f"<!DOCTYPE html>\n<html><head>\n<style>\n{_BROWSER_CSS}\n</style>\n</head><body>\n"
+        '<div class="search-bar">\n'
+        '  <input type="text" id="search-input" placeholder="Search transcript..." oninput="onSearch()">\n'
+        '  <span class="match-count" id="match-count"></span>\n'
+        '  <button class="nav-btn" id="prev-btn" onclick="navigate(-1)" title="Previous match" disabled>&#9650;</button>\n'
+        '  <button class="nav-btn" id="next-btn" onclick="navigate(1)" title="Next match" disabled>&#9660;</button>\n'
+        "</div>\n"
+        '<div class="transcript" id="transcript">\n'
+        + transcript_body
+        + "\n</div>\n"
+        f"<script>\n{_BROWSER_JS}\n</script>\n"
+        "</body></html>"
+    )
+
+    _components.html(component_html, height=400, scrolling=False)


### PR DESCRIPTION
Closes #31

## Summary

- **New layout**: Transcript browser leads the left column (always open, no expander) with the learning path below it; chat takes the full right column with an even 50/50 split
- **Numbered learning path**: Six flat expanders replaced by three collapsible steps — *Step 1 · Overview* (Key Takeaways + Themes), *Step 2 · Tone & Speakers* (Sentiment + Speakers), *Step 3 · Financial/Industry Jargon* (hidden behind an "advanced" toggle). All collapsed by default.
- **Progressive disclosure**: Jargon sections only appear when "Show advanced analysis" is checked, keeping the first-time experience uncluttered. Financial and Industry Jargon are now separate expanders so the boundary between them is unambiguous.
- **Reset Session button**: "Clear Chat" removed from sidebar; replaced by an inline "Reset" button in the chat header with a two-click confirmation before wiping state
- **Simplified Feynman entry**: Long info banner replaced with a compact header + caption; suggested topics expanded from 3 to 5 pills, arranged in a responsive 3-column grid under the label "Practice Topics"
- **Leaner sidebar**: Lighter heading, divider removed, radio renamed from "Learning Mode" to "Mode"

## Test plan

- [ ] Load the app with a transcript in the DB — transcript browser is visible immediately without expanding anything
- [ ] Confirm all three Learning Path steps are collapsed by default
- [ ] Toggle "Show advanced analysis" — Step 3 expanders appear; untoggle — they disappear
- [ ] Confirm Financial Jargon and Industry Jargon are separate expanders with no content bleed between them
- [ ] Click "Reset" in the chat header — confirmation row appears; click "Cancel" — confirmation dismisses without clearing; click "Reset" → "Yes, reset" — chat clears and Feynman loop resets
- [ ] Switch transcripts from the sidebar — chat clears as before
- [ ] Feynman Loop topic picker shows up to 5 pills in a grid; custom topic entry still works