### PR TITLE
feat: replace scikit-learn ML pipeline with Haiku NLP synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,10 @@ earnings-transcript-teacher/
 ├── parsing/            # Transcript loading, section extraction, financial term scanner
 ├── nlp/                # NLP algorithms (TF-IDF keywords, NMF themes, TextRank takeaways)
 ├── services/           # Orchestration and external service integrations
-│   ├── orchestrator.py # Main analysis pipeline — wires all modules together
-│   ├── company_info.py # SEC EDGAR company lookup and context formatting
-│   └── llm.py          # Anthropic/Perplexity API clients with rate limiting
+│   ├── orchestrator.py  # Main analysis pipeline — wires all modules together
+│   ├── company_info.py  # SEC EDGAR company lookup and context formatting
+│   ├── competitors.py   # Competitor identification via Claude Haiku
+│   └── llm.py           # Anthropic API client with rate limiting (Haiku + Sonnet)
 ├── ingestion/          # Three-tier agentic LLM enrichment pipeline (Claude Haiku + Sonnet)
 ├── cli/                # Console UI display and interactive menu
 ├── db/                 # PostgreSQL repository layer and semantic search

--- a/core/models.py
+++ b/core/models.py
@@ -149,6 +149,7 @@ class TopicRecord:
     terms: list[str]
     weight: float
     rank_order: int
+    name: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/db/migrations/008_topic_name.sql
+++ b/db/migrations/008_topic_name.sql
@@ -1,0 +1,4 @@
+-- Migration 008: Add topic_name column to call_topics for Haiku NLP synthesis
+ALTER TABLE call_topics ADD COLUMN IF NOT EXISTS topic_name TEXT DEFAULT '';
+
+INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -13,7 +13,7 @@ class OutdatedSchemaError(Exception):
     """Exception raised when the database schema is out of date."""
     pass
 
-REQUIRED_SCHEMA_VERSION = 8
+REQUIRED_SCHEMA_VERSION = 9
 
 
 def reset_all_data(conn_str: str) -> None:
@@ -719,10 +719,10 @@ class AnalysisRepository:
             cur.execute(
                 """
                 INSERT INTO call_topics (
-                    call_id, label, terms, weight, rank_order
-                ) VALUES (%s, %s, %s, %s, %s)
+                    call_id, label, terms, weight, rank_order, topic_name
+                ) VALUES (%s, %s, %s, %s, %s, %s)
                 """,
-                (str(call_id), topic.label, topic.terms, topic.weight, topic.rank_order)
+                (str(call_id), topic.label, topic.terms, topic.weight, topic.rank_order, getattr(topic, "name", ""))
             )
 
     def _save_keywords(self, cur, call_id, keywords):

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -186,7 +186,7 @@ class IngestionPipeline:
         from services.llm import AgenticExtractor
         self.extractor = AgenticExtractor()
 
-    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord, TokenUsageSummary]:
+    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord, TokenUsageSummary, dict]:
         """Run the full ingestion pipeline on a parsed CallAnalysis."""
         logger.info(f"Starting agentic ingestion for {analysis.call.ticker}")
 
@@ -207,7 +207,7 @@ class IngestionPipeline:
             return [], CallSynthesisRecord(
                 overall_sentiment="", executive_tone="", key_themes=[],
                 strategic_shifts=[], analyst_sentiment="",
-            ), TokenUsageSummary()
+            ), TokenUsageSummary(), {}
 
         # Phase 2: Map Phase (Concurrent Extraction)
         # Process chunks in parallel using a ThreadPoolExecutor
@@ -292,8 +292,65 @@ class IngestionPipeline:
                 synthesis_usage["completion_tokens"],
             )
 
