### PR TITLE
feat: add Recent News section to learning path panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import os
 import streamlit as st
 
 from db.repositories import SchemaRepository
-from ui.data_loaders import load_analyst_view, load_metadata, load_speakers, load_transcript_spans
+from ui.data_loaders import load_analyst_view, load_metadata, load_recent_news, load_speakers, load_transcript_spans
 from ui.feynman import render_chat_interface
 from ui.metadata_panel import render_metadata_panel
 from ui.sidebar import render_sidebar
@@ -89,6 +89,7 @@ themes, takeaways, synthesis, keywords, industry_terms, financial_terms = load_m
 evasion, misconceptions = load_analyst_view(CONN_STR, st.session_state.active_ticker)
 speakers = load_speakers(CONN_STR, st.session_state.active_ticker)
 spans = load_transcript_spans(CONN_STR, st.session_state.active_ticker)
+news_items = load_recent_news(CONN_STR, st.session_state.active_ticker, tuple(themes))
 
 # ------------- Layout -------------
 
@@ -115,6 +116,7 @@ with left_col:
         speakers=speakers,
         evasion=evasion,
         misconceptions=misconceptions,
+        news_items=news_items,
     )
 
 with right_col:

--- a/core/models.py
+++ b/core/models.py
@@ -101,6 +101,7 @@ class CallRecord:
     id: UUID = field(default_factory=uuid4)
     company_name: str = ""
     industry: str = ""
+    call_date: str | None = None   # ISO date string from the transcript JSON
     cached_embeddings_count: int = 0
     api_embeddings_count: int = 0
 
@@ -165,6 +166,21 @@ class QAPairRecord:
     exchange_order: int
     question_span_ids: list[UUID]
     answer_span_ids: list[UUID]
+
+
+# ---------------------------------------------------------------------------
+# News item
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NewsItem:
+    """A single news article fetched around the earnings call date."""
+
+    headline: str
+    url: str
+    source: str
+    date: str       # ISO date string, e.g. "2025-01-15"
+    summary: str
 
 
 # ---------------------------------------------------------------------------

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -75,6 +75,21 @@ class CallRepository:
             logger.warning(f"Could not fetch company info for {ticker}: {e}")
         return ("", "")
 
