### PR TITLE
feat: display token usage and estimated cost after ingestion

### DIFF
--- a/cli/display.py
+++ b/cli/display.py
@@ -1,4 +1,4 @@
-from core.models import CallAnalysis
+from core.models import CallAnalysis, TokenUsageSummary
 
 def display(result: CallAnalysis) -> None:
     """Print the analysis results to console."""
@@ -53,3 +53,45 @@ def display(result: CallAnalysis) -> None:
         print(f"    - {api} generated via Voyage AI API")
     else:
         print("  Skipped (VOYAGE_API_KEY not set)")
+
+    if result.token_usage:
+        _display_token_usage(result.token_usage)
+
+
+def _display_token_usage(usage: TokenUsageSummary) -> None:
+    """Print a summary table of token usage and estimated cost."""
+    print("\nToken Usage & Estimated Cost")
+    print("-" * 28)
+
+    col_model  = 24
+    col_input  = 15
+    col_output = 16
+    col_cost   = 14
+
+    header = (
+        f"{'Model':<{col_model}}"
+        f"{'Input Tokens':>{col_input}}"
+        f"{'Output Tokens':>{col_output}}"
+        f"{'Est. Cost':>{col_cost}}"
+    )
+    print(f"  {header}")
+    print("  " + "-" * (col_model + col_input + col_output + col_cost))
+
+    for m in usage.by_model.values():
+        row = (
+            f"{m.display_name:<{col_model}}"
+            f"{m.input_tokens:>{col_input},}"
+            f"{m.output_tokens:>{col_output},}"
+            f"{'$' + f'{m.estimated_cost:.4f}':>{col_cost}}"
+        )
+        print(f"  {row}")
+
+    if len(usage.by_model) > 1:
+        print("  " + "-" * (col_model + col_input + col_output + col_cost))
+        total_row = (
+            f"{'Total':<{col_model}}"
+            f"{usage.total_input_tokens:>{col_input},}"
+            f"{usage.total_output_tokens:>{col_output},}"
+            f"{'$' + f'{usage.total_cost:.4f}':>{col_cost}}"
+        )
+        print(f"  {total_row}")

--- a/core/models.py
+++ b/core/models.py
@@ -12,6 +12,74 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
 
+# ---------------------------------------------------------------------------
+# Token usage tracking
+# ---------------------------------------------------------------------------
+
+# Pricing in USD per 1 million tokens (input, output)
+_MODEL_PRICING: dict[str, tuple[float, float]] = {
+    "claude-haiku-4-5-20251001": (0.80, 4.00),
+    "claude-haiku-4-5":          (0.80, 4.00),
+    "claude-sonnet-4-5":         (3.00, 15.00),
+    "claude-sonnet-4-6":         (3.00, 15.00),
+    "claude-opus-4-5":           (15.00, 75.00),
+    "claude-opus-4-6":           (15.00, 75.00),
+}
+
+_MODEL_DISPLAY_NAMES: dict[str, str] = {
+    "claude-haiku-4-5-20251001": "Claude Haiku 4.5",
+    "claude-haiku-4-5":          "Claude Haiku 4.5",
+    "claude-sonnet-4-5":         "Claude Sonnet 4.5",
+    "claude-sonnet-4-6":         "Claude Sonnet 4.6",
+    "claude-opus-4-5":           "Claude Opus 4.5",
+    "claude-opus-4-6":           "Claude Opus 4.6",
+}
+
+
+@dataclass
+class ModelTokenUsage:
+    """Accumulated token usage and estimated cost for one model."""
+
+    model_id: str
+    display_name: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def estimated_cost(self) -> float:
+        """Estimated cost in USD based on known pricing."""
+        input_rate, output_rate = _MODEL_PRICING.get(self.model_id, (0.0, 0.0))
+        return (self.input_tokens * input_rate + self.output_tokens * output_rate) / 1_000_000
+
+
+@dataclass
+class TokenUsageSummary:
+    """Aggregated token usage across all LLM calls during ingestion."""
+
+    by_model: dict[str, ModelTokenUsage] = field(default_factory=dict)
+
+    def add(self, model_id: str, input_tokens: int, output_tokens: int) -> None:
+        """Record usage for a model, creating the entry if needed."""
+        if model_id not in self.by_model:
+            display_name = _MODEL_DISPLAY_NAMES.get(model_id, model_id)
+            self.by_model[model_id] = ModelTokenUsage(
+                model_id=model_id, display_name=display_name
+            )
+        self.by_model[model_id].input_tokens += input_tokens
+        self.by_model[model_id].output_tokens += output_tokens
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(m.input_tokens for m in self.by_model.values())
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(m.output_tokens for m in self.by_model.values())
+
+    @property
+    def total_cost(self) -> float:
+        return sum(m.estimated_cost for m in self.by_model.values())
+
 from parsing.sections import SpeakerProfile
 from pydantic import BaseModel, Field as PydanticField
 