+        # Phase 4: NLP Synthesis (Haiku — keywords, themes, top_takeaways)
+        print(f"\n[NLP Synthesis Phase] Extracting keywords, themes, and top takeaways via Haiku...")
+        nlp_synthesis: dict = {}
+        try:
+            signals = self._build_nlp_signals_payload(chunks)
+            nlp_data = self.extractor.extract_nlp_synthesis(signals)
+            nlp_usage = nlp_data.pop("_usage_stats", None)
+            if nlp_usage:
+                token_usage.add(
+                    nlp_usage["model"],
+                    nlp_usage["prompt_tokens"],
+                    nlp_usage["completion_tokens"],
+                )
+                print(f"    ↳ NLP Synthesis [Model: {nlp_usage['model']} | In: {nlp_usage['prompt_tokens']} | Out: {nlp_usage['completion_tokens']}]")
+            nlp_synthesis = nlp_data
+
+            top_takeaways = nlp_synthesis.get("top_takeaways", [])
+            if top_takeaways:
+                print("\n📌 Top Takeaways:")
+                for i, t in enumerate(top_takeaways, 1):
+                    speaker = t.get("speaker", "")
+                    prefix = f"  {i}. [{speaker}] " if speaker else f"  {i}. "
+                    print(f"{prefix}{t.get('takeaway', '')}")
+                    why = t.get("why_it_matters", "")
+                    if why:
+                        print(f"       → {why}")
+        except Exception as e:
+            logger.warning(f"NLP synthesis phase failed: {e}")
+            print(f"⚠️  NLP synthesis phase failed: {e}")
+
         print("✅ Agentic ingestion complete.\n")
-        return chunks, synthesis, token_usage
+        return chunks, synthesis, token_usage, nlp_synthesis
+
+    def _build_nlp_signals_payload(self, chunks: List[TranscriptChunk]) -> str:
+        """Collect map-phase signals from all chunks into a JSON payload for NLP synthesis."""
+        all_terms: list[dict] = []
+        all_concepts: list[str] = []
+        all_takeaways: list[dict] = []
+
+        seen_terms: set[str] = set()
+        for chunk in chunks:
+            for t in chunk.extracted_terms:
+                term = t.get("term", "")
+                if term and term not in seen_terms:
+                    seen_terms.add(term)
+                    all_terms.append({"term": term, "definition": t.get("definition", ""), "category": t.get("category", "")})
+            for concept in chunk.core_concepts:
+                if concept:
+                    all_concepts.append(concept)
+            for takeaway in chunk.takeaways:
+                if takeaway.get("takeaway"):
+                    all_takeaways.append(takeaway)
+
+        payload = {
+            "extracted_terms": all_terms,
+            "core_concepts": all_concepts,
+            "takeaways": all_takeaways,
+        }
+        return json.dumps(payload, indent=2)
         
     def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int, company_context: str = "") -> list[dict]:
         """Helper method to process a single chunk, designed to run in a thread.

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -110,6 +110,35 @@ Respond ONLY with valid JSON matching this schema:
 }
 """
 
+HAIKU_NLP_SYNTHESIS_PROMPT = """You are an expert financial analyst synthesizing signals extracted from an earnings call transcript.
+
+You will receive aggregated signals from the map phase of transcript ingestion:
+- extracted_terms: industry and financial terms identified across all chunks
+- core_concepts: strategic concept summaries from each chunk
+- takeaways: beginner-friendly takeaways with "why it matters" context
+
+Your job is to produce three outputs:
+
+1. **keywords** (top 20): The most important and financially significant terms from this call, ranked by importance. For each, include a brief significance note explaining why it matters for this company/sector — not a generic definition.
+
+2. **themes** (exactly 5): Labeled thematic clusters that represent the dominant strategic narratives of this call. Each theme should have a descriptive, specific name (e.g. "AI Infrastructure Investment Cycle", not "Growth") and 6–8 supporting terms drawn from the extracted signals.
+
+3. **top_takeaways** (top 10): The most important beginner-friendly takeaways across the entire call. For each, include the speaker name if available, the core takeaway text, and why it matters financially.
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "keywords": [
+    {"term": "string", "significance": "string"}
+  ],
+  "themes": [
+    {"name": "string", "terms": ["string"]}
+  ],
+  "top_takeaways": [
+    {"speaker": "string", "takeaway": "string", "why_it_matters": "string"}
+  ]
+}
+"""
+
 QA_DETECTION_SYSTEM_PROMPT = """You are an expert transcript analyst.
 Your task is to identify the exact line where an earnings call transitions from "Prepared Remarks" to the "Question and Answer" (Q&A) session.
 

--- a/migrate.py
+++ b/migrate.py
@@ -147,8 +147,15 @@ try:
             cur.execute(
                 "INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;"
             )
+            # v8 → v9: add topic_name column to call_topics for Haiku NLP synthesis
+            cur.execute(
+                "ALTER TABLE call_topics ADD COLUMN IF NOT EXISTS topic_name TEXT DEFAULT '';"
+            )
+            cur.execute(
+                "INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;"
+            )
 
         conn.commit()
-    print("Migration successful — schema is at version 8.")
+    print("Migration successful — schema is at version 9.")
 except Exception as e:
     print(f"Error during migration: {e}")

--- a/services/competitors.py
+++ b/services/competitors.py
@@ -1,10 +1,9 @@
-"""Fetch competitors for a company via Perplexity and detect transcript mentions."""
+"""Fetch competitors for a company via Claude Haiku and detect transcript mentions."""
 
 import json
 import logging
-import os
 
-import requests
+import anthropic
 
 from core.models import Competitor
 
@@ -25,16 +24,11 @@ def fetch_competitors(
     transcript_text: str,
     max_items: int = _MAX_COMPETITORS,
 ) -> list[Competitor]:
-    """Query Perplexity for direct competitors of the company.
+    """Query Claude Haiku for direct competitors of the company.
 
     Returns up to max_items Competitor objects with mention flags set.
     Returns an empty list on any error so callers are never blocked.
     """