+    def get_call_date(self, ticker: str):
+        """Return the call_date for a ticker, or None if not set."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT call_date FROM calls WHERE ticker = %s LIMIT 1",
+                        (ticker,),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row else None
+        except Exception as e:
+            logger.warning(f"Could not fetch call_date for {ticker}: {e}")
+            return None
+
     def get_all_calls(self) -> list[tuple[str, str]]:
         calls = []
         try:
@@ -508,7 +523,7 @@ class AnalysisRepository:
                 call.company_name or None,
                 call.industry or None,
                 fiscal_quarter,
-                None,  # call_date
+                call.call_date or None,
                 call.transcript_json,
                 call.transcript_text,
                 call.token_count,

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -43,8 +43,10 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     raw_text = extract_transcript_text(content)
 
     # Look up company name and industry from SEC EDGAR using the CIK in the transcript JSON
-    cik = json.loads(content).get("cik", "")
+    transcript_meta = json.loads(content)
+    cik = transcript_meta.get("cik", "")
     company_name, industry = fetch_company_info(cik) if cik else ("", "")
+    call_date = transcript_meta.get("date")  # ISO date string, e.g. "2026-01-29"
 
     # Basic stats
     tokens = tokenize(clean_text(raw_text))
@@ -95,6 +97,7 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
         qa_len=len(qa),
         company_name=company_name,
         industry=industry,
+        call_date=call_date,
     )
 
     # Speakers

--- a/services/recent_news.py
+++ b/services/recent_news.py
@@ -1,0 +1,117 @@
+"""Fetch recent news articles about a company around an earnings call date."""
+
+import json
+import logging
+import os
+from datetime import date, timedelta
+
+import requests
+
+from core.models import NewsItem
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "You are a financial research assistant. "
+    "Return ONLY a valid JSON array, no markdown, no explanations."
+)
+
+_DATE_WINDOW_BEFORE_DAYS = 30
+_DATE_WINDOW_AFTER_DAYS = 7
+
+
+def fetch_recent_news(
+    ticker: str,
+    company_name: str,
+    call_date: date,
+    themes: list[str],
+    max_items: int = 5,
+) -> list[NewsItem]:
+    """Query Perplexity for news about the company around the call date.
+
+    Returns up to max_items NewsItems ranked by relevance to the transcript themes.
+    Returns an empty list on any error so callers are never blocked.
+    """
+    api_key = os.environ.get("PERPLEXITY_API_KEY")
+    if not api_key:
+        logger.warning("PERPLEXITY_API_KEY not set — skipping news fetch")
+        return []
+
+    start_date = (call_date - timedelta(days=_DATE_WINDOW_BEFORE_DAYS)).isoformat()
+    end_date = (call_date + timedelta(days=_DATE_WINDOW_AFTER_DAYS)).isoformat()
+    display_name = company_name or ticker
+    themes_str = ", ".join(themes[:5]) if themes else "earnings results, financial performance"
+
+    user_prompt = (
+        f"Find the {max_items} most relevant news articles about {display_name} ({ticker}) "
+        f"published between {start_date} and {end_date}. "
+        f"Prioritise articles related to these themes: {themes_str}. "
+        f"Return ONLY a JSON array of up to {max_items} objects. "
+        f'Each object must have these keys: "headline" (string), "url" (string), '
+        f'"source" (publication name, string), "date" (YYYY-MM-DD string), '
+        f'"summary" (1-2 sentence summary, string). '
+        f"If fewer than {max_items} relevant articles exist, return what you find."
+    )
+
+    payload = {
+        "model": "sonar",
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "stream": False,
+    }
+
+    try:
+        response = requests.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        content = response.json()["choices"][0]["message"]["content"].strip()
+        return _parse_news_items(content)
+    except Exception as e:
+        logger.error("News fetch failed for %s: %s", ticker, e)
+        return []
+
+
+def _parse_news_items(content: str) -> list[NewsItem]:
+    """Parse a JSON array from the LLM response into NewsItem objects."""
+    # Strip markdown code fences if present
+    if content.startswith("```json"):
+        content = content[7:]
+    elif content.startswith("```"):
+        content = content[3:]
+    if content.endswith("```"):
+        content = content[:-3]
+    content = content.strip()
+
+    try:
+        items = json.loads(content)
+    except json.JSONDecodeError as e:
+        logger.warning("Could not parse news JSON: %s. Content: %.200s", e, content)
+        return []
+
+    if not isinstance(items, list):
+        logger.warning("Expected JSON array, got %s", type(items))
+        return []
+
+    result = []
+    for item in items:
+        if not isinstance(item, dict) or not item.get("headline"):
+            continue
+        result.append(
+            NewsItem(
+                headline=item.get("headline", ""),
+                url=item.get("url", ""),
+                source=item.get("source", ""),
+                date=item.get("date", ""),
+                summary=item.get("summary", ""),
+            )
+        )
+    return result

--- a/ui/data_loaders.py
+++ b/ui/data_loaders.py
@@ -2,6 +2,7 @@ import logging
 
 import streamlit as st
 
+from core.models import NewsItem
 from db.persistence import (
     get_all_calls,
     get_themes_for_ticker,
@@ -15,6 +16,9 @@ from db.persistence import (
     get_evasion_for_ticker,
     get_misconceptions_for_ticker,
 )
+
+from db.repositories import CallRepository
+from services.recent_news import fetch_recent_news
 
 logger = logging.getLogger(__name__)
 
@@ -69,3 +73,28 @@ def load_metadata(conn_str: str, ticker: str):
     except Exception:
         logger.exception("load_metadata failed for ticker %s", ticker)
         raise
+
+
+@st.cache_data
+def load_recent_news(conn_str: str, ticker: str, themes: tuple[str, ...]) -> list[NewsItem]:
+    """Fetch recent news articles around the earnings call date.
+
+    themes is a tuple (not list) so it is hashable for st.cache_data.
+    Returns an empty list if call_date is unknown or the fetch fails.
+    """
+    if not ticker:
+        return []
+
+    repo = CallRepository(conn_str)
+    call_date = repo.get_call_date(ticker)
+    if not call_date:
+        logger.info("No call_date for %s — skipping news fetch", ticker)
+        return []
+
+    company_name, _ = repo.get_company_info(ticker)
+    return fetch_recent_news(
+        ticker=ticker,
+        company_name=company_name,
+        call_date=call_date,
+        themes=list(themes),
+    )

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -1,6 +1,45 @@
 import streamlit as st
 
+from core.models import NewsItem
+from services.llm import stream_chat
 from ui.term_actions import handle_define_click, handle_explain_click
+
+
+def _handle_relevance_click(
+    article_key: str,
+    headline: str,
+    summary: str,
+    themes: list[str],
+) -> None:
+    """Generate and cache a relevance explanation for a news article."""
+    if st.session_state.get(f"relevance_{article_key}"):
+        st.session_state[f"show_relevance_{article_key}"] = True
+        return
+
+    themes_str = ", ".join(themes[:5]) if themes else "the earnings call results"
+    system_prompt = (
+        "You are a financial analyst. In 2-3 sentences explain why the given news article "
+        "is relevant to the provided earnings call themes. Be specific and concise."
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": (
+                f"Earnings call themes: {themes_str}\n\n"
+                f"News headline: {headline}\n"
+                f"Article summary: {summary}"
+            ),
+        }
+    ]
+
+    explanation = ""
+    for chunk in stream_chat(messages, system_prompt, model="sonar-pro"):
+        if isinstance(chunk, str):
+            explanation += chunk
+
+    if explanation:
+        st.session_state[f"relevance_{article_key}"] = explanation.strip()
+        st.session_state[f"show_relevance_{article_key}"] = True
 
 
 def render_metadata_panel(
@@ -15,6 +54,7 @@ def render_metadata_panel(
     speakers: list,
     evasion: list | None = None,
     misconceptions: list | None = None,
+    news_items: list[NewsItem] | None = None,
 ) -> None:
     """Render the left-column analysis panel as a numbered learning path."""
     st.markdown(f"### 📊 {ticker} — Learning Path")
@@ -80,6 +120,37 @@ def render_metadata_panel(
                 st.markdown(f"**Misconception:** {misinterpretation}")
                 st.markdown(f"**Correction:** {correction}")
                 st.divider()
+
+    if news_items:
+        with st.expander("Step 4 · Recent News"):
+            st.caption("Top news from around the earnings call, ranked by relevance to transcript themes.")
+            for i, item in enumerate(news_items):
+                article_key = f"{ticker}_news_{i}"
+                if item.url:
+                    st.markdown(f"**[{item.headline}]({item.url})**")
+                else:
+                    st.markdown(f"**{item.headline}**")
+
+                meta_parts = [p for p in (item.source, item.date) if p]
+                if meta_parts:
+                    st.caption(" · ".join(meta_parts))
+
+                if item.summary:
+                    st.markdown(item.summary)
+
+                st.button(
+                    "Explain relevance",
+                    key=f"relevance_btn_{article_key}",
+                    on_click=_handle_relevance_click,
+                    args=(article_key, item.headline, item.summary, themes),
+                )
+
+                if st.session_state.get(f"show_relevance_{article_key}"):
+                    explanation = st.session_state.get(f"relevance_{article_key}", "")
+                    st.markdown(f"💡 **Relevance:** {explanation}")
+
+                if i < len(news_items) - 1:
+                    st.divider()
 
     st.checkbox("Show advanced analysis", key="show_advanced_analysis")
 


### PR DESCRIPTION
## Summary

- Adds **Step 4 · Recent News** expander to the learning path panel, showing the top 5 news headlines from the 30-day window before (and 7 days after) the earnings call date
- Headlines are fetched from Perplexity (`sonar` model), ranked by relevance to the transcript themes, and rendered as clickable links with source and date
- Each headline has an **"Explain relevance"** button that streams a `sonar-pro` response explaining how the article connects to the earnings call — same UX pattern as the jargon Explain button
- Results are cached in the Streamlit session via `@st.cache_data` (no DB writes)
- Also fixes a bug where `call_date` was always written as `NULL` to the database even though the transcript JSON contains a `date` field — the news section depends on this value to define the search window

## Files changed

| File | Change |
|---|---|
| `services/recent_news.py` | New — Perplexity fetch + JSON parsing |
| `core/models.py` | Add `NewsItem` dataclass; add `call_date` field to `CallRecord` |
| `db/repositories.py` | Add `get_call_date()`; fix `_save_call` to persist `call_date` |
| `services/orchestrator.py` | Parse `date` from transcript JSON and pass to `CallRecord` |
| `ui/data_loaders.py` | Add `load_recent_news()` with session caching |
| `ui/metadata_panel.py` | Add news expander + `_handle_relevance_click` handler |
| `app.py` | Call `load_recent_news` and pass `news_items` to panel |

## Test plan

- [ ] Re-ingest a transcript (`python3 main.py AAPL --save`) and confirm `call_date` is now populated in the DB
- [ ] Load the app and verify **Step 4 · Recent News** appears in the learning path panel
- [ ] Confirm headlines are clickable and open the correct source URL
- [ ] Click **Explain relevance** on at least one headline and verify a meaningful explanation streams in
- [ ] Switch tickers and confirm the news section updates (cache invalidates per ticker)
- [ ] Verify a transcript with no `call_date` shows no news section (no error)

Closes #5