@@ -158,3 +226,4 @@ class CallAnalysis:
     
     chunks: list[TranscriptChunk] = field(default_factory=list)
     synthesis: CallSynthesisRecord | None = None
+    token_usage: TokenUsageSummary | None = None

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Dict, Any, Optional, Tuple, Set
 import concurrent.futures
 
-from core.models import CallAnalysis, CallSynthesisRecord, TranscriptChunk
+from core.models import CallAnalysis, CallSynthesisRecord, TranscriptChunk, TokenUsageSummary
 from parsing.financial_terms import scan_chunk
 from services.company_info import build_company_context
 
@@ -186,7 +186,7 @@ class IngestionPipeline:
         from services.llm import AgenticExtractor
         self.extractor = AgenticExtractor()
 
-    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord]:
+    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord, TokenUsageSummary]:
         """Run the full ingestion pipeline on a parsed CallAnalysis."""
         logger.info(f"Starting agentic ingestion for {analysis.call.ticker}")
 
@@ -204,19 +204,21 @@ class IngestionPipeline:
         max_workers = min(10, len(chunks)) # Don't spin up more threads than we have chunks
         print(f"\n[Map Phase] Running extraction on {len(chunks)} chunks with {max_workers} concurrent workers...")
         
+        all_chunk_usage: list[dict] = []
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
             # Map chunk indices to future objects so we know which is which when completed
             future_to_chunk = {
                 executor.submit(self._process_single_chunk, chunk, i, len(chunks), company_context): chunk
                 for i, chunk in enumerate(chunks, 1)
             }
-            
-            # Wait for all futures to complete
+
+            # Wait for all futures to complete, collecting per-chunk usage stats
             for future in concurrent.futures.as_completed(future_to_chunk):
                 try:
-                    # The chunk is updated in-place by _process_single_chunk, 
-                    # we just need to catch any unhandled exceptions
-                    future.result()
+                    chunk_usage = future.result()
+                    if chunk_usage:
+                        all_chunk_usage.extend(chunk_usage)
                 except Exception as exc:
                     chunk = future_to_chunk[future]
                     logger.error(f"Chunk {chunk.chunk_id} generated an exception: {exc}")
@@ -241,12 +243,12 @@ class IngestionPipeline:
         aggregated_text = json.dumps(compact_summaries, indent=2)
         
         synthesis_data = self.extractor.extract_synthesis(aggregated_text)
-        
+
         # Manually extract usage stats before creating the dataclass
-        usage = synthesis_data.pop("_usage_stats", None)
-        if usage:
-            print(f"    ↳ Synthesis [Model: {usage['model']} | In: {usage['prompt_tokens']} | Out: {usage['completion_tokens']}]")
-            
+        synthesis_usage = synthesis_data.pop("_usage_stats", None)
+        if synthesis_usage:
+            print(f"    ↳ Synthesis [Model: {synthesis_usage['model']} | In: {synthesis_usage['prompt_tokens']} | Out: {synthesis_usage['completion_tokens']}]")
+
         synthesis = CallSynthesisRecord(
             overall_sentiment=synthesis_data.get("overall_sentiment", ""),
             executive_tone=synthesis_data.get("executive_tone", ""),
@@ -255,31 +257,46 @@ class IngestionPipeline:
             analyst_sentiment=synthesis_data.get("analyst_sentiment", "")
         )
 
+        # Aggregate all token usage across chunks and synthesis
+        token_usage = TokenUsageSummary()
+        for u in all_chunk_usage:
+            token_usage.add(u["model"], u["prompt_tokens"], u["completion_tokens"])
+        if synthesis_usage:
+            token_usage.add(
+                synthesis_usage["model"],
+                synthesis_usage["prompt_tokens"],
+                synthesis_usage["completion_tokens"],
+            )
+
         print("✅ Agentic ingestion complete.\n")
