### PR TITLE
feat: enrich learning path with summary, dynamics, and structured shifts

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import os
 import streamlit as st
 
 from db.repositories import SchemaRepository
-from ui.data_loaders import load_analyst_view, load_metadata, load_qa_evasion, load_speakers, load_strategic_shifts, load_transcript_spans
+from ui.data_loaders import load_analyst_view, load_call_summary, load_metadata, load_qa_evasion, load_speaker_dynamics, load_speakers, load_strategic_shifts, load_transcript_spans
 from ui.feynman import render_chat_interface
 from ui.metadata_panel import render_metadata_panel
 from ui.sidebar import render_sidebar
@@ -88,6 +88,8 @@ speakers = load_speakers(CONN_STR, st.session_state.active_ticker)
 spans = load_transcript_spans(CONN_STR, st.session_state.active_ticker)
 strategic_shifts = load_strategic_shifts(CONN_STR, st.session_state.active_ticker)
 qa_evasion = load_qa_evasion(CONN_STR, st.session_state.active_ticker)
+call_summary = load_call_summary(CONN_STR, st.session_state.active_ticker)
+speaker_dynamics = load_speaker_dynamics(CONN_STR, st.session_state.active_ticker)
 
 # ------------- Layout -------------
 
@@ -116,6 +118,8 @@ with left_col:
         misconceptions=misconceptions,
         strategic_shifts=strategic_shifts,
         qa_evasion=qa_evasion,
+        call_summary=call_summary,
+        speaker_dynamics=speaker_dynamics,
     )
 
 with right_col:

--- a/core/models.py
+++ b/core/models.py
@@ -203,10 +203,11 @@ class CallSynthesisRecord:
     overall_sentiment: str
     executive_tone: str
     key_themes: list[str]
-    strategic_shifts: list[str]
+    strategic_shifts: list[dict]
     analyst_sentiment: str
     call_id: UUID = field(default_factory=uuid4)
     id: UUID = field(default_factory=uuid4)
+    call_summary: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/db/migrations/005_call_summary.sql
+++ b/db/migrations/005_call_summary.sql
@@ -1,0 +1,3 @@
+-- Migration 005: Add call_summary to call_synthesis
+ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS call_summary TEXT;
+INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;

--- a/db/migrations/006_strategic_shifts_jsonb.sql
+++ b/db/migrations/006_strategic_shifts_jsonb.sql
@@ -1,0 +1,22 @@
+-- Migration 006: Convert strategic_shifts from TEXT[] to JSONB[]
+-- PostgreSQL does not allow subqueries in ALTER COLUMN TYPE ... USING,
+-- so we add a new column, populate it via UPDATE, then rename.
+ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS strategic_shifts_new JSONB[] DEFAULT '{}';
+
+UPDATE call_synthesis
+SET strategic_shifts_new = (
+    SELECT array_agg(
+        jsonb_build_object(
+            'prior_position', '',
+            'current_position', s,
+            'investor_significance', ''
+        )
+    )
+    FROM unnest(strategic_shifts) AS s
+)
+WHERE strategic_shifts IS NOT NULL AND array_length(strategic_shifts, 1) > 0;
+
+ALTER TABLE call_synthesis DROP COLUMN strategic_shifts;
+ALTER TABLE call_synthesis RENAME COLUMN strategic_shifts_new TO strategic_shifts;
+
+INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;

--- a/db/persistence.py
+++ b/db/persistence.py
@@ -43,10 +43,20 @@ def get_synthesis_for_ticker(conn_str: str, ticker: str) -> tuple[str, str, str]
     repo = AnalysisRepository(conn_str)
     return repo.get_synthesis_for_ticker(ticker)
 
-def get_strategic_shifts_for_ticker(conn_str: str, ticker: str) -> list[str] | None:
-    """Return the strategic_shifts list for a ticker, or None if absent."""
+def get_strategic_shifts_for_ticker(conn_str: str, ticker: str) -> list[dict] | None:
+    """Return the strategic_shifts list for a ticker as structured dicts, or None if absent."""
     repo = AnalysisRepository(conn_str)
     return repo.get_strategic_shifts_for_ticker(ticker)
