### PR TITLE
docs: first draft of diary article 001

### DIFF
--- a/ideation/articles/diary/001-why-i-built-an-earnings-transcript-parser-to-learn-ai.md
+++ b/ideation/articles/diary/001-why-i-built-an-earnings-transcript-parser-to-learn-ai.md
@@ -2,7 +2,7 @@
 
 **Track:** Diary
 **Sequence:** 1
-**Status:** Pre-draft
+**Status:** Draft
 
 ---
 
@@ -55,11 +55,13 @@
 
 ## Draft
 
+## The Advice That Exposed a Gap
+
 It started with a casual piece of advice that quietly exposed a gap in my business acumen: *"You should really listen to more earnings calls."*
 
 My colleague was right. As a technical consultant and mentor with nearly thirty years of experience in technology and management, I had spent my career mastering complex systems and architectures. Yet, when it came to the enterprise-scale financial machinery that actually governs strategic business decisions, I was missing a crucial piece of the puzzle. Earnings calls are the unfiltered pulse of the corporate world. They signal strategic shifts, reveal underlying health, and dictate market movements.
 
-So, I tried listening to them. And it was brutal.
+The first one I tried was Microsoft's. I sat with the transcript open alongside the audio and felt two things arrive in quick succession: first, the sheer volume — the density, the pace, the relentless forward motion of financial language I had no way to anchor. Then, right behind it, the more discouraging realization: without prior context, nothing had a foothold. I recognized the feeling. I'd watched it cross the faces of technical mentees encountering a complex codebase for the first time. I could read every word and still lose the thread, because I didn't yet know which words mattered.
 
 Earnings transcripts are a dense thicket of unfamiliar vocabulary, arcane industry context, and carefully constructed corporate speak. For an experienced financial analyst, these transcripts are rich with signal. They can scan the text, instantly extract the salient points, read between the lines to detect subtle shifts in tone or deliberate deflections, and synthesize the information in minutes.
 
@@ -67,42 +69,44 @@ But for a learner? It's an exhausting exercise in information overload. Trying t
 
 I realized I needed a better way to consume this information—a tool that didn't just summarize a document, but actively helped me learn how to read it. 
 
-### 2. The Builder's Dilemma (Why Not Just ChatGPT?)
+## Why a Chatbot Wasn't Enough
 
 The obvious question, especially in today's generative AI landscape, is: *Why not just drop the PDF into ChatGPT or Claude and ask it to summarize?*
 
-As a technical consultant and mentor with nearly thirty years of experience, I knew that approach wouldn't cut it. A standard chatbot is a generalist. It will happily summarize an earnings call, but it does so passively. If you don't know the right questions to ask, or if you don't even know what you don't know, a chat interface won't save you. 
+I knew that approach wouldn't cut it. A standard chatbot is a generalist. It will happily summarize an earnings call, but it does so passively. I didn't know the right questions to ask — and I didn't know what I didn't know. A chat interface wasn't going to surface that. 
 
 I didn't want a passive summarizer; I wanted an active learning tool. My goal was to build something specifically for learners, like retail investors, who need a guided path to understanding. I needed to isolate the AI's behavior exclusively to the finance domain and take strict control over its inference. 
 
-More importantly, true learning requires iteration. I wanted to implement a Feynman learning loop—a structured, interactive flow where the user is prompted to explain concepts back and fill gaps in their knowledge. Orchestrating that kind of continuous, guided state machine is nearly impossible to achieve consistently in a standard off-the-shelf chat interface. I needed to build a custom application to pull it off.
+More importantly, true learning requires iteration. I wanted to implement a Feynman learning loop — think of it as an interactive form of rubber ducking, except instead of a silent duck, you have an AI that actually pushes back and identifies the gaps in your understanding. It's a structured flow where I'm prompted to explain concepts back and fill gaps in my knowledge. Orchestrating that kind of continuous, guided learning loop is nearly impossible to achieve consistently in a standard off-the-shelf chat interface. I needed to build a custom application to pull it off.
 