-        return chunks, synthesis
+        return chunks, synthesis, token_usage
         
-    def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int, company_context: str = "") -> None:
-        """Helper method to process a single chunk, designed to run in a thread."""
+    def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int, company_context: str = "") -> list[dict]:
+        """Helper method to process a single chunk, designed to run in a thread.
+
+        Returns a list of ``_usage_stats`` dicts (one per LLM call made).
+        """
         logger.info(f"Processing chunk {chunk.chunk_id} [{index}/{total_chunks}]")
-        # print relies on thread-safety of the built-in print, but might interleave slightly in stdout.
-        # This is usually fine for a simple UI, but could be logged instead.
         print(f"  [{index}/{total_chunks}] Analysing {chunk.chunk_id}... ")
+
+        usage_records: list[dict] = []
 
         t1_usage = self._run_tier1(chunk, company_context)
         if t1_usage:
             logger.info(f"Chunk {chunk.chunk_id} - Tier 1 usage: {t1_usage}")
-            # print(f"    ↳ Tier 1 [Model: {t1_usage['model']} | In: {t1_usage['prompt_tokens']} | Out: {t1_usage['completion_tokens']}]")
-        
+            usage_records.append(t1_usage)
+
         # Phase 3: Tier 2 Deep Enrichment (Conditional routing)
         if chunk.requires_deep_analysis and getattr(chunk, 'tier1_score', 0) >= self.tier1_threshold:
             print(f"    ↳ Deep dive required on {chunk.chunk_id} (Score: {chunk.tier1_score}). Routing to Tier 2... ")
             t2_usage = self._run_tier2(chunk)
             if t2_usage:
                 logger.info(f"Chunk {chunk.chunk_id} - Tier 2 usage: {t2_usage}")
-                # print(f"      ↳ Tier 2 [Model: {t2_usage['model']} | In: {t2_usage['prompt_tokens']} | Out: {t2_usage['completion_tokens']}]")
+                usage_records.append(t2_usage)
         else:
             logger.info(f"Chunk {chunk.chunk_id} - Skipping Tier 2 (Score: {getattr(chunk, 'tier1_score', 0)})")
-            # print(f"    ↳ Skipping Tier 2 for {chunk.chunk_id} (Score: {getattr(chunk, 'tier1_score', 0)}).")
+
+        return usage_records
         
     def _run_tier1(self, chunk: TranscriptChunk, company_context: str = "") -> Optional[Dict[str, Any]]:
         """Run Tier 1 extraction: LLM for industry terms + CSV scan for financial terms."""

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -236,9 +236,10 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     try:
         from ingestion.pipeline import IngestionPipeline
         pipeline = IngestionPipeline()
-        chunks, synthesis = pipeline.process(analysis)
+        chunks, synthesis, token_usage = pipeline.process(analysis)
         analysis.chunks = chunks
         analysis.synthesis = synthesis
+        analysis.token_usage = token_usage
     except Exception as e:
         logger.warning(f"Agentic pipeline failed or skipped: {e}")
 


### PR DESCRIPTION
## Summary

- Adds `TokenUsageSummary` and `ModelTokenUsage` dataclasses to `core/models.py` with pricing constants for all current Claude models
- Collects `_usage_stats` from every LLM call in the agentic pipeline (Tier 1, Tier 2 per chunk, and synthesis) in a thread-safe way via future return values
- Wires the summary through `orchestrator.py` into `CallAnalysis.token_usage`
- Displays a formatted cost table in the CLI after ingestion completes

Example output:
```
Token Usage & Estimated Cost
----------------------------
  Model                      Input Tokens   Output Tokens     Est. Cost
  ---------------------------------------------------------------------
  Claude Sonnet 4.5                12,345           3,456       $0.0889
  Claude Haiku 4.5                  1,200             450       $0.0028
  ---------------------------------------------------------------------
  Total                            13,545           3,906       $0.0916
```

## Test plan

- [ ] Run ingestion on a ticker (`python3 main.py AAPL --save`) and verify the cost table appears after the analysis summary
- [ ] Confirm rows appear for each model actually used (Sonnet 4.5 for Tier 1/2, Haiku 4.5 for synthesis)
- [ ] Confirm totals row only appears when more than one model is present
- [ ] Run `pytest` — all 45 tests pass

Closes #35