### PR TITLE
fix: restore Feynman topic chips and consolidate to right panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ import streamlit as st
 from db.repositories import SchemaRepository
 from ui.data_loaders import load_analyst_view, load_call_summary, load_metadata, load_qa_evasion, load_speaker_dynamics, load_speakers, load_strategic_shifts, load_transcript_spans
 from ui.feynman import render_chat_interface
-from ui.metadata_panel import render_metadata_panel
+from ui.metadata_panel import build_feynman_suggestions, render_metadata_panel
 from ui.sidebar import render_sidebar
 from ui.transcript_browser import render_transcript_browser
 
@@ -90,6 +90,7 @@ strategic_shifts = load_strategic_shifts(CONN_STR, st.session_state.active_ticke
 qa_evasion = load_qa_evasion(CONN_STR, st.session_state.active_ticker)
 call_summary = load_call_summary(CONN_STR, st.session_state.active_ticker)
 speaker_dynamics = load_speaker_dynamics(CONN_STR, st.session_state.active_ticker)
+suggested_topics = build_feynman_suggestions(strategic_shifts, evasion, qa_evasion)
 
 # ------------- Layout -------------
 
@@ -127,8 +128,7 @@ with right_col:
         conn_str=CONN_STR,
         ticker=st.session_state.active_ticker,
         chat_mode=chat_mode,
-        themes=themes,
-        takeaways=takeaways,
+        suggested_topics=suggested_topics,
         financial_terms=financial_terms,
         industry_terms=industry_terms,
         on_reset=_reset_chat,

--- a/docs/learning-path-redesign.md
+++ b/docs/learning-path-redesign.md
@@ -1,0 +1,239 @@
+# Learning Path Redesign — Spike #48
+
+*Audit and redesign of the 7-step learning path structure.*
+
+---
+
+## 1. Current State Audit
+
+The current 7 steps in `ui/metadata_panel.py` (with implementation issues noted):
+
+| Step | Label | Contents | Problems |
+|------|-------|----------|----------|
+| 1 | Overview | Key Takeaways + Extracted Themes | No narrative summary; takeaways and themes unlabelled as distinct |
+| 2 | Tone & Speakers | Sentiment + Speaker roster | Speaker data is list-only; no dynamics (who dominated? who asked tough Qs?) |
+| 3a | What management avoided | Non-Q&A evasion | **Duplicate "Step 3" label** with 3b |
+| 3b | Learning Opportunities | Misconceptions/corrections | **Duplicate "Step 3" label** with 3a; no interactivity |
+| 4 | Recent News | News articles (async fetch) | Educational framing is optional ("Explain relevance" is buried) |
+| 5 | Competitors | Competitor list (async fetch) | Surface-level; no pedagogical structure |
+| 6 | Strategic Shifts | Shift descriptions | No before/after framing; no "why it matters for investors" |
+| 7 | Q&A Evasion Review | Q&A evasion analysis | **Conceptually redundant with Step 3a** — same concept, split by source |
+| — | Advanced (hidden) | Financial + Industry Jargon | Gated behind a checkbox; treated as advanced when it's foundational |
+| — | Feynman Loop | 5-stage Socratic loop | **Entirely disconnected** from the numbered steps; feels like a separate product |
+
+**Root problems:**
+- The step structure evolved feature-by-feature, not from a learning design perspective
+- Evasion analysis is split across two steps (3a and 7) for implementation reasons the learner doesn't care about
+- The Feynman Loop — the app's most valuable pedagogical tool — has no connection to the steps that precede it
+- Vocabulary (jargon) is hidden as "advanced" when it's actually foundational to comprehension
+- There is no "done" state; learners don't know when they've finished a transcript
+
+---
+
+## 2. Proposed New Step Structure
+
+### Design principles
+
+1. **Narrative first** — Start with what happened, before drilling into how and why
+2. **Read before test** — All passive analysis steps come before the Feynman Loop
+3. **One concept per step** — No duplicate labels; no split implementations of the same idea
+4. **Feynman as culmination** — The loop is the payoff after completing the reading steps, not a parallel track
+5. **Vocabulary is foundational** — Jargon review is a named step, not an advanced toggle
+
+---
+
+### Step 1 · The Story
+
+**What it contains:**
+- A 1-paragraph executive summary of the call (new — currently missing)
+- Key Takeaways (with "why it matters" explanation)
+- Extracted Themes
+
+**Rationale:** Learners need a hook before they engage with detail. Without knowing "Apple beat on revenue but guided conservatively on China" they have no frame for reading anything else. The executive summary is the most important missing piece in the current UI.
+
+**What changed from current:** Adds the summary (new content). Keeps takeaways and themes but clearly labels them as distinct things. Renamed from "Overview" to "The Story."
+
+---
+
+### Step 2 · Who Was In The Room
+
+**What it contains:**
+- Speaker roster: executives with titles, analysts with firms
+- Sentiment analysis: overall, executive tone, analyst sentiment
+- Speaker dynamics: who spoke most, which analysts asked the most probing questions (enriched — see data model section)
+
+**Rationale:** Understanding who is on a call changes how you hear it. Knowing the CFO was unusually defensive vs. the CEO sounded confident is context that shapes interpretation of everything that follows.
+
+**What changed from current:** Renamed from "Tone & Speakers." Reorders sentiment before speaker list (sentiment is the conclusion; speaker list is context). Adds speaker dynamics (requires ingestion pipeline change).
+
+---
+
+### Step 3 · What Was Said vs. Avoided
+
+**What it contains:**
+- All evasion analysis in one place: both scripted-remarks evasion (current Step 3a) and Q&A evasion (current Step 7)
+- Organized by topic/theme, not by source (prepared vs Q&A)
+- Each item shows: what the analyst/topic probed, how management responded, defensiveness score, what a transparent answer would have looked like
+
+**Rationale:** From a learning perspective, evasion is evasion. The distinction between "management avoided X in their prepared remarks" and "management avoided X when asked directly" is interesting colour but not a reason to split these into two UI sections. Merging them gives the learner a coherent picture of what management was reluctant to discuss.
+
+**What changed from current:** Merges Step 3a (non-Q&A evasion) and Step 7 (Q&A Evasion Review) into one step. **Step 7 is removed.**
+
+**Note on misconceptions (current Step 3b):** Learning Opportunities (misconceptions/corrections) is conceptually different from evasion — it's about the learner's likely misunderstandings, not management behaviour. It belongs in the Feynman prep section as a "common traps to avoid" block, surfaced just before the learner starts a Feynman loop. It is not an independent step.
+
+---
+
+### Step 4 · What Changed
+
+**What it contains:**
+- Strategic shifts from prior calls
+- Before/after framing: "Previously management said X; now they said Y"
+- Investor significance: why does this shift matter?
+- "Explain via Feynman" button (keep existing — this is a good connection)
+
+**Rationale:** Strategic shifts are higher-signal than news or competitors — they tell you something changed in the company's story. They belong closer to the overview, before external context. The current placement (Step 6, after competitors) buries the most strategically important content.
+
+**What changed from current:** Moved from Step 6 to Step 4. Renamed from "Strategic Shifts" to "What Changed." Adds before/after framing and investor significance (requires ingestion pipeline change).
+
+---
+
+### Step 5 · The Bigger Picture
+
+**What it contains:**
+- Recent news (around the call date, ranked by theme relevance)
+- Competitive landscape
+- Both sections load asynchronously in parallel (keep existing background thread pattern)
+
+**Rationale:** News and competitors are both external context — they answer "what was happening around this call?" Neither requires a separate numbered step. Merging them into one "external context" step reduces the step count without losing content.
+
+**What changed from current:** Merges Step 4 (Recent News) and Step 5 (Competitors) into one step. Uses tabs or sub-sections within the expander.
+
+---
+
+### Step 6 · Language Lab
+
+**What it contains:**
+- Financial jargon (term, definition, "Explain in context" button)
+- Industry jargon (term, definition, "Explain in context" button)
+- Top TF-IDF keywords
+- Common misconceptions about this transcript's content (moved here from Step 3b)
+
+**Rationale:** Vocabulary is not an advanced feature — it is foundational. A learner who doesn't understand "gross margin expansion," "NWC," or "TAM" cannot engage meaningfully with the Feynman Loop. Removing the `show_advanced_analysis` checkbox and making this a first-class step is one of the highest-value changes in this redesign.
+
+**What changed from current:** Promoted from behind the `show_advanced_analysis` toggle to a named step. Added misconceptions (from current Step 3b). Renamed from "Financial/Industry Jargon" to "Language Lab."
+
+---
+
+### → Feynman Loop (Culmination)
+
+**What it is:** Not a numbered step — the natural endpoint of the learning path.
+
+**What changes:**
+- At the bottom of Step 6, add a "You're ready to teach this" CTA panel that links directly to the chat pane and auto-suggests the most important topics
+- Topic suggestions are prioritised: strategic shifts and evasion topics are surfaced first (they are the most educationally rich)
+- Common misconceptions (from Step 6) are surfaced as "watch out for these traps" context before the learner starts
+- The connection between the left panel and the chat pane is made explicit
+
+**Rationale:** The Feynman Loop is pedagogically the most valuable part of the app. It should feel like the reward for completing the reading steps, not a separate mode you discover in the sidebar.
+
+---
+
+## 3. Step Mapping
+
+| Current | New | Action |
+|---------|-----|--------|
+| Step 1 · Overview (Takeaways + Themes) | Step 1 · The Story | Add executive summary; keep content |
+| Step 2 · Tone & Speakers | Step 2 · Who Was In The Room | Rename; add speaker dynamics |
+| Step 3a · What Management Avoided (evasion) | Step 3 · What Was Said vs. Avoided | Merge with Step 7 |
+| Step 3b · Learning Opportunities (misconceptions) | Step 6 · Language Lab (sub-section) | Move; not a standalone step |
+| Step 4 · Recent News | Step 5 · The Bigger Picture (tab) | Merge with Step 5 |
+| Step 5 · Competitors | Step 5 · The Bigger Picture (tab) | Merge with Step 4 |
+| Step 6 · Strategic Shifts | Step 4 · What Changed | Reorder; enrich with before/after |
+| Step 7 · Q&A Evasion Review | Step 3 · What Was Said vs. Avoided | Merge with Step 3a; step removed |
+| Advanced: Financial Jargon | Step 6 · Language Lab | Promote from hidden |
+| Advanced: Industry Jargon | Step 6 · Language Lab | Promote from hidden |
+| Feynman Loop (separate pane) | Culmination after Step 6 | Add CTA; connect to left panel |
+
+**Net change:** 7 steps → 6 steps. Step 7 is eliminated. Advanced jargon is promoted to a named step. Feynman Loop gains an explicit connection to the reading path.
+
+---
+
+## 4. Implementation Issues
+
+These flow from the new structure and can be filed as individual issues.
+
+### UI refactoring (no pipeline changes)
+
+- **#A** Fix duplicate Step 3 label — quick win, should have been done already
+- **#B** Rename "General Q&A" → "Ask the Transcript" in sidebar
+- **#C** Remove token counts from learner-facing chat messages
+- **#D** Merge Step 3a (evasion) and Step 7 (Q&A evasion) into a single expander in `metadata_panel.py`
+- **#E** Merge Step 4 (Recent News) and Step 5 (Competitors) into one "The Bigger Picture" expander with tabs/sub-sections
+- **#F** Reorder: move Strategic Shifts from position 6 to position 4
+- **#G** Promote Language Lab: remove `show_advanced_analysis` checkbox; make it Step 6
+- **#H** Move misconceptions from Step 3b into the Language Lab section
+- **#I** Add "You're ready to teach this" CTA panel at the bottom of the left column that links to the Feynman Loop and surfaces prioritised topic suggestions
+
+### Ingestion pipeline changes (new LLM calls)
+
+- **#J** Generate executive summary during ingestion — 1 paragraph, stored in DB. Haiku is sufficient. Surface in Step 1.
+- **#K** Enrich Strategic Shifts with before/after framing — modify the strategic shifts extraction prompt to output `{prior_position, current_position, investor_significance}` instead of a plain text description. Requires DB schema change.
+- **#L** Speaker dynamics — count speaking turns per speaker and identify which analysts asked the most questions. Can be computed from the `spans` table at query time (no new LLM call needed).
+
+### Data model changes
+
+- **`call_synthesis` table:** Add `call_summary TEXT` column for the executive summary (Issue #J)
+- **`call_synthesis.strategic_shifts` column:** Currently `TEXT[]` (flat strings). Change to `JSONB[]` to store `{prior, current, significance}` objects, or add a separate `strategic_shifts` table. (Issue #K)
+- **No other schema changes required** — evasion merge (#D), step reordering (#F), language lab promotion (#G) are all UI-only changes
+
+### "Done with a transcript" definition
+
+A learner is **done** when they have:
+1. Read steps 1–6 (tracked by which expanders they've opened — Streamlit session state)
+2. Completed at least one Feynman loop on a topic from this transcript
+
+Neither of these is currently tracked. Issue #M: add per-transcript completion tracking (session state + optional DB persistence in `learning_sessions`).
+
+---
+
+## 5. Questions Answered
+
+**What is the ideal learning sequence for a first-time user?**
+
+Story → Voices → Tensions (evasion) → Changes → Context → Vocabulary → Teach it back (Feynman)
+
+**Which current steps should be merged, split, reordered, or removed?**
+- **Merge:** Steps 3a + 7 (evasion) → new Step 3; Steps 4 + 5 (external context) → new Step 5
+- **Reorder:** Step 6 (Strategic Shifts) moves to Step 4
+- **Remove:** Step 7 (absorbed into Step 3)
+- **Promote:** Advanced jargon becomes Step 6
+- **Add:** Executive summary in Step 1; before/after framing in Step 4
+
+**Are there concepts that deserve a step but currently don't?**
+- Executive summary (narrative hook) — **yes, missing from Step 1**
+- Vocabulary as a foundational step — **exists but hidden**
+- Speaker dynamics — **exists as data, not rendered usefully**
+
+**How should the Feynman Loop relate to the steps?**
+- It is the **culmination**, not a parallel track
+- Steps 1–6 are the reading phase; the Feynman Loop is the testing phase
+- The left panel should end with an explicit handoff to the chat pane
+
+**What does "done with a transcript" mean?**
+- Read all 6 steps (at least opened each expander)
+- Completed ≥ 1 Feynman loop on a topic from the transcript
+- Currently undefined in the app — needs explicit tracking
+
+---
+
+## 6. Summary of New Structure
+
+```
+Step 1 · The Story           ← was: Overview + NEW executive summary
+Step 2 · Who Was In The Room ← was: Tone & Speakers
+Step 3 · Said vs. Avoided    ← MERGE: Step 3a + Step 7 (evasion)
+Step 4 · What Changed        ← was: Step 6 (Strategic Shifts), moved earlier
+Step 5 · The Bigger Picture  ← MERGE: Step 4 (News) + Step 5 (Competitors)
+Step 6 · Language Lab        ← was: hidden Advanced section, PROMOTED
+→ Feynman Loop               ← culmination CTA, no longer disconnected
+```

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -196,12 +196,22 @@ class IngestionPipeline:
         chunks = create_chunks_from_analysis(analysis)
         prep_count = sum(1 for c in chunks if c.chunk_type == 'prepared')
         qa_count = sum(1 for c in chunks if c.chunk_type == 'qa')
+        prepared_span_count = sum(1 for s in analysis.spans if s.section == 'prepared')
+        print(f"  ↳ Spans: {len(analysis.spans)} total ({prepared_span_count} prepared), QA pairs: {len(analysis.qa_pairs)}")
         logger.info(f"Created {len(chunks)} chunks ({prep_count} prep, {qa_count} qa)")
         print(f"\n🚀 Starting Agentic LLM Ingestion Pipeline ({len(chunks)} chunks)...")
-        
+
+        if not chunks:
+            logger.warning("No chunks created from analysis — skipping LLM extraction")
+            print("⚠️  No chunks created — transcript may have no prepared remarks and no Q&A pairs. Skipping agentic extraction.")
+            return [], CallSynthesisRecord(
+                overall_sentiment="", executive_tone="", key_themes=[],
+                strategic_shifts=[], analyst_sentiment="",
+            ), TokenUsageSummary()
+
         # Phase 2: Map Phase (Concurrent Extraction)
         # Process chunks in parallel using a ThreadPoolExecutor
-        max_workers = min(10, len(chunks)) # Don't spin up more threads than we have chunks
+        max_workers = max(1, min(10, len(chunks)))
         print(f"\n[Map Phase] Running extraction on {len(chunks)} chunks with {max_workers} concurrent workers...")
         
         all_chunk_usage: list[dict] = []

--- a/services/llm.py
+++ b/services/llm.py
@@ -236,7 +236,7 @@ class AgenticExtractor:
         self.rate_limiter.wait()
         message = self.client.messages.create(
             model=self.tier3_model,
-            max_tokens=1024,
+            max_tokens=4096,
             system=TIER_3_SYNTHESIS_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -244,6 +244,7 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
         analysis.synthesis = synthesis
         analysis.token_usage = token_usage
     except Exception as e:
+        print(f"❌ Agentic pipeline failed: {e}")
         logger.warning(f"Agentic pipeline failed or skipped: {e}")
 
     return analysis

--- a/ui/feynman.py
+++ b/ui/feynman.py
@@ -60,8 +60,7 @@ def render_chat_interface(
     conn_str: str,
     ticker: str,
     chat_mode: str,
-    themes: list,
-    takeaways: list,
+    suggested_topics: list[str],
     financial_terms: list,
     industry_terms: list,
     on_reset=None,
@@ -92,7 +91,7 @@ def render_chat_interface(
     if chat_mode == "Feynman Loop" and not st.session_state.feynman_topic:
         from db.repositories import LearningRepository
         past_sessions = LearningRepository(conn_str).get_sessions_for_ticker(ticker)
-        _render_topic_picker(themes, takeaways, past_sessions=past_sessions)
+        _render_topic_picker(suggested_topics=suggested_topics, past_sessions=past_sessions)
         return
 
     if chat_mode == "Feynman Loop":
@@ -108,7 +107,7 @@ def render_chat_interface(
 # Topic picker (shown before Feynman loop starts)
 # ---------------------------------------------------------------------------
 
-def _render_topic_picker(themes: list, takeaways: list, past_sessions: list[dict] | None = None) -> None:
+def _render_topic_picker(suggested_topics: list[str] | None = None, past_sessions: list[dict] | None = None) -> None:
     """Show the Feynman topic selection UI."""
     st.markdown("#### 🧠 Feynman Loop")
     st.caption("Choose a topic. The AI will guide you to explain it back, expose gaps, and deepen your understanding.")
@@ -155,17 +154,10 @@ def _render_topic_picker(themes: list, takeaways: list, past_sessions: list[dict
                                 st.rerun()
             st.markdown("---")
 
-    suggestions: list[str] = []
-    for t in themes[:3]:
-        suggestions.append(t)
-    for t, _ in takeaways[:2]:
-        if len(suggestions) < 5 and t not in suggestions:
-            suggestions.append(t)
-
-    if suggestions:
-        st.markdown("**Practice Topics**")
-        num_cols = min(3, len(suggestions))
-        rows = [suggestions[i:i + num_cols] for i in range(0, len(suggestions), num_cols)]
+    if suggested_topics:
+        st.markdown("**Suggested topics:**")
+        num_cols = min(3, len(suggested_topics))
+        rows = [suggested_topics[i:i + num_cols] for i in range(0, len(suggested_topics), num_cols)]
         for row in rows:
             chip_cols = st.columns(num_cols)
             for col, suggestion in zip(chip_cols, row):
@@ -174,8 +166,8 @@ def _render_topic_picker(themes: list, takeaways: list, past_sessions: list[dict
                     st.session_state.feynman_session_id = str(uuid.uuid4())
                     st.session_state.feynman_topic = suggestion
                     st.rerun()
+        st.markdown("---")
 
-    st.markdown("---")
     st.markdown("**Or enter your own topic:**")
     custom_topic = st.text_input(
         "Topic",

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -184,19 +184,13 @@ def _handle_feynman_shift_click(shift_text: str) -> None:
     st.session_state.feynman_topic = shift_text
 
 
-def _handle_feynman_topic_click(topic: str) -> None:
-    """Set feynman_topic and switch to Feynman Loop mode when a CTA button is clicked."""
-    st.session_state.feynman_topic = topic
-    st.session_state.chat_mode = "Feynman Loop"
-
-
-def _render_feynman_cta(
-    ticker: str,
-    strategic_shifts: list[str] | None,
+def build_feynman_suggestions(
+    strategic_shifts: list[dict] | None,
     evasion: list | None,
     qa_evasion: list | None,
-) -> None:
-    """Render the 'You're ready to teach this' CTA at the bottom of the learning path."""
+    max_suggestions: int = 3,
+) -> list[str]:
+    """Build an ordered list of suggested Feynman topics from the richest available sources."""
     suggested: list[str] = []
 
     if strategic_shifts:
@@ -207,44 +201,21 @@ def _render_feynman_cta(
 
     if evasion:
         for analyst_concern, _, _ in evasion:
-            if len(suggested) >= 3:
+            if len(suggested) >= max_suggestions:
                 break
             if analyst_concern not in suggested:
                 suggested.append(analyst_concern)
 
     if qa_evasion:
         for _, question_topic, _, _, concern, _, _ in qa_evasion:
-            if len(suggested) >= 3:
+            if len(suggested) >= max_suggestions:
                 break
             topic = question_topic or concern
             if topic and topic not in suggested:
                 suggested.append(topic)
 
-    if not suggested:
-        return
+    return suggested
 
-    st.divider()
-    st.markdown("### 🧠 Ready to test your understanding?")
-    st.caption("Suggested topics to teach:")
-
-    cols = st.columns(len(suggested))
-    for i, (col, topic) in enumerate(zip(cols, suggested)):
-        with col:
-            label = topic[:50] + "…" if len(topic) > 50 else topic
-            st.button(
-                label,
-                key=f"cta_topic_{ticker}_{i}",
-                on_click=_handle_feynman_topic_click,
-                args=(topic,),
-                use_container_width=True,
-            )
-
-    st.button(
-        "Start the Feynman Loop with your own topic →",
-        key=f"cta_start_loop_{ticker}",
-        on_click=_handle_feynman_topic_click,
-        args=("",),
-    )
 
 
 def render_metadata_panel(
@@ -420,7 +391,6 @@ def render_metadata_panel(
             st.markdown("**Top Keywords (TF-IDF):**")
             st.markdown(", ".join([f"`{k}`" for k in keywords[:15]]))
 
-    _render_feynman_cta(ticker, strategic_shifts, evasion, qa_evasion)
 
 
 def _render_term_list(conn_str: str, ticker: str, terms: list, key_prefix: str) -> None:

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -31,6 +31,11 @@ def render_sidebar(conn_str: str, on_ticker_change) -> tuple[str, str]:
             ),
         )
 
+        st.markdown("---")
+        if st.button("🔄 Reload data", help="Clear cached data and reload from the database. Use this after re-ingesting a transcript."):
+            st.cache_data.clear()
+            st.rerun()
+
         learning_repo = LearningRepository(conn_str)
         stats = learning_repo.get_learning_stats()
         if stats["total_sessions"] > 0:


### PR DESCRIPTION
## Summary
- **Root cause fix**: `extract_synthesis` had `max_tokens=1024` — too low after `call_summary` was added to the prompt. Synthesis JSON was truncated mid-response, silently leaving `strategic_shifts` and evasion data unsaved. Raised to 4096.
- **Pipeline resilience**: Guard against 0-chunk transcripts (`max_workers=0` caused a silent `ValueError`); agentic pipeline failures now print to stdout.
- **UX**: Add "🔄 Reload data" button to sidebar so re-ingestion changes are visible without restarting the Streamlit server.
- **Suggested topics consolidation**: Extracted `build_feynman_suggestions()` so both panels draw from the same ranked source (strategic shifts → evasion → Q&A evasion). Removed the duplicate CTA from the left learning-path panel; topic chips now live only in the right-panel Feynman topic picker.

## Test plan
- [ ] Re-ingest a ticker and confirm `call_synthesis`, `transcript_chunks`, and `evasion_analysis` rows are populated
- [ ] Confirm suggested topic chips appear in the right-panel Feynman topic picker
- [ ] Confirm no duplicate topic chips in the left learning-path panel
- [ ] Confirm "Reload data" button clears cache and reflects freshly ingested data
- [ ] Confirm "Explain via Feynman" buttons on Step 4 strategic shifts still work