### PR TITLE
feat: add competitors section to learning path (Step 5)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import os
 import streamlit as st
 
 from db.repositories import SchemaRepository
-from ui.data_loaders import load_analyst_view, load_metadata, load_recent_news, load_speakers, load_transcript_spans
+from ui.data_loaders import load_analyst_view, load_metadata, load_speakers, load_transcript_spans
 from ui.feynman import render_chat_interface
 from ui.metadata_panel import render_metadata_panel
 from ui.sidebar import render_sidebar
@@ -89,7 +89,6 @@ themes, takeaways, synthesis, keywords, industry_terms, financial_terms = load_m
 evasion, misconceptions = load_analyst_view(CONN_STR, st.session_state.active_ticker)
 speakers = load_speakers(CONN_STR, st.session_state.active_ticker)
 spans = load_transcript_spans(CONN_STR, st.session_state.active_ticker)
-news_items = load_recent_news(CONN_STR, st.session_state.active_ticker, tuple(themes))
 
 # ------------- Layout -------------
 
@@ -116,7 +115,6 @@ with left_col:
         speakers=speakers,
         evasion=evasion,
         misconceptions=misconceptions,
-        news_items=news_items,
     )
 
 with right_col:

--- a/cli/menu.py
+++ b/cli/menu.py
@@ -16,10 +16,29 @@ from db.persistence import (
     get_extracted_terms_for_ticker,
     search_spans
 )
+from db.repositories import CompetitorRepository
 from nlp.embedder import get_embeddings
+from services.competitors import fetch_competitors
 from services.llm import stream_chat
 from services.orchestrator import analyze
 from cli.display import display
+
+def _cache_competitors(conn_str: str, analysis) -> None:
+    """Fetch competitors from Perplexity and persist them so the UI loads them instantly."""
+    try:
+        print("Pre-caching competitors...")
+        competitors = fetch_competitors(
+            ticker=analysis.call.ticker,
+            company_name=analysis.call.company_name,
+            industry=analysis.call.industry,
+            transcript_text=analysis.call.transcript_text,
+        )
+        if competitors:
+            CompetitorRepository(conn_str).save(analysis.call.ticker, competitors)
+            print(f"Cached {len(competitors)} competitors.")
+    except Exception as e:
+        print(f"Warning: could not pre-cache competitors: {e}")
+
 
 def _validate_ticker(ticker: str) -> bool:
     """Return True if ticker is 1-5 uppercase alphabetical characters (e.g. AAPL, MSFT)."""
@@ -104,6 +123,7 @@ def interactive_menu() -> None:
                     print(f"\nSaving analysis to database ({conn_str})...")
                     save_analysis(conn_str, analysis)
                     print("Successfully saved to database.")
+                    _cache_competitors(conn_str, analysis)
                 except Exception as e:
                     print(f"Error analyzing or saving transcript: {e}", file=sys.stderr)
                     

--- a/core/models.py
+++ b/core/models.py
@@ -183,6 +183,16 @@ class NewsItem:
     summary: str
 
 
+@dataclass
+class Competitor:
+    """A competitor company identified via Perplexity for a given ticker."""
+
+    name: str
+    ticker: str             # may be empty string if unknown
+    description: str        # one-sentence description
+    mentioned_in_transcript: bool = False
+
+
 # ---------------------------------------------------------------------------
 # Synthesis record
 # ---------------------------------------------------------------------------

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -1,9 +1,11 @@
 import uuid
 import logging
+from datetime import datetime, timezone, timedelta
+
 import psycopg
 import psycopg.errors
 from pgvector.psycopg import register_vector
-from core.models import CallAnalysis, TranscriptChunk
+from core.models import CallAnalysis, Competitor, TranscriptChunk
 
 logger = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ class OutdatedSchemaError(Exception):
     """Exception raised when the database schema is out of date."""
     pass
 
-REQUIRED_SCHEMA_VERSION = 2
+REQUIRED_SCHEMA_VERSION = 3
 
 
 def reset_all_data(conn_str: str) -> None:
@@ -711,6 +713,109 @@ class AnalysisRepository:
                     gotcha.get("correction") or "",
                 ),
             )
