### PR TITLE
fix: run migrate.py after setup.sh in reset_db.sh

### DIFF
--- a/reset_db.sh
+++ b/reset_db.sh
@@ -39,6 +39,11 @@ fi
 step "Re-initializing database using setup.sh..."
 bash setup.sh
 
+# ── 3. Run migrations ────────────────────────────────────────────────────────
+step "Applying schema migrations..."
+.venv/bin/python migrate.py
+ok "Migrations applied"
+
 echo ""
 echo -e "${BOLD}Reset complete!${NC}"
 echo ""


### PR DESCRIPTION
## Summary

`setup.sh` applies `db/schema.sql` directly, which creates the base schema at version 3. `reset_db.sh` calls `setup.sh` but never ran `migrate.py` afterwards, leaving the DB at version 3 instead of the current version (7). Opening the app after a reset would immediately show the schema-outdated warning.

Adds a migration step to `reset_db.sh` so a full reset lands at the current schema version.

## Test plan

- [ ] Run `bash reset_db.sh` — confirm no schema-outdated warning when opening the app afterwards