### PR TITLE
fix: recent news JSON parse failure when Perplexity appends explanatory text

### DIFF
--- a/services/recent_news.py
+++ b/services/recent_news.py
@@ -91,6 +91,12 @@ def _parse_news_items(content: str) -> list[NewsItem]:
         content = content[:-3]
     content = content.strip()
 
+    # Extract just the JSON array in case the model appended explanatory text
+    start = content.find("[")
+    end = content.rfind("]")
+    if start != -1 and end != -1 and end >= start:
+        content = content[start : end + 1]
+
     try:
         items = json.loads(content)
     except json.JSONDecodeError as e:


### PR DESCRIPTION
## Summary
- Perplexity sometimes returns a valid JSON array followed by plain-text prose on subsequent lines, causing `json.loads` to raise `Extra data` and silently drop all news results
- Extract the substring between the outermost `[` and `]` before parsing, discarding any leading/trailing text

## Test plan
- [ ] Load a transcript where the earnings call date falls in a range with no Perplexity results — recent news panel should show empty state rather than an error in the console
- [ ] Load a transcript with results in range — news items should populate as before
- [ ] Confirm no `Could not parse news JSON` warning in logs on normal runs

Closes #105