+
+
+_COMPETITOR_CACHE_TTL_DAYS = 30
+
+
+class CompetitorRepository:
+    """Read/write cached competitors for a given ticker."""
+
+    def __init__(self, conn_str: str):
+        self.conn_str = conn_str
+
+    def _get_call_id(self, cur, ticker: str) -> str | None:
+        """Return the call UUID for a ticker, or None if not found."""
+        cur.execute("SELECT id FROM calls WHERE ticker = %s LIMIT 1", (ticker,))
+        row = cur.fetchone()
+        return str(row[0]) if row else None
+
+    def get(self, ticker: str) -> list[Competitor]:
+        """Return cached competitors for a ticker if still within TTL, else empty list."""
+        rows = []
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT co.competitor_name, co.competitor_ticker,
+                               co.description, co.mentioned_in_transcript, co.fetched_at
+                        FROM competitors co
+                        JOIN calls c ON co.call_id = c.id
+                        WHERE c.ticker = %s
+                        ORDER BY co.competitor_name ASC
+                        """,
+                        (ticker,),
+                    )
+                    rows = cur.fetchall()
+        except Exception as e:
+            logger.warning("Could not fetch competitors for %s: %s", ticker, e)
+            return []
+
+        if not rows:
+            return []
+
+        # Check TTL against the oldest fetched_at in the set
+        cutoff = datetime.now(timezone.utc) - timedelta(days=_COMPETITOR_CACHE_TTL_DAYS)
+        fetched_at = rows[0][4]
+        if fetched_at and fetched_at < cutoff:
+            return []
+
+        return [
+            Competitor(
+                name=row[0],
+                ticker=row[1] or "",
+                description=row[2] or "",
+                mentioned_in_transcript=bool(row[3]),
+            )
+            for row in rows
+        ]
+
+    def save(self, ticker: str, competitors: list[Competitor]) -> None:
+        """Delete existing competitors for a ticker and insert the new list."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    call_id = self._get_call_id(cur, ticker)
+                    if not call_id:
+                        logger.warning("No call found for ticker %s — skipping competitor save", ticker)
+                        return
+                    cur.execute("DELETE FROM competitors WHERE call_id = %s", (call_id,))
+                    for c in competitors:
+                        cur.execute(
+                            """
+                            INSERT INTO competitors (
+                                call_id, competitor_name, competitor_ticker,
+                                description, mentioned_in_transcript
+                            ) VALUES (%s, %s, %s, %s, %s)
+                            ON CONFLICT (call_id, competitor_name) DO UPDATE SET
+                                competitor_ticker = EXCLUDED.competitor_ticker,
+                                description = EXCLUDED.description,
+                                mentioned_in_transcript = EXCLUDED.mentioned_in_transcript,
+                                fetched_at = now()
+                            """,
+                            (call_id, c.name, c.ticker or None, c.description, c.mentioned_in_transcript),
+                        )
+                conn.commit()
+        except Exception as e:
+            logger.warning("Could not save competitors for %s: %s", ticker, e)
+
+    def delete(self, ticker: str) -> None:
+        """Remove all cached competitors for a ticker (forces re-fetch)."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        DELETE FROM competitors
+                        USING calls
+                        WHERE competitors.call_id = calls.id AND calls.ticker = %s
+                        """,
+                        (ticker,),
+                    )
+                conn.commit()
+        except Exception as e:
+            logger.warning("Could not delete competitors for %s: %s", ticker, e)
 
 
 SYSTEM_USER_ID = "00000000-0000-0000-0000-000000000001"

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE schema_version (
 );
 
 -- Initialize version
-INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (3) ON CONFLICT DO NOTHING;
 
 
 -- One row per earnings call
@@ -238,4 +238,17 @@ CREATE TABLE call_synthesis (
     strategic_shifts   TEXT NOT NULL,
     analyst_sentiment  TEXT NOT NULL
 );
+
+CREATE TABLE competitors (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    call_id                 UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+    competitor_name         TEXT NOT NULL,
+    competitor_ticker       TEXT,
+    description             TEXT,
+    mentioned_in_transcript BOOLEAN NOT NULL DEFAULT FALSE,
+    fetched_at              TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (call_id, competitor_name)
+);
+
+CREATE INDEX idx_competitors_call ON competitors(call_id);
 