-### 3. The App & Its "Magic"
+## From Wall of Text to Learning Engine
 
-The Earnings Transcript Teacher isn't just a reader; it's a fully automated ingestion and analysis pipeline. Give it a stock ticker and a quarter, and it downloads the raw transcript, parses it, and ingests it into local storage. 
+The first time I ran a transcript through the pipeline, the interface was a simple console application — no GUI, no AI, just Python and scikit-learn doing statistical analysis and primitive classification. I expected the output to be sparse. Instead, the terminal filled with structure: speakers segmented, Q&A separated from prepared remarks, jargon extracted, key phrases surfaced. It worked. More than that, the sheer volume of signal already embedded in the document's structure — before a single AI call — surprised me.
 
-During that process, it systematically tears the document down to its structural components. It identifies the prepared remarks, segments the Q&A sessions, profiles the speakers, and extracts both financial and industry-specific jargon. A deeper LLM-driven analysis pinpoints core takeaways, strategic shifts, and even relevant news from the time period surrounding the call.
+That was the foundation. The GUI came later. The AI-powered analysis layer came after that, adding depth that statistical methods alone couldn't reach: core takeaways, strategic shifts, and relevant news from the period surrounding the call. Each layer made the transcript less of a document and more of a map.
 
-But the real "magic" happens in the GUI. Instead of staring at a multi-page wall of text, learners get a cohesive visual representation of the call's concepts enabling rapid exploration and review. The application surfaces the "hidden" signals that an experienced analyst would catch naturally—sentiment shifts across speakers, changes in tone, and subtle cues buried in the dialogue that are difficult for learners to detect.
+But the real shift came with the GUI. Instead of a wall of text, the transcript becomes navigable — the structure visible at a glance. More importantly, the application surfaces what I used to miss entirely: sentiment shifts across speakers, the difference in tone between prepared remarks and Q&A, the subtle deflections buried in the dialogue that an experienced analyst reads instinctively. Getting those signals into the interface was the difference between building a summarizer and building something that actually teaches you how to read.
 
-You can also drill down into the extracted concepts, for example defining a financial term or concept, or exploring the strategic implications of a particular statement within the context of the call.
+I can drill down into the extracted concepts, for example defining a financial term, or exploring the strategic implications of a particular statement within the context of the call.
 
-Rather than reading passively, you can also engage with the transcript through an interactive Feynman learning loop. The app prompts you to explain what you've just read, analyzes your understanding, and helps you fill in the gaps through a guided, open-ended discussion. The transcript goes from a daunting block of text to a dynamic educational engine.
+Rather than reading passively, I can also engage with the transcript through an interactive Feynman learning loop. The app prompts me to explain what I've just read, analyzes my understanding, and helps me fill in the gaps through a guided, open-ended discussion. The transcript goes from a daunting block of text to a dynamic educational engine.
 
-### 4. Facing the Learning Curve (Honesty & Vulnerability)
+What I had, though, was a well-fleshed-out prototype — not yet hardened for production, not ready for multi-user scale, but functional enough to prove the concept. Getting there was another matter entirely.
 
-I won't pretend this was an easy build. Before writing a single line of code, the imposter syndrome hit hard. Questions like *"Will this actually be useful for real enterprise-level finance, or am I just building an expensive summarization toy?"* and *"What happens if the LLM hallucinates and gives me terrible financial insights?"* were constant companions. Add to that the overwhelming technical question: *"How do I even begin to wire together Python, Streamlit, and LLM APIs when the landscape changes every week?"*
+## The Part Nobody Talks About
 
-The reality of building an AI-native application is that it's an avalanche of new technology. It wasn't just about learning Python or building a UI with Streamlit. I had to simultaneously wrap my head around AI model selection, prompt engineering, complex data ingestion pipelines, product development, and the very new world of AI-assisted coding flows. It was overwhelming, and there were days when the learning curve felt more like a brick wall.
+Before I wrote a single line of code, the imposter syndrome had already arrived. Questions like *"Will this actually be useful for real enterprise-level finance, or am I just building an expensive summarization toy?"* and *"What happens if the LLM hallucinates and gives me terrible financial insights?"* were constant companions. Then came the technical reality: *"How do I even begin to wire together Python, Streamlit, and LLM APIs when the landscape changes every week?"*
 
