### PR TITLE
feat: smarter Feynman loop — orientation, prioritization, grounding, synthesis (#97)

### DIFF
--- a/app.py
+++ b/app.py
@@ -40,6 +40,12 @@ if "feynman_topic" not in st.session_state:
 if "feynman_session_id" not in st.session_state:
     st.session_state.feynman_session_id = ""
 
+if "feynman_is_synthesis" not in st.session_state:
+    st.session_state.feynman_is_synthesis = False
+
+if "feynman_synthesis_notes" not in st.session_state:
+    st.session_state.feynman_synthesis_notes = []
+
 if "confirm_reset" not in st.session_state:
     st.session_state.confirm_reset = False
 
@@ -73,6 +79,8 @@ def _reset_chat() -> None:
     st.session_state.feynman_stage = 1
     st.session_state.feynman_topic = ""
     st.session_state.feynman_session_id = ""
+    st.session_state.feynman_is_synthesis = False
+    st.session_state.feynman_synthesis_notes = []
 
 
 selected_ticker, chat_mode = render_sidebar(CONN_STR, on_ticker_change=_reset_chat)

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -990,6 +990,7 @@ class LearningRepository:
         stage: int,
         messages: list[dict],
         completed: bool,
+        session_type: str = "feynman",
     ) -> bool:
         """Upsert a learning session. Stores full message history in notes as JSON. Returns True on success."""
         import json
@@ -1000,7 +1001,7 @@ class LearningRepository:
                     if not call_id:
                         logger.warning(f"No call found for ticker {ticker}, skipping session save")
                         return False