--- a/main.py
+++ b/main.py
@@ -59,11 +59,23 @@ if __name__ == "__main__":
     
         if args.save:
             from db.persistence import save_analysis
+            from db.repositories import CompetitorRepository
+            from services.competitors import fetch_competitors
             conn_str = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
             print(f"\nSaving analysis to database ({conn_str})...")
             try:
                 save_analysis(conn_str, result)
                 print("Successfully saved to database.")
+                print("Pre-caching competitors...")
+                competitors = fetch_competitors(
+                    ticker=result.call.ticker,
+                    company_name=result.call.company_name,
+                    industry=result.call.industry,
+                    transcript_text=result.call.transcript_text,
+                )
+                if competitors:
+                    CompetitorRepository(conn_str).save(result.call.ticker, competitors)
+                    print(f"Cached {len(competitors)} competitors.")
             except Exception as e:
                 print(f"Error saving to database: {e}", file=sys.stderr)
                 sys.exit(1)

--- a/migrate.py
+++ b/migrate.py
@@ -23,7 +23,27 @@ try:
             cur.execute(
                 "INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;"
             )
+
+            # v2 → v3: add competitors table
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS competitors (
+                    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    call_id                 UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+                    competitor_name         TEXT NOT NULL,
+                    competitor_ticker       TEXT,
+                    description             TEXT,
+                    mentioned_in_transcript BOOLEAN NOT NULL DEFAULT FALSE,
+                    fetched_at              TIMESTAMPTZ DEFAULT now(),
+                    UNIQUE (call_id, competitor_name)
+                );
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_competitors_call ON competitors(call_id);"
+            )
+            cur.execute(
+                "INSERT INTO schema_version (version) VALUES (3) ON CONFLICT DO NOTHING;"
+            )
         conn.commit()
-    print("Migration successful — schema is at version 2.")
+    print("Migration successful — schema is at version 3.")
 except Exception as e:
     print(f"Error during migration: {e}")

--- a/services/competitors.py
+++ b/services/competitors.py
@@ -1,0 +1,134 @@
+"""Fetch competitors for a company via Perplexity and detect transcript mentions."""
+
+import json
+import logging
+import os
+
+import requests
+
+from core.models import Competitor
+
+logger = logging.getLogger(__name__)
+
+_SYSTEM_PROMPT = (
+    "You are a financial research assistant. "
+    "Return ONLY a valid JSON array, no markdown, no explanations."
+)
+
+_MAX_COMPETITORS = 8
+
+
+def fetch_competitors(
+    ticker: str,
+    company_name: str,
+    industry: str,
+    transcript_text: str,
+    max_items: int = _MAX_COMPETITORS,
+) -> list[Competitor]:
+    """Query Perplexity for direct competitors of the company.
+
+    Returns up to max_items Competitor objects with mention flags set.
+    Returns an empty list on any error so callers are never blocked.
+    """
+    api_key = os.environ.get("PERPLEXITY_API_KEY")
+    if not api_key:
+        logger.warning("PERPLEXITY_API_KEY not set — skipping competitors fetch")
+        return []
+
+    display_name = company_name or ticker
+    industry_str = industry or "their industry"
+
+    user_prompt = (
+        f"List the top {max_items} direct competitors of {display_name} ({ticker}) "
+        f"in the {industry_str} sector. "
+        f"Return ONLY a JSON array of up to {max_items} objects. "
+        f'Each object must have these keys: "name" (company name, string), '
+        f'"ticker" (stock ticker symbol or empty string if unknown, string), '
+        f'"description" (one sentence describing the company and why it competes, string). '
+        f"Focus on publicly traded direct competitors. "
+        f"If fewer than {max_items} exist, return what you find."
+    )
+
+    payload = {
+        "model": "sonar",
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "stream": False,
+    }
+
+    try:
+        response = requests.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        content = response.json()["choices"][0]["message"]["content"].strip()
+        competitors = _parse_competitors(content)
+        return _flag_transcript_mentions(competitors, transcript_text)
+    except Exception as e:
+        logger.error("Competitors fetch failed for %s: %s", ticker, e)
+        return []
+
+
+def _parse_competitors(content: str) -> list[Competitor]:
+    """Parse a JSON array from the LLM response into Competitor objects."""
+    if content.startswith("```json"):
+        content = content[7:]
+    elif content.startswith("```"):
+        content = content[3:]
+    if content.endswith("```"):
+        content = content[:-3]
+    content = content.strip()
+
+    try:
+        items = json.loads(content)
+    except json.JSONDecodeError as e:
+        logger.warning("Could not parse competitors JSON: %s. Content: %.200s", e, content)
+        return []
+
+    if not isinstance(items, list):
+        logger.warning("Expected JSON array for competitors, got %s", type(items))
+        return []
+
+    result = []
+    for item in items:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        result.append(
+            Competitor(
+                name=item.get("name", ""),
+                ticker=item.get("ticker", "") or "",
+                description=item.get("description", ""),
+            )
+        )
+    return result
+
+
+def _flag_transcript_mentions(
+    competitors: list[Competitor], transcript_text: str
+) -> list[Competitor]:
+    """Return a new list of Competitors with mentioned_in_transcript set via string search."""
+    text_lower = transcript_text.lower()
+    result = []
+    for c in competitors:
+        mentioned = False
+        if c.name and c.name.lower() in text_lower:
+            mentioned = True
+        elif c.ticker and c.ticker.upper() in transcript_text.upper():
+            mentioned = True
+        result.append(
+            Competitor(
+                name=c.name,
+                ticker=c.ticker,
+                description=c.description,
+                mentioned_in_transcript=mentioned,
+            )
+        )
+    return result