+
+def get_call_summary_for_ticker(conn_str: str, ticker: str) -> str | None:
+    """Return the call_summary paragraph for a ticker, or None if absent."""
+    repo = AnalysisRepository(conn_str)
+    return repo.get_call_summary_for_ticker(ticker)
+
+def get_speaker_dynamics(conn_str: str, ticker: str) -> list[dict]:
+    """Return per-speaker turn and word counts for a ticker."""
+    repo = AnalysisRepository(conn_str)
+    return repo.get_speaker_dynamics(ticker)
 
 def get_keywords_for_ticker(conn_str: str, ticker: str, limit: int = 15) -> list[str]:
     repo = AnalysisRepository(conn_str)

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -13,7 +13,7 @@ class OutdatedSchemaError(Exception):
     """Exception raised when the database schema is out of date."""
     pass
 
-REQUIRED_SCHEMA_VERSION = 4
+REQUIRED_SCHEMA_VERSION = 7
 
 
 def reset_all_data(conn_str: str) -> None:
@@ -36,7 +36,7 @@ class SchemaRepository:
         try:
             with psycopg.connect(self.conn_str) as conn:
                 with conn.cursor() as cur:
-                    cur.execute("SELECT version FROM schema_version ORDER BY installed_at DESC LIMIT 1")
+                    cur.execute("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1")
                     row = cur.fetchone()
                     return row[0] if row else 0
         except psycopg.errors.UndefinedTable:
@@ -226,8 +226,8 @@ class AnalysisRepository:
             logger.warning(f"Could not fetch synthesis for {ticker}: {e}")
         return None
 
-    def get_strategic_shifts_for_ticker(self, ticker: str) -> list[str] | None:
-        """Return the strategic_shifts list for a ticker, or None if absent."""
+    def get_strategic_shifts_for_ticker(self, ticker: str) -> list[dict] | None:
+        """Return the strategic_shifts list for a ticker as structured dicts, or None if absent."""
         try:
             with psycopg.connect(self.conn_str) as conn:
                 with conn.cursor() as cur:
@@ -241,10 +241,91 @@ class AnalysisRepository:
                         (ticker,),
                     )
                     row = cur.fetchone()
-                    return row[0] if row else None
+                    if not row or not row[0]:
+                        return None
+                    # Normalise: old TEXT[] rows may have been migrated; ensure list[dict]
+                    shifts = []
+                    for item in row[0]:
+                        if isinstance(item, dict):
+                            shifts.append(item)
+                        else:
+                            shifts.append({"prior_position": "", "current_position": str(item), "investor_significance": ""})
+                    return shifts
         except Exception as e:
             logger.warning(f"Could not fetch strategic_shifts for {ticker}: {e}")
         return None