-                    notes = json.dumps({"topic": topic, "stage": stage, "messages": messages})
+                    notes = json.dumps({"topic": topic, "stage": stage, "messages": messages, "type": session_type})
                     completed_at_expr = "now()" if completed else "NULL"
                     cur.execute(
                         f"""
@@ -1062,6 +1063,7 @@ class LearningRepository:
                             "completed": completed_at is not None,
                             "teaching_note": teaching_note,
                             "started_at": started_at,
+                            "session_type": notes.get("type", "feynman"),
                         })
         except Exception as e:
             logger.warning(f"Could not fetch sessions for ticker {ticker}: {e}")

--- a/prompts/feynman/01_initial_explanation.md
+++ b/prompts/feynman/01_initial_explanation.md
@@ -14,7 +14,12 @@ The company whose transcript is being studied will be noted in the user's messag
 3. Keep your response concise. DO NOT jump ahead to asking test questions yet. Allow the user to absorb the analogy first.
 4. Maintain an encouraging, curious tone.
 5. End your response with a clear, friendly call to action — ask the user to try explaining the concept back to you in their own words. Make it feel low-stakes (e.g. "Don't worry about getting it perfect — just give it a go!").
+6. Anchor your explanation in the transcript. After your opening analogy, include 1–2 specific moments from the transcript (from the <transcript_context> provided) where this concept appeared. Quote or closely paraphrase what was said and explain how it illustrates the concept. Format these as: "In the call, [speaker/role] said: '[brief quote or paraphrase]' — that's this concept in action."
 </Instructions>
+
+<TranscriptGrounding>
+Transcript excerpts relevant to this topic are provided in <transcript_context> tags appended to the user message. You MUST use at least one of these excerpts to ground your explanation in the actual call. If the context contains a direct quote, use it. If the context is a paraphrase or summary, say "In the call, [role] noted that…". Do not fabricate quotes. If no relevant excerpt is available, skip this step and focus on the analogy.
+</TranscriptGrounding>
 
 <AnalogyGuidance>
 Choose an analogy domain that fits the nature of the concept and the company's industry. Actively vary across sessions — do not default to the same scenario repeatedly.

--- a/prompts/feynman/synthesis.md
+++ b/prompts/feynman/synthesis.md
@@ -1,0 +1,18 @@
+<System>
+You are a Socratic learning guide helping a student synthesize their understanding across multiple topics they have studied from a financial earnings transcript.
+</System>
+
+<Context>
+The student has completed Feynman Loop sessions on two or more topics from the same transcript. Their teaching notes for each topic are provided in the <StudiedTopics> section. Your role is to help them see how these topics connect, reinforce each other, and form a coherent picture of the company's situation.
+</Context>
+
+<Instructions>
+1. Open by briefly naming the topics the student studied and acknowledging their work.
+2. Identify 2–3 meaningful connections between the topics (e.g., one topic explains the cause, another shows the effect; two topics are different symptoms of the same underlying pressure; one topic is the company's strategy to address another).
+3. Pose 1–2 open-ended synthesis questions that invite the student to articulate how these pieces fit together. Examples:
+   - "How does [topic A] help explain why [topic B] is happening?"
+   - "If you were an investor reading this transcript, how would these two dynamics change your view of the company's outlook?"
+   - "Can you describe the story these two topics tell together, in two or three sentences?"
+4. Keep your tone encouraging and curious. Treat this as a capstone conversation, not a quiz.
+5. Do NOT ask the student to explain the topics again from scratch — they've already done that. Focus on connections and implications.
+</Instructions>

--- a/ui/feynman.py
+++ b/ui/feynman.py
@@ -36,7 +36,7 @@ _FEYNMAN_PROMPT_FILES = {
 }
 
 
-def _save_feynman_session(conn_str: str, ticker: str, completed: bool) -> None:
+def _save_feynman_session(conn_str: str, ticker: str, completed: bool, session_type: str = "feynman") -> None:
     """Write current Feynman session state to DB. Silently skips if session_id not set."""
     session_id = st.session_state.get("feynman_session_id")
     topic = st.session_state.get("feynman_topic", "")
@@ -53,6 +53,7 @@ def _save_feynman_session(conn_str: str, ticker: str, completed: bool) -> None:
         stage=stage,
         messages=messages,
         completed=completed,
+        session_type=session_type,
     )
 
 
@@ -107,14 +108,27 @@ def render_chat_interface(
 # Topic picker (shown before Feynman loop starts)
 # ---------------------------------------------------------------------------
 
+_STAGE_DESCRIPTIONS = {
+    1: "The AI explains the topic simply, using an everyday analogy anchored in the transcript.",
+    2: "You explain it back in your own words. The AI identifies gaps and asks targeted questions.",
+    3: "Refine your understanding through back-and-forth dialogue. Advance when you feel confident.",
+    4: "Apply the concept to a new scenario the AI gives you.",
+    5: "Receive a concise teaching note — a summary you can keep.",
+}
+
+
 def _render_topic_picker(suggested_topics: list[str] | None = None, past_sessions: list[dict] | None = None) -> None:
     """Show the Feynman topic selection UI."""
     st.markdown("#### 🧠 Feynman Loop")
     st.caption("Choose a topic. The AI will guide you to explain it back, expose gaps, and deepen your understanding.")
 
+    with st.expander("How does the Feynman Loop work?", expanded=False):
+        for stage_num, stage_name in _STAGE_NAMES.items():
+            st.markdown(f"**Stage {stage_num} — {stage_name}:** {_STAGE_DESCRIPTIONS[stage_num]}")
+
     if past_sessions:
-        in_progress = [s for s in past_sessions if not s["completed"]]
-        completed = [s for s in past_sessions if s["completed"]]
+        in_progress = [s for s in past_sessions if not s["completed"] and s.get("session_type", "feynman") == "feynman"]
+        completed = [s for s in past_sessions if s["completed"] and s.get("session_type", "feynman") == "feynman"]
 
         if in_progress or completed:
             with st.expander("📚 Previous Sessions", expanded=True):
@@ -154,15 +168,42 @@ def _render_topic_picker(suggested_topics: list[str] | None = None, past_session
                                 st.rerun()
             st.markdown("---")
 
+        # Synthesis: offer when 2+ sessions completed (#74)
+        if len(completed) >= 2:
+            synthesis_notes = [
+                {"topic": s["topic"], "teaching_note": s.get("teaching_note")}
+                for s in completed
+            ]
+            synthesis_label = " + ".join(s["topic"][:30] for s in completed[:3])
+            if len(completed) > 3:
+                synthesis_label += f" + {len(completed) - 3} more"
+            st.markdown("**Connect the dots:**")
+            if st.button(
+                f"🔗 Synthesize what you've learned — {synthesis_label}",
+                use_container_width=True,
+                help="Pull together your learning across completed sessions",
+            ):
+                st.session_state.feynman_session_id = str(uuid.uuid4())
+                st.session_state.feynman_topic = f"Synthesis: {synthesis_label}"
+                st.session_state.feynman_is_synthesis = True
+                st.session_state.feynman_synthesis_notes = synthesis_notes
+                st.rerun()
+            st.markdown("---")
+
     if suggested_topics:
         st.markdown("**Suggested topics:**")
         num_cols = min(3, len(suggested_topics))
         rows = [suggested_topics[i:i + num_cols] for i in range(0, len(suggested_topics), num_cols)]
+        topic_index = 0
         for row in rows:
             chip_cols = st.columns(num_cols)
             for col, suggestion in zip(chip_cols, row):
                 label = suggestion if len(suggestion) <= 55 else suggestion[:52] + "…"
-                if col.button(label, use_container_width=True):
+                is_recommended = topic_index == 0
+                button_label = f"⭐ {label}" if is_recommended else label
+                button_help = "Recommended starting point" if is_recommended else None
+                topic_index += 1
+                if col.button(button_label, use_container_width=True, help=button_help):
                     st.session_state.feynman_session_id = str(uuid.uuid4())
                     st.session_state.feynman_topic = suggestion
                     st.rerun()
@@ -214,6 +255,12 @@ def _render_stage_header(ticker: str) -> None:
     topic_label = st.session_state.feynman_topic
     if len(topic_label) > 50:
         topic_label = topic_label[:47] + "…"
+    is_synthesis = st.session_state.get("feynman_is_synthesis", False)
+
+    if is_synthesis:
+        st.caption(f"🔗 **Synthesis Session** · *{topic_label}*")
+        st.info("💡 Reflect on how your studied topics connect. The AI will help you see the big picture.")
+        return
 
     st.caption(
         f"🧠 **Feynman Loop** · Topic: *{topic_label}* · "
@@ -236,6 +283,8 @@ def _render_stage_header(ticker: str) -> None:
                     st.session_state.feynman_topic = ""
                     st.session_state.feynman_stage = 1
                     st.session_state.messages = []
+                    st.session_state.feynman_is_synthesis = False
+                    st.session_state.feynman_synthesis_notes = []
                     st.rerun()
             with export_col:
                 topic = st.session_state.feynman_topic
@@ -306,6 +355,8 @@ def _render_stage_advance_buttons(chat_mode: str) -> None:
 def _handle_auto_fire_stage5(chat_mode: str) -> None:
     """Inject the stage 5 trigger if it's missing (fallback for page refresh)."""
     if chat_mode != "Feynman Loop" or st.session_state.feynman_stage != 5:
+        return
+    if st.session_state.get("feynman_is_synthesis", False):
         return
 
     last_assistant = next(
@@ -393,8 +444,10 @@ def _render_chat_input(
             response_placeholder=response_placeholder,
         )
 
-    # Auto-advance stages 1 & 2
-    if chat_mode == "Feynman Loop" and full_response:
+    is_synthesis = st.session_state.get("feynman_is_synthesis", False)
+
+    # Auto-advance stages 1 & 2 (not for synthesis sessions)
+    if chat_mode == "Feynman Loop" and full_response and not is_synthesis:
         stage = st.session_state.feynman_stage
         if stage in (1, 2):
             st.session_state.feynman_stage += 1
@@ -412,10 +465,14 @@ def _render_chat_input(
             "display": True,
             "feynman_stage": st.session_state.feynman_stage,
         })
-        if chat_mode == "Feynman Loop" and st.session_state.feynman_stage == 5:
-            last_appended = st.session_state.messages[-1]
-            if last_appended.get("feynman_stage") == 5:
-                _save_feynman_session(conn_str, ticker, completed=True)
+        if chat_mode == "Feynman Loop":
+            if is_synthesis and len(st.session_state.messages) <= 2:
+                # Save synthesis session after first exchange
+                _save_feynman_session(conn_str, ticker, completed=True, session_type="synthesis")
+            elif not is_synthesis and st.session_state.feynman_stage == 5:
+                last_appended = st.session_state.messages[-1]
+                if last_appended.get("feynman_stage") == 5:
+                    _save_feynman_session(conn_str, ticker, completed=True)
         st.rerun()
 
 
@@ -447,6 +504,8 @@ def _stream_response(
     """Build the API message list, call the LLM, and stream the response."""
     stage = st.session_state.feynman_stage
 
+    is_synthesis = st.session_state.get("feynman_is_synthesis", False)
+
     if chat_mode == "Ask the Transcript":
         sys_prompt = _load_prompt_file("feynman/00_general_qa.md")
         # Inject jargon when explicitly requested
@@ -456,6 +515,15 @@ def _stream_response(
                 context_spans = list(context_spans) + [
                     "Extracted Jargon:\n" + "\n".join([f"- {t}: {d}" for t, d, _ in all_terms])
                 ]
+    elif is_synthesis:
+        sys_prompt = _load_prompt_file("feynman/synthesis.md")
+        synthesis_notes = st.session_state.get("feynman_synthesis_notes", [])
+        if synthesis_notes:
+            notes_str = "\n".join(
+                f"- **{n['topic']}**: {n['teaching_note'] or 'No teaching note saved.'}"
+                for n in synthesis_notes
+            )
+            sys_prompt += f"\n\n<StudiedTopics>\n{notes_str}\n</StudiedTopics>"
     else:
         sys_prompt = _load_prompt_file(_FEYNMAN_PROMPT_FILES[stage])
         if stage == 1 and ticker:


### PR DESCRIPTION
## Summary

Implements all four issues in Slice 2 of issue #97, following the suggested sequencing.

**#64 — Stage orientation**
- Added a collapsible "How does the Feynman Loop work?" expander on the topic picker
- Shows all 5 stages with a one-line description of what to expect at each step
- Dismissible, so returning users are not forced to read it every time

**#69 — Topic prioritization**
- First suggested topic chip is now marked with a star and a "Recommended starting point" tooltip
- Topic ordering was already priority-ranked (strategic shifts > evasion > Q&A); now the recommendation is visible to the learner

**#73 — Transcript grounding (highest-impact)**
- Updated Stage 1 prompt to require 1-2 specific transcript moments in the explanation
- AI is instructed to quote or closely paraphrase the speaker and explain how it illustrates the concept
- Uses the existing RAG context already injected via transcript_context tags — no new infra needed

**#74 — Synthesis**
- After 2+ completed Feynman sessions, the topic picker shows a "Synthesize what you've learned" button
- New `prompts/feynman/synthesis.md` guides the AI to surface connections between studied topics
- Synthesis sessions bypass the 5-stage loop, display a distinct header, and are saved with `type=synthesis` in the notes JSON
- `db/repositories.py` updated to store and return `session_type` from notes
- Synthesis state keys initialized in `app.py` and cleared on reset and new-cycle

## Test plan

- [ ] Open topic picker: "How does the Feynman Loop work?" expander is present and collapsible
- [ ] Suggested topic chips appear with first chip marked as Recommended
- [ ] Stage 1 explanation references specific moments from the transcript (quotes/paraphrases)
- [ ] Complete 2+ Feynman sessions: "Synthesize what you've learned" button appears
- [ ] Clicking Synthesize starts a session with distinct header and no stage auto-advance
- [ ] Synthesis session saved to DB with type=synthesis marker
- [ ] Reset and "Start a new Feynman cycle" both clear synthesis flags
- [ ] All 56 existing tests pass