-    api_key = os.environ.get("PERPLEXITY_API_KEY")
-    if not api_key:
-        logger.warning("PERPLEXITY_API_KEY not set — skipping competitors fetch")
-        return []
-
     display_name = company_name or ticker
     industry_str = industry or "their industry"
 
@@ -49,27 +43,15 @@ def fetch_competitors(
         f"If fewer than {max_items} exist, return what you find."
     )
 
-    payload = {
-        "model": "sonar",
-        "messages": [
-            {"role": "system", "content": _SYSTEM_PROMPT},
-            {"role": "user", "content": user_prompt},
-        ],
-        "stream": False,
-    }
-
     try:
-        response = requests.post(
-            "https://api.perplexity.ai/chat/completions",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json=payload,
-            timeout=30,
+        client = anthropic.Anthropic()
+        message = client.messages.create(
+            model="claude-haiku-4-5-20251001",
+            max_tokens=1024,
+            system=_SYSTEM_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}],
         )
-        response.raise_for_status()
-        content = response.json()["choices"][0]["message"]["content"].strip()
+        content = message.content[0].text.strip()
         competitors = _parse_competitors(content)
         return _flag_transcript_mentions(competitors, transcript_text)
     except Exception as e:
@@ -80,12 +62,13 @@ def fetch_competitors(
 def _parse_competitors(content: str) -> list[Competitor]:
     """Parse a JSON array from the LLM response into Competitor objects."""
     if content.startswith("```json"):
-        content = content[7:]
+        end = content.rfind("```", 7)
+        content = (content[7:end] if end != -1 else content[7:]).strip()
     elif content.startswith("```"):
-        content = content[3:]
-    if content.endswith("```"):
-        content = content[:-3]
-    content = content.strip()
+        end = content.rfind("```", 3)
+        content = (content[3:end] if end != -1 else content[3:]).strip()
+    else:
+        content = content.strip()
 
     try:
         items = json.loads(content)

--- a/services/llm.py
+++ b/services/llm.py
@@ -12,7 +12,7 @@ from tenacity import retry, wait_exponential_jitter, stop_after_attempt, retry_i
 _CITATION_PATTERN = re.compile(r'\[(?:\d+|[a-z_]+)\]')
 
 import anthropic
-from ingestion.prompts import TIER_1_SYSTEM_PROMPT, TIER_2_SYSTEM_PROMPT, TIER_3_SYNTHESIS_PROMPT, QA_DETECTION_SYSTEM_PROMPT
+from ingestion.prompts import TIER_1_SYSTEM_PROMPT, TIER_2_SYSTEM_PROMPT, TIER_3_SYNTHESIS_PROMPT, QA_DETECTION_SYSTEM_PROMPT, HAIKU_NLP_SYNTHESIS_PROMPT
 
 logger = logging.getLogger(__name__)
 
@@ -172,14 +172,21 @@ class AgenticExtractor:
         """Parse an Anthropic message response into a result dict with usage stats."""
         content = message.content[0].text.strip()
         if content.startswith("```json"):
-            content = content[7:-3].strip()
+            end = content.rfind("```", 7)
+            content = (content[7:end] if end != -1 else content[7:]).strip()
         elif content.startswith("```"):
-            content = content[3:-3].strip()
+            end = content.rfind("```", 3)
+            content = (content[3:end] if end != -1 else content[3:]).strip()
         try:
             result = json.loads(content)
-        except json.JSONDecodeError as e:
-            logger.error("Failed to parse LLM JSON response: %s. Content: %.200s", e, content)
-            raise ValueError(f"LLM returned malformed JSON: {e}") from e
+        except json.JSONDecodeError:
+            # Fall back to raw_decode: parses the first valid JSON object and
+            # ignores any trailing text/prose the model appended after closing brace.
+            try:
+                result, _ = json.JSONDecoder().raw_decode(content)
+            except json.JSONDecodeError as e:
+                logger.error("Failed to parse LLM JSON response: %s. Content: %.200s", e, content)
+                raise ValueError(f"LLM returned malformed JSON: {e}") from e
         result["_usage_stats"] = {
             "model": message.model,
             "prompt_tokens": message.usage.input_tokens,
@@ -218,7 +225,7 @@ class AgenticExtractor:
         self.rate_limiter.wait()
         message = self.client.messages.create(
             model=self.tier2_model,
-            max_tokens=4096,
+            max_tokens=8192,
             system=TIER_2_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
@@ -241,6 +248,24 @@ class AgenticExtractor:
             messages=[{"role": "user", "content": user_prompt}]
         )
         return self._parse_response(message)
+    @retry(
+        wait=wait_exponential_jitter(initial=2, max=60),
+        stop=stop_after_attempt(5),
+        retry=retry_if_exception(_should_retry_error),
+        reraise=True
+    )
+    def extract_nlp_synthesis(self, signals_payload: str) -> Dict[str, Any]:
+        """Run Phase 4 NLP synthesis: produce keywords, themes, and top takeaways via Haiku."""
+        user_prompt = f"### Aggregated Signals from Map Phase:\n{signals_payload}\n\nProduce the NLP synthesis JSON."
+        self.rate_limiter.wait()
+        message = self.client.messages.create(
+            model=self.tier3_model,
+            max_tokens=4096,
+            system=HAIKU_NLP_SYNTHESIS_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}]
+        )
+        return self._parse_response(message)
+
     @retry(
         wait=wait_exponential_jitter(initial=2, max=60),
         stop=stop_after_attempt(5),

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -4,9 +4,6 @@ import logging
 from parsing.loader import read_text_file, extract_transcript_text
 from services.company_info import fetch_company_info
 from nlp.analysis import clean_text, tokenize
-from nlp.keywords import extract_keywords
-from nlp.themes import extract_themes
-from nlp.takeaways import extract_takeaways
 from parsing.sections import (
     extract_transcript_sections,
     extract_qa_exchanges,
@@ -153,47 +150,11 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
         key = (s.speaker_name, s.text[:80])
         span_lookup[key] = s
 
-    # Keywords
-    keyword_results = extract_keywords(raw_text)
-    keywords = [
-        KeywordRecord(term=term, score=score)
-        for term, score in keyword_results
-    ]
-
-    # Topics
-    theme_results = extract_themes(raw_text)
-    topics = [
-        TopicRecord(
-            label=t.label,
-            terms=t.terms,
-            weight=t.weight,
-            rank_order=rank,
-        )
-        for rank, t in enumerate(theme_results, 1)
-    ]
-
-    # Takeaways — link back to span records
-    takeaway_results = extract_takeaways(raw_text)
+    # Keywords and topics are populated by the Haiku NLP synthesis phase (Phase 4 of ingestion).
+    # Initialise as empty lists here; the pipeline will replace them below.
+    keywords: list[KeywordRecord] = []
+    topics: list[TopicRecord] = []
     takeaway_spans: list[SpanRecord] = []
-    for t in takeaway_results:
-        key = (t.speaker, t.text[:80])
-        if key in span_lookup:
-            span = span_lookup[key]
-            span.textrank_score = t.score
-            takeaway_spans.append(span)
-        else:
-            # Takeaway didn't match a span (e.g. sentence-level split);
-            # create a standalone span for it.
-            takeaway_span = SpanRecord(
-                call_id=call.id,
-                speaker_name=t.speaker,
-                section="qa",
-                span_type="turn",
-                sequence_order=-1,
-                text=t.text,
-                textrank_score=t.score,
-            )
-            takeaway_spans.append(takeaway_span)
 
     # Q&A pairs — link exchanges to span IDs
     exchanges = extract_qa_exchanges(qa, prepared_remarks=prepared_remarks)
@@ -239,10 +200,28 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     try:
         from ingestion.pipeline import IngestionPipeline
         pipeline = IngestionPipeline()
-        chunks, synthesis, token_usage = pipeline.process(analysis)
+        chunks, synthesis, token_usage, nlp_synthesis = pipeline.process(analysis)
         analysis.chunks = chunks
         analysis.synthesis = synthesis
         analysis.token_usage = token_usage
+
+        if nlp_synthesis:
+            raw_keywords = nlp_synthesis.get("keywords", [])
+            analysis.keywords = [
+                KeywordRecord(term=k["term"], score=len(raw_keywords) - i)
+                for i, k in enumerate(raw_keywords)
+                if k.get("term")
+            ]
+            analysis.topics = [
+                TopicRecord(
+                    label=i,
+                    name=t.get("name", ""),
+                    terms=t.get("terms", []),
+                    weight=1.0,
+                    rank_order=i + 1,
+                )
+                for i, t in enumerate(nlp_synthesis.get("themes", []))
+            ]
     except Exception as e:
         print(f"❌ Agentic pipeline failed: {e}")
         logger.warning(f"Agentic pipeline failed or skipped: {e}")

--- a/tests/services/test_orchestrator.py
+++ b/tests/services/test_orchestrator.py
@@ -21,54 +21,65 @@ def mock_external_calls(mocker):
     They actually increased due to efficiency.
     """)
     mocker.patch("services.orchestrator.read_text_file", return_value=json.dumps({"transcript": raw_text}))
-    
-    # Mock NLP functions to avoid length/dimension errors on tiny texts
-    mocker.patch("services.orchestrator.extract_keywords", return_value=[("cloud", 0.9), ("growth", 0.8)])
-    
-    mock_theme = MagicMock()
-    mock_theme.label = 0
-    mock_theme.terms = ["cloud", "azure"]
-    mock_theme.weight = 1.5
-    mocker.patch("services.orchestrator.extract_themes", return_value=[mock_theme])
-    
-    mock_takeaway = MagicMock()
-    mock_takeaway.speaker = "Satya Nadella"
-    mock_takeaway.text = "Cloud growth was tremendous this quarter."
-    mock_takeaway.score = 2.0
-    mocker.patch("services.orchestrator.extract_takeaways", return_value=[mock_takeaway])
-    
+
+    # Mock schema health check to pass without a real DB connection
+    mock_schema_repo = MagicMock()
+    mock_schema_repo.check_health.return_value = (True, "ok")
+    mocker.patch("services.orchestrator.SchemaRepository", return_value=mock_schema_repo)
+
     # Mock DB/Embedder
     mocker.patch("services.orchestrator.fetch_existing_embeddings", return_value={"Thank you.": [0.1, 0.1, 0.1]})
-    mocker.patch("services.orchestrator.get_embeddings", return_value=[[0.2, 0.2, 0.2]] * 10) # arbitrary sufficient list
-    
-    # Mock IngestionPipeline to prevent API calls
+    mocker.patch("services.orchestrator.get_embeddings", return_value=[[0.2, 0.2, 0.2]] * 10)
+
+    # Mock IngestionPipeline — return 4-tuple including NLP synthesis output
+    from core.models import CallSynthesisRecord, TokenUsageSummary
+    mock_synthesis = CallSynthesisRecord(
+        overall_sentiment="positive",
+        executive_tone="confident",
+        key_themes=["cloud"],
+        strategic_shifts=[],
+        analyst_sentiment="cautious",
+    )
+    nlp_synthesis = {
+        "keywords": [
+            {"term": "cloud", "significance": "core growth driver"},
+            {"term": "azure", "significance": "flagship product"},
+        ],
+        "themes": [
+            {"name": "Cloud Expansion", "terms": ["cloud", "azure", "growth"]},
+        ],
+        "top_takeaways": [
+            {"speaker": "Satya Nadella", "takeaway": "Cloud growth was tremendous.", "why_it_matters": "Signals accelerating adoption."},
+        ],
+    }
     mock_pipeline_class = mocker.patch("ingestion.pipeline.IngestionPipeline")
     mock_pipeline_instance = MagicMock()
-    mock_pipeline_instance.process.return_value = []
+    mock_pipeline_instance.process.return_value = ([], mock_synthesis, TokenUsageSummary(), nlp_synthesis)
     mock_pipeline_class.return_value = mock_pipeline_instance
+
 
 def test_analyze_orchestrator(mock_external_calls):
     result = analyze("MSFT")
-    
+
     # Verify the structure of the returned CallAnalysis
     assert isinstance(result, CallAnalysis)
     assert result.call.ticker == "MSFT"
     assert result.call.token_count > 0
-    
-    # Check that speakers were extracted (Operator, Satya, Jane)
+
+    # Check that speakers were extracted (Operator, Satya, John Doe)
     assert len(result.speakers) == 3
-    
-    # Check that keywords, topics, and takeaways are linked
+
+    # Keywords come from NLP synthesis
     assert len(result.keywords) == 2
     assert result.keywords[0].term == "cloud"
-    
+
+    # Topics come from NLP synthesis
     assert len(result.topics) == 1
-    assert result.topics[0].terms == ["cloud", "azure"]
-    
-    # The takeaway should have been linked to a span, or created as a standalone span
-    assert len(result.takeaways) == 1
-    assert result.takeaways[0].text == "Cloud growth was tremendous this quarter."
-    assert result.takeaways[0].speaker_name == "Satya Nadella"
-    
+    assert result.topics[0].terms == ["cloud", "azure", "growth"]
+    assert result.topics[0].name == "Cloud Expansion"
+
+    # Takeaways list is empty (scikit-learn TextRank removed; NLP takeaways go to console)
+    assert result.takeaways == []
+
     # QA Pair extraction
     assert len(result.qa_pairs) > 0


### PR DESCRIPTION
## Summary

- Adds Phase 4 to the ingestion pipeline: a single Haiku call synthesises **keywords** (top 20 with significance notes), **themes** (5 labelled clusters with 6–8 supporting terms), and **top takeaways** (10, printed to console) from the aggregated map-phase signals — replacing TF-IDF, NMF, and TextRank
- Removes `extract_keywords`, `extract_themes`, `extract_takeaways` (scikit-learn) from the orchestrator; NLP synthesis output is wired to `KeywordRecord` / `TopicRecord`
- Adds `topic_name` field to `TopicRecord`, `call_topics` table (migration 008, schema v9), and `_save_topics()`
- Switches competitor identification from Perplexity `sonar` to Claude Haiku, eliminating JSON reliability issues (citation bleed, inconsistent object format)
- Increases Tier 2 `max_tokens` from 4096 → 8192 to prevent truncation on long Q&A chunks
- Fixes `_parse_response` to use `rfind` for fence boundary detection and `raw_decode` as fallback for trailing content

## Test plan

- [ ] Run `python migrate.py` to apply schema v9 (`topic_name` column)
- [ ] Run pipeline on 2–3 known transcripts and verify Haiku keywords/themes appear in console output
- [ ] Compare Haiku `top_takeaways` printout against previous TextRank output for quality
- [ ] Confirm competitors are fetched without JSON parse errors
- [ ] `pytest` passes (56 tests)

Closes #118