+
+    def get_call_summary_for_ticker(self, ticker: str) -> str | None:
+        """Return the call_summary paragraph for a ticker, or None if absent."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT cs.call_summary
+                        FROM call_synthesis cs
+                        JOIN calls c ON cs.call_id = c.id
+                        WHERE c.ticker = %s
+                        """,
+                        (ticker,),
+                    )
+                    row = cur.fetchone()
+                    return row[0] if row else None
+        except Exception as e:
+            logger.warning(f"Could not fetch call_summary for {ticker}: {e}")
+        return None
+
+    def get_speaker_dynamics(self, ticker: str) -> list[dict]:
+        """Return per-speaker, per-section turn and word counts for a ticker.
+
+        Each dict contains: speaker, role, firm, section, turn_count, word_count.
+        """
+        rows = []
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                            COALESCE(sp.name, 'Unknown') AS speaker,
+                            COALESCE(sp.role, 'unknown') AS role,
+                            COALESCE(sp.firm, '') AS firm,
+                            s.section,
+                            COUNT(*) AS turn_count,
+                            SUM(COALESCE(
+                                array_length(regexp_split_to_array(trim(s.text), '\\s+'), 1),
+                                0
+                            )) AS word_count
+                        FROM spans s
+                        JOIN calls c ON s.call_id = c.id
+                        LEFT JOIN speakers sp ON s.speaker_id = sp.id
+                        WHERE c.ticker = %s
+                          AND s.span_type = 'turn'
+                          AND s.sequence_order >= 0
+                          AND (sp.role IS NULL OR sp.role != 'operator')
+                        GROUP BY
+                            COALESCE(sp.name, 'Unknown'),
+                            COALESCE(sp.role, 'unknown'),
+                            COALESCE(sp.firm, ''),
+                            s.section
+                        ORDER BY turn_count DESC
+                        """,
+                        (ticker,),
+                    )
+                    rows = [
+                        {
+                            "speaker": r[0],
+                            "role": r[1],
+                            "firm": r[2],
+                            "section": r[3],
+                            "turn_count": r[4],
+                            "word_count": r[5],
+                        }
+                        for r in cur.fetchall()
+                    ]
+        except Exception as e:
+            logger.warning(f"Could not fetch speaker dynamics for {ticker}: {e}")
+        return rows
 
     def get_takeaways_for_ticker(self, ticker: str, limit: int = 5) -> list[tuple[str, str]]:
         takeaways = []
@@ -530,18 +611,29 @@ class AnalysisRepository:
             conn.commit()
 
     def _save_call_synthesis(self, cur, call_id, synthesis):
+        from psycopg.types.json import Jsonb
+
+        # Serialise strategic_shifts: list[dict] → JSONB[]
+        shifts = synthesis.strategic_shifts or []
+        shifts_value = [
+            Jsonb(s) if isinstance(s, dict)
+            else Jsonb({"prior_position": "", "current_position": str(s), "investor_significance": ""})
+            for s in shifts
+        ]
+
         cur.execute(
             """
             INSERT INTO call_synthesis (
                 id, call_id, overall_sentiment, executive_tone,
-                key_themes, strategic_shifts, analyst_sentiment
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                key_themes, strategic_shifts, analyst_sentiment, call_summary
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             ON CONFLICT (call_id) DO UPDATE SET
                 overall_sentiment = EXCLUDED.overall_sentiment,
                 executive_tone = EXCLUDED.executive_tone,
                 key_themes = EXCLUDED.key_themes,
                 strategic_shifts = EXCLUDED.strategic_shifts,
-                analyst_sentiment = EXCLUDED.analyst_sentiment
+                analyst_sentiment = EXCLUDED.analyst_sentiment,
+                call_summary = EXCLUDED.call_summary
             """,
             (
                 str(synthesis.id),
@@ -549,8 +641,9 @@ class AnalysisRepository:
                 synthesis.overall_sentiment,
                 synthesis.executive_tone,
                 synthesis.key_themes,
-                synthesis.strategic_shifts,
-                synthesis.analyst_sentiment
+                shifts_value,
+                synthesis.analyst_sentiment,
+                synthesis.call_summary,
             )
         )
 

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -249,12 +249,26 @@ class IngestionPipeline:
         if synthesis_usage:
             print(f"    ↳ Synthesis [Model: {synthesis_usage['model']} | In: {synthesis_usage['prompt_tokens']} | Out: {synthesis_usage['completion_tokens']}]")
 
+        # Normalise strategic_shifts: accept list[str] (old prompts) or list[dict] (new prompt)
+        raw_shifts = synthesis_data.get("strategic_shifts", [])
+        structured_shifts = []
+        for s in raw_shifts:
+            if isinstance(s, dict):
+                structured_shifts.append(s)
+            else:
+                structured_shifts.append({
+                    "prior_position": "",
+                    "current_position": str(s),
+                    "investor_significance": "",
+                })
+
         synthesis = CallSynthesisRecord(
             overall_sentiment=synthesis_data.get("overall_sentiment", ""),
             executive_tone=synthesis_data.get("executive_tone", ""),
             key_themes=synthesis_data.get("key_themes", []),
-            strategic_shifts=synthesis_data.get("strategic_shifts", []),
-            analyst_sentiment=synthesis_data.get("analyst_sentiment", "")
+            strategic_shifts=structured_shifts,
+            analyst_sentiment=synthesis_data.get("analyst_sentiment", ""),
+            call_summary=synthesis_data.get("call_summary") or None,
         )
 
         # Aggregate all token usage across chunks and synthesis

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -84,21 +84,27 @@ You will be provided with:
 1. The aggregated Tier 1 and Tier 2 outputs (terms, concepts, takeaways, evasion analysis, and misconceptions) from across the entire call.
 
 Follow these instructions to generate the final synthesis:
-1. **overall_sentiment**: Summarize the overall sentiment of the call in one concise sentence (e.g., "Cautiously optimistic despite macroeconomic headwinds.").
-2. **executive_tone**: Describe the tone of the executives, particularly during Q&A (e.g., "Defensive on margin questions but highly confident on product roadmap.").
-3. **key_themes**: Extract the 3-5 most dominant and recurring thematic clusters across all chunks.
-4. **strategic_shifts**: Identify any major pivots, new initiatives, or changes to prior guidance that signal a structural shift. Return each distinct shift as a separate string in the array.
-5. **analyst_sentiment**: Summarize the prevailing mood and main areas of concern from the analyst questions.
+1. **call_summary**: Write a 2-3 sentence narrative summary of the call covering: what the company reported (headline numbers or events), the overall tone and market reaction, and the single most important forward-looking signal. This is the first thing a learner reads — make it vivid and specific.
+2. **overall_sentiment**: Summarize the overall sentiment of the call in one concise sentence (e.g., "Cautiously optimistic despite macroeconomic headwinds.").
+3. **executive_tone**: Describe the tone of the executives, particularly during Q&A (e.g., "Defensive on margin questions but highly confident on product roadmap.").
+4. **key_themes**: Extract the 3-5 most dominant and recurring thematic clusters across all chunks.
+5. **strategic_shifts**: Identify any major pivots, new initiatives, or changes to prior guidance that signal a structural shift. For each shift, provide three fields: prior_position (what management had previously signalled or committed to — leave empty string if unknown), current_position (what they are saying now), and investor_significance (why this change matters for valuation, risk, or narrative).
+6. **analyst_sentiment**: Summarize the prevailing mood and main areas of concern from the analyst questions.
 
 Respond ONLY with valid JSON matching this schema:
 {
+  "call_summary": "string",
   "overall_sentiment": "string",
   "executive_tone": "string",
   "key_themes": [
     "string"
   ],
   "strategic_shifts": [
-    "string"
+    {
+      "prior_position": "string",
+      "current_position": "string",
+      "investor_significance": "string"
+    }
   ],
   "analyst_sentiment": "string"
 }

--- a/migrate.py
+++ b/migrate.py
@@ -71,7 +71,67 @@ try:
             cur.execute(
                 "INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;"
             )
+
+            # v5 → v6: add call_summary to call_synthesis
+            cur.execute(
+                "ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS call_summary TEXT;"
+            )
+            cur.execute(
+                "INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;"
+            )
+
+            # v6 → v7: convert strategic_shifts from TEXT[] to JSONB[]
+            # Uses a new-column+UPDATE+rename approach because PostgreSQL does not
+            # allow subqueries in ALTER COLUMN TYPE ... USING.
+            # The block is written to be safe to re-run after a partial failure:
+            #   - inspect actual column state before each step
+            #   - only execute steps that have not already completed
+            cur.execute("""
+                SELECT column_name, udt_name
+                FROM information_schema.columns
+                WHERE table_name = 'call_synthesis'
+                  AND column_name IN ('strategic_shifts', 'strategic_shifts_new')
+            """)
+            existing = {row[0]: row[1] for row in cur.fetchall()}
+
+            shifts_type = existing.get("strategic_shifts")        # '_text', '_jsonb', or None
+            shifts_new_exists = "strategic_shifts_new" in existing
+
+            if shifts_type == "_jsonb":
+                # Already migrated — nothing to do
+                pass
+            else:
+                if not shifts_new_exists:
+                    cur.execute(
+                        "ALTER TABLE call_synthesis ADD COLUMN strategic_shifts_new JSONB[] DEFAULT '{}';"
+                    )
+                if shifts_type == "_text":
+                    # Populate from the TEXT[] column
+                    cur.execute(
+                        """
+                        UPDATE call_synthesis
+                        SET strategic_shifts_new = (
+                            SELECT array_agg(
+                                jsonb_build_object(
+                                    'prior_position', '',
+                                    'current_position', s,
+                                    'investor_significance', ''
+                                )
+                            )
+                            FROM unnest(strategic_shifts) AS s
+                        )
+                        WHERE strategic_shifts IS NOT NULL
+                          AND array_length(strategic_shifts, 1) > 0;
+                        """
+                    )
+                    cur.execute("ALTER TABLE call_synthesis DROP COLUMN strategic_shifts;")
+                cur.execute(
+                    "ALTER TABLE call_synthesis RENAME COLUMN strategic_shifts_new TO strategic_shifts;"
+                )
+            cur.execute(
+                "INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;"
+            )
         conn.commit()
-    print("Migration successful — schema is at version 5.")
+    print("Migration successful — schema is at version 7.")
 except Exception as e:
     print(f"Error during migration: {e}")

--- a/ui/data_loaders.py
+++ b/ui/data_loaders.py
@@ -17,6 +17,8 @@ from db.persistence import (
     get_misconceptions_for_ticker,
     get_strategic_shifts_for_ticker,
     get_qa_evasion_for_ticker,
+    get_call_summary_for_ticker,
+    get_speaker_dynamics,
 )
 
 from db.repositories import CallRepository, CompetitorRepository
@@ -121,11 +123,27 @@ def load_qa_evasion(conn_str: str, ticker: str) -> list[tuple[str, int, str]]:
 
 
 @st.cache_data
-def load_strategic_shifts(conn_str: str, ticker: str) -> list[str] | None:
-    """Fetch the strategic shifts list for a transcript."""
+def load_strategic_shifts(conn_str: str, ticker: str) -> list[dict] | None:
+    """Fetch the strategic shifts list for a transcript as structured dicts."""
     if not ticker:
         return None
     return get_strategic_shifts_for_ticker(conn_str, ticker)
+
+
+@st.cache_data
+def load_call_summary(conn_str: str, ticker: str) -> str | None:
+    """Fetch the executive summary paragraph for a transcript."""
+    if not ticker:
+        return None
+    return get_call_summary_for_ticker(conn_str, ticker)
+
+
+@st.cache_data
+def load_speaker_dynamics(conn_str: str, ticker: str) -> list[dict]:
+    """Fetch per-speaker turn and word counts for a transcript."""
+    if not ticker:
+        return []
+    return get_speaker_dynamics(conn_str, ticker)
 
 
 @st.cache_data

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -200,7 +200,10 @@ def _render_feynman_cta(
     suggested: list[str] = []
 
     if strategic_shifts:
-        suggested.extend(strategic_shifts[:2])
+        for shift in strategic_shifts[:2]:
+            topic = shift.get("current_position", "") if isinstance(shift, dict) else str(shift)
+            if topic:
+                suggested.append(topic)
 
     if evasion:
         for analyst_concern, _, _ in evasion:
@@ -256,13 +259,19 @@ def render_metadata_panel(
     speakers: list,
     evasion: list | None = None,
     misconceptions: list | None = None,
-    strategic_shifts: list[str] | None = None,
-    qa_evasion: list[tuple[str, int, str]] | None = None,
+    strategic_shifts: list[dict] | None = None,
+    qa_evasion: list[tuple] | None = None,
+    call_summary: str | None = None,
+    speaker_dynamics: list[dict] | None = None,
 ) -> None:
     """Render the left-column analysis panel as a numbered learning path."""
     st.markdown(f"### 📊 {ticker} — Learning Path")
 
     with st.expander("Step 1 · Overview"):
+        if call_summary:
+            st.markdown(call_summary)
+            st.markdown("---")
+
         if takeaways:
             st.markdown("**Key Takeaways**")
             for t, why in takeaways:
@@ -308,6 +317,26 @@ def render_metadata_panel(
         else:
             st.info("No speaker data available.")
 
+        if speaker_dynamics:
+            st.markdown("---")
+            st.markdown("**Call Dynamics**")
+            # Most active executive: highest total turn count across all sections
+            exec_rows = [r for r in speaker_dynamics if r["role"] == "executive"]
+            if exec_rows:
+                by_exec: dict[str, int] = {}
+                for r in exec_rows:
+                    by_exec[r["speaker"]] = by_exec.get(r["speaker"], 0) + r["turn_count"]
+                top_exec, top_exec_turns = max(by_exec.items(), key=lambda x: x[1])
+                st.markdown(f"Most active executive: **{top_exec}** — {top_exec_turns} turns")
+            # Most active analyst: highest Q&A turn count
+            analyst_qa_rows = [r for r in speaker_dynamics if r["role"] == "analyst" and r["section"] == "qa"]
+            if analyst_qa_rows:
+                top = max(analyst_qa_rows, key=lambda r: r["turn_count"])
+                label = top["speaker"]
+                if top["firm"]:
+                    label += f", {top['firm']}"
+                st.markdown(f"Most active analyst: **{label}** — {top['turn_count']} exchanges in Q&A")
+
     if evasion or qa_evasion:
         with st.expander("Step 3 · Said vs. Avoided"):
             if evasion:
@@ -339,12 +368,19 @@ def render_metadata_panel(
     with st.expander("Step 4 · What Changed"):
         if strategic_shifts:
             for i, shift in enumerate(strategic_shifts):
-                st.markdown(shift)
+                prior = shift.get("prior_position", "") if isinstance(shift, dict) else ""
+                current = shift.get("current_position", str(shift)) if isinstance(shift, dict) else str(shift)
+                significance = shift.get("investor_significance", "") if isinstance(shift, dict) else ""
+                if prior:
+                    st.markdown(f"**Prior:** {prior}")
+                st.markdown(f"**Now:** {current}")
+                if significance:
+                    st.markdown(f"**Why it matters:** {significance}")
                 st.button(
                     "Explain via Feynman",
                     key=f"feynman_shift_{ticker}_{i}",
                     on_click=_handle_feynman_shift_click,
-                    args=(shift,),
+                    args=(current,),
                 )
                 if i < len(strategic_shifts) - 1:
                     st.divider()


### PR DESCRIPTION
## Summary

- **#88** — Speaker dynamics in Step 2: new `get_speaker_dynamics()` query on `spans` + `speakers`; displays most active executive (total turns) and most active analyst (Q&A turns + firm) below the speaker roster.
- **#89** — Executive summary in Step 1: ingestion prompt now generates a 2–3 sentence `call_summary` narrative; stored in `call_synthesis`, rendered at the top of Step 1 before takeaways. Graceful fallback for older transcripts.
- **#90** — Structured strategic shifts: `strategic_shifts` column migrated from `TEXT[]` to `JSONB[]`; prompt outputs `{prior_position, current_position, investor_significance}`; Step 4 renders all three fields; Feynman button and CTA topic suggestions use `current_position`. Old string-format rows normalised on read.

## Schema migrations (v5 → v7)

Also fixes a pre-existing `REQUIRED_SCHEMA_VERSION` discrepancy (was hardcoded at 4, migrate.py was already writing v5).

- **v6** — `ALTER TABLE call_synthesis ADD COLUMN call_summary TEXT`
- **v7** — `strategic_shifts TEXT[] → JSONB[]` via add-column + UPDATE + rename (PostgreSQL forbids subqueries in `ALTER COLUMN TYPE ... USING`)
- `migrate.py` v6→v7 block is idempotent: inspects `information_schema.columns` before each step, safe to re-run after any partial failure
- `get_current_version()` now sorts by `version DESC` instead of `installed_at DESC` to avoid non-determinism when multiple rows share the same timestamp

## Test plan

- [ ] Run `python migrate.py` — should print "schema is at version 7" with no errors
- [ ] Schema warning does not appear in the app after migration
- [ ] Step 2 shows "Call Dynamics" block with most active executive and analyst (when span data exists)
- [ ] Step 1 shows summary paragraph above takeaways for newly ingested transcripts; no gap for old ones
- [ ] Step 4 renders Prior / Now / Why it matters for each shift; "Explain via Feynman" still works
- [ ] Feynman CTA topic buttons draw from `current_position`