--- a/ui/data_loaders.py
+++ b/ui/data_loaders.py
@@ -2,7 +2,7 @@ import logging
 
 import streamlit as st
 
-from core.models import NewsItem
+from core.models import Competitor, NewsItem  # Competitor used by load_competitors return type
 from db.persistence import (
     get_all_calls,
     get_themes_for_ticker,
@@ -17,7 +17,8 @@ from db.persistence import (
     get_misconceptions_for_ticker,
 )
 
-from db.repositories import CallRepository
+from db.repositories import CallRepository, CompetitorRepository
+from services.competitors import fetch_competitors
 from services.recent_news import fetch_recent_news
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,40 @@ def load_metadata(conn_str: str, ticker: str):
     except Exception:
         logger.exception("load_metadata failed for ticker %s", ticker)
         raise
+
+
+@st.cache_data
+def load_competitors(conn_str: str, ticker: str) -> list[Competitor]:
+    """Return competitors for a ticker, using the DB cache when fresh.
+
+    Falls back to a live Perplexity fetch when the cache is empty or stale (>30 days).
+    Returns an empty list if the ticker is unknown or the fetch fails.
+    """
+    if not ticker:
+        return []
+
+    repo = CompetitorRepository(conn_str)
+    cached = repo.get(ticker)
+    if cached:
+        return cached
+
+    call_repo = CallRepository(conn_str)
+    company_name, industry = call_repo.get_company_info(ticker)
+
+    # We need the transcript text to flag mentions — fetch from the spans table.
+    from db.persistence import get_spans_for_ticker
+    spans = get_spans_for_ticker(conn_str, ticker)
+    transcript_text = " ".join(text for _, _, text in spans)
+
+    competitors = fetch_competitors(
+        ticker=ticker,
+        company_name=company_name,
+        industry=industry,
+        transcript_text=transcript_text,
+    )
+    if competitors:
+        repo.save(ticker, competitors)
+    return competitors
 
 
 @st.cache_data

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -1,7 +1,14 @@
-import streamlit as st
+import threading
 
-from core.models import NewsItem
+import streamlit as st
+from streamlit.runtime.scriptrunner import add_script_run_ctx, get_script_run_ctx
+
+from core.models import Competitor, NewsItem
+from db.repositories import CallRepository, CompetitorRepository
+from db.persistence import get_spans_for_ticker
+from services.competitors import fetch_competitors
 from services.llm import stream_chat
+from services.recent_news import fetch_recent_news
 from ui.term_actions import handle_define_click, handle_explain_click
 
 
@@ -42,6 +49,140 @@ def _handle_relevance_click(
         st.session_state[f"show_relevance_{article_key}"] = True
 
 
+@st.fragment(run_every="1s")
+def _render_news_fragment(conn_str: str, ticker: str, themes: list[str]) -> None:
+    """Render the Recent News section. Fetches data in a background thread so the
+    main script (and the right-hand pane) are never blocked."""
+    data_key = f"news_data_{ticker}"
+    thread_key = f"news_thread_{ticker}"
+
+    news_items = st.session_state.get(data_key)
+
+    if news_items is not None:
+        # Data ready — render it. run_every keeps firing but this branch is fast.
+        with st.expander("Step 4 · Recent News"):
+            if news_items:
+                st.caption("Top news from around the earnings call, ranked by relevance to transcript themes.")
+                for i, item in enumerate(news_items):
+                    article_key = f"{ticker}_news_{i}"
+                    if item.url:
+                        st.markdown(f"**[{item.headline}]({item.url})**")
+                    else:
+                        st.markdown(f"**{item.headline}**")
+                    meta_parts = [p for p in (item.source, item.date) if p]
+                    if meta_parts:
+                        st.caption(" · ".join(meta_parts))
+                    if item.summary:
+                        st.markdown(item.summary)
+                    st.button(
+                        "Explain relevance",
+                        key=f"relevance_btn_{article_key}",
+                        on_click=_handle_relevance_click,
+                        args=(article_key, item.headline, item.summary, themes),
+                    )
+                    if st.session_state.get(f"show_relevance_{article_key}"):
+                        explanation = st.session_state.get(f"relevance_{article_key}", "")
+                        st.markdown(f"💡 **Relevance:** {explanation}")
+                    if i < len(news_items) - 1:
+                        st.divider()
+            else:
+                st.info("No recent news found.")
+        return
+
+    # Still loading — show placeholder and start the background thread once.
+    with st.expander("Step 4 · Recent News  ·  ⏳ Loading…"):
+        st.caption("Fetching recent news in the background…")
+
+    if not st.session_state.get(thread_key):
+        st.session_state[thread_key] = True
+        ctx = get_script_run_ctx()
+
+        def _fetch() -> None:
+            add_script_run_ctx(threading.current_thread(), ctx)
+            call_repo = CallRepository(conn_str)
+            call_date = call_repo.get_call_date(ticker)
+            company_name, _ = call_repo.get_company_info(ticker)
+            if call_date:
+                result = fetch_recent_news(
+                    ticker=ticker,
+                    company_name=company_name,
+                    call_date=call_date,
+                    themes=list(themes),
+                )
+            else:
+                result = []
+            st.session_state[data_key] = result
+
+        threading.Thread(target=_fetch, daemon=True).start()
+
+
+@st.fragment(run_every="1s")
+def _render_competitors_fragment(conn_str: str, ticker: str) -> None:
+    """Render the Competitors section. Fetches data in a background thread so the
+    main script (and the right-hand pane) are never blocked."""
+    data_key = f"competitors_data_{ticker}"
+    thread_key = f"competitors_thread_{ticker}"
+
+    competitors = st.session_state.get(data_key)
+
+    if competitors is not None:
+        # Data ready — render it.
+        with st.expander("Step 5 · Competitors"):
+            if competitors:
+                st.caption("Direct competitors identified for this company and industry.")
+                for c in competitors:
+                    name_line = f"**{c.name}**"
+                    if c.ticker:
+                        name_line += f" `{c.ticker}`"
+                    if c.mentioned_in_transcript:
+                        name_line += " 🔖 *mentioned in transcript*"
+                    st.markdown(name_line)
+                    if c.description:
+                        st.markdown(f"_{c.description}_")
+                    st.divider()
+            else:
+                st.info("No competitor data available.")
+
+            if st.button("Refresh competitors", key=f"refresh_competitors_{ticker}"):
+                CompetitorRepository(conn_str).delete(ticker)
+                del st.session_state[data_key]
+                if thread_key in st.session_state:
+                    del st.session_state[thread_key]
+                st.rerun()
+        return
+
+    # Still loading — show placeholder and start the background thread once.
+    with st.expander("Step 5 · Competitors  ·  ⏳ Loading…"):
+        st.caption("Fetching competitors in the background…")
+
+    if not st.session_state.get(thread_key):
+        st.session_state[thread_key] = True
+        ctx = get_script_run_ctx()
+
+        def _fetch() -> None:
+            add_script_run_ctx(threading.current_thread(), ctx)
+            repo = CompetitorRepository(conn_str)
+            cached = repo.get(ticker)
+            if cached:
+                st.session_state[data_key] = cached
+                return
+            call_repo = CallRepository(conn_str)
+            company_name, industry = call_repo.get_company_info(ticker)
+            spans = get_spans_for_ticker(conn_str, ticker)
+            transcript_text = " ".join(text for _, _, text in spans)
+            result = fetch_competitors(
+                ticker=ticker,
+                company_name=company_name,
+                industry=industry,
+                transcript_text=transcript_text,
+            )
+            if result:
+                repo.save(ticker, result)
+            st.session_state[data_key] = result
+
+        threading.Thread(target=_fetch, daemon=True).start()
+
+
 def render_metadata_panel(
     conn_str: str,
     ticker: str,
@@ -54,7 +195,6 @@ def render_metadata_panel(
     speakers: list,
     evasion: list | None = None,
     misconceptions: list | None = None,
-    news_items: list[NewsItem] | None = None,
 ) -> None:
     """Render the left-column analysis panel as a numbered learning path."""
     st.markdown(f"### 📊 {ticker} — Learning Path")
@@ -121,36 +261,9 @@ def render_metadata_panel(
                 st.markdown(f"**Correction:** {correction}")
                 st.divider()
 
-    if news_items:
-        with st.expander("Step 4 · Recent News"):
-            st.caption("Top news from around the earnings call, ranked by relevance to transcript themes.")
-            for i, item in enumerate(news_items):
-                article_key = f"{ticker}_news_{i}"
-                if item.url:
-                    st.markdown(f"**[{item.headline}]({item.url})**")
-                else:
-                    st.markdown(f"**{item.headline}**")
-
-                meta_parts = [p for p in (item.source, item.date) if p]
-                if meta_parts:
-                    st.caption(" · ".join(meta_parts))
-
-                if item.summary:
-                    st.markdown(item.summary)
-
-                st.button(
-                    "Explain relevance",
-                    key=f"relevance_btn_{article_key}",
-                    on_click=_handle_relevance_click,
-                    args=(article_key, item.headline, item.summary, themes),
-                )
-
-                if st.session_state.get(f"show_relevance_{article_key}"):
-                    explanation = st.session_state.get(f"relevance_{article_key}", "")
-                    st.markdown(f"💡 **Relevance:** {explanation}")
-
-                if i < len(news_items) - 1:
-                    st.divider()
+    if ticker:
+        _render_news_fragment(conn_str, ticker, themes)
+        _render_competitors_fragment(conn_str, ticker)
 
     st.checkbox("Show advanced analysis", key="show_advanced_analysis")
 


### PR DESCRIPTION
Closes #4
Closes #6

## Summary

- Adds a **Step 5 · Competitors** expander to the left-column learning path panel, showing up to 8 direct competitors with name, ticker, one-line description, and a badge when the competitor is mentioned in the transcript
- Competitor data is sourced from Perplexity and **cached in a new `competitors` DB table** (schema v3) with a 30-day TTL; a Refresh button allows manual re-fetch
- Competitors are **pre-cached during transcript ingestion** (`cli/menu.py`, `main.py`) so they load from the DB on first UI view rather than hitting Perplexity live
- The news and competitors sections now **load in background threads** with Streamlit run-context propagation (`add_script_run_ctx`), so the main page layout and right-hand chat pane render immediately while the expander headers show a `⏳ Loading…` indicator

## Schema change

New `competitors` table (migration in `migrate.py`, schema bumped to v3). Run `python migrate.py` before starting the app.

## Test plan

- [ ] Run `python migrate.py` — should report "schema is at version 3"
- [ ] Ingest a ticker via the CLI menu — should print "Pre-caching competitors…" and "Cached N competitors."
- [ ] Open the web UI — transcript browser and chat pane should appear immediately, before the competitor/news expanders finish loading
- [ ] Expand Step 5 — should show competitor list; competitors mentioned in the transcript should have the 🔖 badge
- [ ] Click Refresh — should clear and re-fetch from Perplexity
- [ ] Switch tickers — competitors section should show correct data for the new ticker