### PR TITLE
feat: Slice 1 — Trust & Orient polish

### DIFF
--- a/db/persistence.py
+++ b/db/persistence.py
@@ -9,7 +9,7 @@ def fetch_existing_embeddings(
     repo = EmbeddingRepository(conn_str)
     return repo.fetch_existing_embeddings(ticker, fiscal_quarter)
 
-def get_all_calls(conn_str: str) -> list[tuple[str, str]]:
+def get_all_calls(conn_str: str) -> list[tuple[str, str, str | None, str | None]]:
     repo = CallRepository(conn_str)
     return repo.get_all_calls()
 

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -92,14 +92,15 @@ class CallRepository:
             logger.warning(f"Could not fetch call_date for {ticker}: {e}")
             return None
 
-    def get_all_calls(self) -> list[tuple[str, str]]:
+    def get_all_calls(self) -> list[tuple[str, str, str | None, str | None]]:
+        """Return (ticker, fiscal_quarter, company_name, call_date) for all stored calls."""
         calls = []
         try:
             with psycopg.connect(self.conn_str) as conn:
                 with conn.cursor() as cur:
                     cur.execute(
                         """
-                        SELECT ticker, fiscal_quarter
+                        SELECT ticker, fiscal_quarter, company_name, call_date
                         FROM calls
                         ORDER BY created_at DESC
                         """

--- a/tests/integration/db/test_repositories.py
+++ b/tests/integration/db/test_repositories.py
@@ -24,23 +24,26 @@ def test_get_all_calls(mock_psycopg_connect):
     m_connect, m_cursor = mock_psycopg_connect
     
     # Mock the results of fetchall()
-    m_cursor.fetchall.return_value = [("MSFT", "Q1 2024 MSFT"), ("AAPL", "Q2 2024 AAPL")]
-    
+    m_cursor.fetchall.return_value = [
+        ("MSFT", "Q1 2024 MSFT", "Microsoft Corp", None),
+        ("AAPL", "Q2 2024 AAPL", "Apple Inc", None),
+    ]
+
     repo = CallRepository("fake_connection_string")
     calls = repo.get_all_calls()
-    
+
     # Verify the SQL was executed
     m_cursor.execute.assert_called_once_with(
         """
-                        SELECT ticker, fiscal_quarter
+                        SELECT ticker, fiscal_quarter, company_name, call_date
                         FROM calls
                         ORDER BY created_at DESC
                         """
     )
-    
+
     # Verify the return value
     assert len(calls) == 2
-    assert calls[0] == ("MSFT", "Q1 2024 MSFT")
+    assert calls[0] == ("MSFT", "Q1 2024 MSFT", "Microsoft Corp", None)
 
 
 def test_fetch_existing_embeddings(mock_psycopg_connect, mocker):

--- a/ui/data_loaders.py
+++ b/ui/data_loaders.py
@@ -29,10 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 @st.cache_data
-def load_transcripts(conn_str: str) -> list[str]:
-    """Fetch available transcript tickers from the database."""
+def load_transcripts(conn_str: str) -> list[tuple[str, str, str | None, str | None]]:
+    """Fetch available transcripts from the database as (ticker, fiscal_quarter, company_name, call_date)."""
     calls = get_all_calls(conn_str)
-    return [c[0] for c in calls] if calls else []
+    return [(c[0], c[1], c[2], c[3]) for c in calls] if calls else []
 
 
 @st.cache_data

--- a/ui/metadata_panel.py
+++ b/ui/metadata_panel.py
@@ -218,6 +218,19 @@ def build_feynman_suggestions(
 
 
 
+_AI_BADGE = '<abbr title="This analysis is AI-generated — verify against the transcript">🤖</abbr>'
+
+
+def _defensiveness_label(score: int) -> str:
+    """Convert a numeric defensiveness score to a qualitative label."""
+    if score >= 8:
+        return "High"
+    elif score >= 5:
+        return "Moderate"
+    else:
+        return "Low"
+
+
 def render_metadata_panel(
     conn_str: str,
     ticker: str,
@@ -244,7 +257,8 @@ def render_metadata_panel(
             st.markdown("---")
 
         if takeaways:
-            st.markdown("**Key Takeaways**")
+            st.markdown(f"**Key Takeaways** {_AI_BADGE}", unsafe_allow_html=True)
+            st.caption("The 'so what' — narrative insights and implications from the call.")
             for t, why in takeaways:
                 st.markdown(f"- **{t}**\n  - *{why}*")
         else:
@@ -253,7 +267,8 @@ def render_metadata_panel(
         st.markdown("---")
 
         if themes:
-            st.markdown("**Extracted Themes**")
+            st.markdown(f"**Extracted Themes** {_AI_BADGE}", unsafe_allow_html=True)
+            st.caption("Recurring topics and subject clusters identified across the transcript.")
             for idx, t in enumerate(themes, 1):
                 st.markdown(f"**Theme {idx}:** {t}")
         else:
@@ -262,7 +277,7 @@ def render_metadata_panel(
     with st.expander("Step 2 · Tone & Speakers"):
         if synthesis:
             overall, exec_tone, analyst_sent = synthesis
-            st.markdown("**Sentiment Analysis**")
+            st.markdown(f"**Sentiment Analysis** {_AI_BADGE}", unsafe_allow_html=True)
             st.markdown(f"**Overall Sentiment:** {overall}")
             st.markdown(f"**Executive Tone:** {exec_tone}")
             st.markdown(f"**Analyst Sentiment:** {analyst_sent}")
@@ -311,15 +326,15 @@ def render_metadata_panel(
     if evasion or qa_evasion:
         with st.expander("Step 3 · Said vs. Avoided"):
             if evasion:
-                st.markdown("**📋 Prepared Remarks**")
+                st.markdown(f"**📋 Prepared Remarks** {_AI_BADGE}", unsafe_allow_html=True)
                 for analyst_concern, defensiveness_score, evasion_explanation in evasion:
                     st.markdown(f"**Concern:** {analyst_concern}")
-                    st.markdown(f"*Defensiveness score: {defensiveness_score}/10*")
+                    st.markdown(f"*Defensiveness: {_defensiveness_label(defensiveness_score)}*")
                     st.markdown(f"**Why it was flagged:** {evasion_explanation}")
                     st.divider()
 
             if qa_evasion:
-                st.markdown("**🎤 Q&A Session**")
+                st.markdown(f"**🎤 Q&A Session** {_AI_BADGE}", unsafe_allow_html=True)
                 for i, (analyst_name, question_topic, question_text, answer_text, concern, score, explanation) in enumerate(qa_evasion):
                     badge = "🔴" if score >= 8 else "🟡" if score >= 5 else "🟢"
                     name = analyst_name or "The analyst"
@@ -368,7 +383,7 @@ def render_metadata_panel(
 
     with st.expander("Step 6 · Language Lab"):
         if misconceptions:
-            st.markdown("**Common Misconceptions**")
+            st.markdown(f"**Common Misconceptions** {_AI_BADGE}", unsafe_allow_html=True)
             for fact, misinterpretation, correction in misconceptions:
                 st.markdown(f"*Context: {fact}*")
                 st.markdown(f"**Misconception:** {misinterpretation}")

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -4,20 +4,42 @@ from db.repositories import LearningRepository
 from ui.data_loaders import load_transcripts
 
 
+def _format_call_label(ticker: str, fiscal_quarter: str, company_name: str | None, call_date) -> str:
+    """Format a transcript selector label from available call metadata."""
+    parts = [ticker]
+    if company_name:
+        parts.append(company_name)
+    if fiscal_quarter:
+        parts.append(fiscal_quarter)
+    if call_date:
+        try:
+            parts.append(call_date.strftime("%b %-d, %Y"))
+        except AttributeError:
+            parts.append(str(call_date))
+    return " — ".join(parts)
+
+
 def render_sidebar(conn_str: str, on_ticker_change) -> tuple[str, str]:
     """Render the settings sidebar and return (selected_ticker, chat_mode)."""
     with st.sidebar:
         st.markdown("### 📄 Transcript")
 
-        available_tickers = load_transcripts(conn_str)
+        available_calls = load_transcripts(conn_str)
 
-        if not available_tickers:
+        if not available_calls:
             st.warning("No transcripts found in database. Run `python main.py [TICKER]` first.")
             st.stop()
 
+        tickers = [c[0] for c in available_calls]
+        label_by_ticker = {
+            c[0]: _format_call_label(c[0], c[1], c[2], c[3])
+            for c in available_calls
+        }
+
         selected_ticker = st.selectbox(
             "Select Transcript",
-            available_tickers,
+            tickers,
+            format_func=lambda t: label_by_ticker.get(t, t),
             on_change=on_ticker_change,
         )
 


### PR DESCRIPTION
## Summary

- **#55** — Transcript selector now shows ticker, company name, fiscal quarter, and call date (e.g. `AAPL — Apple Inc. — Q1 FY2025 — Jan 30, 2025`). Degrades gracefully when fields are missing.
- **#57** — Defensiveness scores replaced with qualitative labels (`High` / `Moderate` / `Low`) to avoid false precision from LLM estimates. Color coding (🔴🟡🟢) retained.
- **#58** — AI-generated sections (Key Takeaways, Themes, Sentiment Analysis, Prepared Remarks, Q&A Session, Common Misconceptions) marked with 🤖 emoji. Hovering shows: *"This analysis is AI-generated — verify against the transcript"*. Not applied to transcript-sourced content.
- **#53** — Key Takeaways and Extracted Themes each have a brief caption: takeaways = "narrative insights / so what", themes = "topical clusters across the transcript".

## Test plan

- [ ] Sidebar selector shows full label for ingested transcripts; degrades to ticker-only for records without company name / date
- [ ] Defensiveness display shows "High", "Moderate", or "Low" — no integer scores remain
- [ ] 🤖 badge appears on AI sections; hovering shows tooltip
- [ ] Step 1 shows captions below each section header
- [ ] All 56 tests pass (`pytest`)

Closes #55, #57, #58, #53, #96