### PR TITLE
feat: export Feynman session chat log to markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ set_env.ps1
 
 # Claude
 .claude/worktrees/
+
+# Feynman session exports (local only)
+feynman_sessions/

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -2,6 +2,7 @@ import os
 import re
 import sys
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 _PROMPTS_DIR = Path(__file__).parent.parent / "prompts" / "feynman"
@@ -23,6 +24,46 @@ from cli.display import display
 def _validate_ticker(ticker: str) -> bool:
     """Return True if ticker is 1-5 uppercase alphabetical characters (e.g. AAPL, MSFT)."""
     return bool(re.match(r'^[A-Z]{1,5}$', ticker))
+
+
+def _export_feynman_session(ticker: str, topic: str, messages: list[dict]) -> None:
+    """Offer to export a completed Feynman session to a markdown file.
+
+    Writes the chat history to feynman_sessions/<ticker>_<slug>_<timestamp>.md.
+    The directory is created if it does not exist.
+    """
+    answer = input("\nWould you like to export this session to a markdown file? (y/n): ").strip().lower()
+    if answer != "y":
+        return
+
+    sessions_dir = Path("feynman_sessions")
+    sessions_dir.mkdir(exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    topic_slug = re.sub(r"[^a-z0-9]+", "_", topic.lower()).strip("_")[:40]
+    filename = sessions_dir / f"{ticker}_{topic_slug}_{timestamp}.md"
+
+    lines: list[str] = [
+        f"# Feynman Session — {ticker}",
+        f"",
+        f"**Topic:** {topic}  ",
+        f"**Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        f"",
+        f"---",
+        f"",
+    ]
+
+    for msg in messages:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if role == "user":
+            lines.append(f"**You:** {content}")
+        elif role == "assistant":
+            lines.append(f"**Teacher:** {content}")
+        lines.append("")
+
+    filename.write_text("\n".join(lines), encoding="utf-8")
+    print(f"\nSession exported to {filename}")
 
 
 def interactive_menu() -> None:
@@ -283,7 +324,10 @@ def interactive_menu() -> None:
                         elif state == 5:
                             print("\n[System] Feynman Session Complete!")
                             break
-                        
+
+                    if messages:
+                        _export_feynman_session(ticker, topic, messages)
+
         elif choice == "5":
             ticker = input("Enter the ticker symbol to view: ").strip().upper()
             if not _validate_ticker(ticker):

--- a/ui/feynman.py
+++ b/ui/feynman.py
@@ -1,3 +1,5 @@
+import re
+from datetime import datetime
 from pathlib import Path
 
 import streamlit as st
@@ -71,7 +73,7 @@ def render_chat_interface(
         return
 
     if chat_mode == "Feynman Loop":
-        _render_stage_header()
+        _render_stage_header(ticker)
 
     _render_message_history()
     _render_stage_advance_buttons(chat_mode)
@@ -123,7 +125,31 @@ def _render_topic_picker(themes: list, takeaways: list) -> None:
 # Stage header and progress indicator
 # ---------------------------------------------------------------------------
 
-def _render_stage_header() -> None:
+def _build_feynman_markdown(ticker: str, topic: str, messages: list[dict]) -> str:
+    """Build a markdown string from a completed Feynman session chat history."""
+    lines: list[str] = [
+        f"# Feynman Session — {ticker}",
+        "",
+        f"**Topic:** {topic}  ",
+        f"**Date:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+        "",
+        "---",
+        "",
+    ]
+    for msg in messages:
+        if msg.get("feynman_auto") or msg.get("display") is False:
+            continue
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if role == "user":
+            lines.append(f"**You:** {content}")
+        elif role == "assistant":
+            lines.append(f"**Teacher:** {content}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _render_stage_header(ticker: str) -> None:
     """Render the Feynman stage caption, hint, and completion banner."""
     stage = st.session_state.feynman_stage
     topic_label = st.session_state.feynman_topic
@@ -145,11 +171,26 @@ def _render_stage_header() -> None:
         )
         if last_msg and last_msg.get("feynman_stage") == 5:
             st.success("🎉 **Feynman Session Complete!** Review your teaching note above.")
-            if st.button("🔄 Start a new Feynman cycle", type="secondary"):
-                st.session_state.feynman_topic = ""
-                st.session_state.feynman_stage = 1
-                st.session_state.messages = []
-                st.rerun()
+            new_cycle_col, export_col = st.columns(2)
+            with new_cycle_col:
+                if st.button("🔄 Start a new Feynman cycle", type="secondary", use_container_width=True):
+                    st.session_state.feynman_topic = ""
+                    st.session_state.feynman_stage = 1
+                    st.session_state.messages = []
+                    st.rerun()
+            with export_col:
+                topic = st.session_state.feynman_topic
+                topic_slug = re.sub(r"[^a-z0-9]+", "_", topic.lower()).strip("_")[:40]
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+                filename = f"{ticker}_{topic_slug}_{timestamp}.md"
+                markdown = _build_feynman_markdown(ticker, topic, st.session_state.messages)
+                st.download_button(
+                    label="⬇️ Export session",
+                    data=markdown,
+                    file_name=filename,
+                    mime="text/markdown",
+                    use_container_width=True,
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- After a Feynman loop ends in the **CLI**, the user is prompted to export the session; if they confirm, the chat is written to `feynman_sessions/<TICKER>_<topic-slug>_<timestamp>.md`
- After a Feynman loop ends in the **GUI**, an "⬇️ Export session" download button appears next to "Start a new Feynman cycle", triggering a browser file download
- `feynman_sessions/` added to `.gitignore` so exports stay local

Closes #30

## Test plan

- [ ] CLI: run a Feynman session to completion, confirm export prompt appears, verify the `.md` file is created in `feynman_sessions/` with correct content
- [ ] CLI: answer `n` at the export prompt, confirm no file is written
- [ ] CLI: exit a session early with `exit`, confirm export prompt still appears
- [ ] GUI: run a Feynman session to completion, confirm "Export session" button appears alongside "Start a new Feynman cycle"
- [ ] GUI: click export, confirm the downloaded `.md` file contains the chat history and correct metadata
- [ ] Confirm `feynman_sessions/` does not appear as a tracked path in `git status`