-Beyond the technical hurdles, there was a very practical fear: cost. An interactive application, especially one driving a continuous Feynman learning loop, makes a *lot* of LLM requests. I had to learn on the fly how to manage tokens, optimize inference, and balance capability with potential for runaway API bills. It forced me to treat every prompt not just as an instruction, but as a unit of economics.
+The reality of building an AI-native application is that it's an avalanche of new technology. It wasn't just about learning Python or building a UI with Streamlit. I had to simultaneously wrap my head around AI model selection, prompt engineering, complex data ingestion pipelines, product development, and the very new world of AI-assisted coding flows. It was overwhelming, and there were days when I felt completely buried under it.
 
-### 5. Conclusion: A New Lens on AI and Finance
+Beyond the technical hurdles, there was a practical fear: cost. An interactive application, especially one driving a continuous Feynman learning loop, makes a *lot* of LLM requests. I had to learn on the fly how to manage tokens, optimize inference, and balance capability with potential for runaway API bills. It forced me to treat every prompt not just as an instruction, but as a unit of economics.
+
+The moment the project stopped feeling like a prototype was when I added the Feynman flow. Before that, it was a sophisticated analysis tool — useful, but passive. The moment it could push back, ask me to explain something, and identify where my understanding broke down, it became something closer to what I'd originally imagined: a learning partner. That shift changed what I thought I was building.
+
+## What It Taught Me
 
 What started as an attempt to close a gap in my business acumen became a full-fledged journey into modern AI application development. The Earnings Transcript Teacher solved my immediate problem: it gave me a structured, visually coherent, and interactive way to consume complex financial transcripts without the cognitive overload.
 
-Crucially, while the core features are in place, the application isn't finished. Right now, it's a well-fleshed-out prototype. It's not yet hardened for production—it lacks multi-user support, a scalable web UI, proper deployment pipelines, and robust observability. But that's exactly the point. Building this prototype didn't just teach me how to read an earnings report; it laid the foundation for learning how to *productionize* AI applications, design non-linear user flows, and collaborate with AI to write code.
+I started this project trying to understand earnings calls. I ended it with a much harder problem: how do you take something that works on your laptop and turn it into something that works for anyone? That's the question I'll be working through next.
 
-This diary entry is just the beginning. Over the next few months, I'll be unpacking the technical architecture, prompt strategies, and the hard-won lessons of moving from prototype to production. If you're a developer curious about how to guide an AI codebase, watch for the **Building With AI** track. If you're looking for deep dives into structured output reliability, deployment, and "productionizing" these tools, follow the **LLMs in Production** track.
-
-I built this parser to learn. Let's explore what it can teach us.
+I built this parser to learn. It's still teaching me.


### PR DESCRIPTION
## Summary

- Develops the rough draft of article 001 into a complete first draft
- Adds narrative section headers, a concrete opening scene, and an emotional arc that was missing from the rough draft
- Rewrites Section 3 through the builder's experience rather than a product spec, grounding the app description in the first run (console, scikit-learn) and building up to the GUI and AI layers
- Adds the arrival beat (Feynman flow as the turning point from tool to learning partner) at the end of Section 4

## Key changes

- Section headers now arc as a story: *The Advice That Exposed a Gap → Why a Chatbot Wasn't Enough → From Wall of Text to Learning Engine → The Part Nobody Talks About → What It Taught Me*
- Opening grounded with a specific MSFT scene and mentoring parallel
- Feynman technique explained via rubber ducking analogy for mixed audiences
- Prototype disclosure moved from conclusion to end of Section 3
- Conclusion track-teaser CTA replaced with a narrative closer
- Voice consistently first-person throughout; jargon removed

## Test plan

- [ ] Read through the full draft for voice consistency and flow
- [ ] Confirm section headers read as a coherent arc
- [ ] Verify no second-person slips remain in the draft section