### PR TITLE
feat: admin ingestion endpoint and dev.sh (#124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,38 +213,56 @@ earnings-transcript-teacher/
 
 ### Local development (new stack)
 
-**Required environment variables for the FastAPI backend** (add to `set_env.sh` / `set_env.ps1`):
+#### First-time setup
+
+1. Copy the env templates and fill in your values:
+
+```bash
+cp api/.env.example api/.env
+cp web/.env.example web/.env.local
+```
+
+**`api/.env` variables:**
 
 | Variable | Description |
 |---|---|
-| `DATABASE_URL` | PostgreSQL connection string (e.g. `postgresql://localhost/earnings_teacher`) |
-| `SUPABASE_JWT_SECRET` | JWT secret from Supabase → Project Settings → API |
-| `ADMIN_SECRET_TOKEN` | Arbitrary secret for admin-only routes — set to any strong random string |
-| `VOYAGE_API_KEY` | Required for the `/search` endpoint; the other endpoints work without it |
+| `DATABASE_URL` | Supabase connection string (Supabase → Project Settings → Database → URI) |
+| `SUPABASE_JWT_SECRET` | JWT secret (Supabase → Project Settings → API) |
+| `ADMIN_SECRET_TOKEN` | Any strong random string — protects admin-only routes |
+| `VOYAGE_API_KEY` | Required for the `/search` endpoint; other endpoints work without it |
+| `PERPLEXITY_API_KEY` | Required for the Feynman chat endpoint |
+
+**`web/.env.local` variables:**
+
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key |
+
+#### Starting the dev servers
 
 ```bash
-# Source env vars first — the API refuses to start without them
-source set_env.sh   # or: . .\set_env.ps1 on Windows
+./dev.sh          # start API + Next.js together (Ctrl-C stops both)
+./dev.sh api      # API only (http://localhost:8000)
+./dev.sh web      # Next.js only (http://localhost:3000)
+```
 
-# FastAPI backend — PYTHONPATH must include the project root so api/routes can
-# import from db/, nlp/, etc.
-cd api && PYTHONPATH=.. uvicorn main:app --reload
+The script reads env vars from `api/.env` and `web/.env.local` directly — no need to source them manually.
 
-# Next.js frontend
-cd web && npm run dev
+#### Modal ingestion pipeline (test run)
 
-# Modal ingestion pipeline (test run)
+```bash
 modal run pipeline/ingest.py --ticker AAPL
 ```
 
-**Verify the API is running:**
+#### Verify the API is running
 
 ```bash
 curl http://localhost:8000/health
 # → {"status":"ok"}
 ```
 
-**Smoke-test the /api/calls endpoints** (requires at least one ingested transcript):
+#### Smoke-test the /api/calls endpoints (requires at least one ingested transcript)
 
 ```bash
 # List all calls
@@ -258,9 +276,16 @@ curl "http://localhost:8000/api/calls/AAPL/spans?section=prepared&page=1&page_si
 
 # Semantic search (requires VOYAGE_API_KEY)
 curl "http://localhost:8000/api/calls/AAPL/search?q=AI+infrastructure+spending"
+
+# Trigger ingestion (requires Modal deployed + ADMIN_SECRET_TOKEN)
+curl -X POST http://localhost:8000/admin/ingest \
+  -H "X-Admin-Token: $ADMIN_SECRET_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"ticker": "AAPL"}'
+# → {"status":"accepted","ticker":"AAPL","message":"Ingestion dispatched"}
 ```
 
-**Run the API unit tests:**
+#### Run the API unit tests
 
 ```bash
 pytest tests/unit/api/ -v

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,3 +6,4 @@ PyJWT>=2.8.0
 python-multipart>=0.0.9
 voyageai>=0.3.0
 pgvector>=0.3.0
+modal>=0.73.0

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,5 +1,43 @@
-"""Admin routes — placeholder, implemented in #124."""
+"""Admin routes — protected ingestion dispatch."""
 
-from fastapi import APIRouter
+import logging
+import re
+from datetime import UTC, datetime
+
+import modal
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, field_validator
+
+from dependencies import AdminDep
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+_TICKER_RE = re.compile(r"^[A-Z]{2,5}$")
+
+
+class IngestRequest(BaseModel):
+    ticker: str
+
+    @field_validator("ticker")
+    @classmethod
+    def validate_ticker(cls, v: str) -> str:
+        """Uppercase and validate ticker format (2–5 alpha chars)."""
+        upper = v.upper()
+        if not _TICKER_RE.match(upper):
+            raise ValueError("ticker must be 2–5 alphabetic characters")
+        return upper
+
+
+@router.post("/ingest", status_code=202)
+async def trigger_ingestion(body: IngestRequest, _: AdminDep) -> dict:
+    """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""
+    fn = modal.Function.lookup("earnings-ingestion", "ingest_ticker")
+    fn.spawn(body.ticker)
+    logger.info("Ingestion dispatched: ticker=%s at=%s", body.ticker, datetime.now(UTC).isoformat())
+    return {
+        "status": "accepted",
+        "ticker": body.ticker,
+        "message": "Ingestion dispatched",
+    }

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# dev.sh — start all local development tiers
+#
+# Usage:
+#   ./dev.sh          # start API + web (default)
+#   ./dev.sh api      # start API only
+#   ./dev.sh web      # start Next.js frontend only
+#
+# Prerequisites:
+#   - api/.env exists with all required variables (copy api/.env.example)
+#   - web/.env.local exists (copy web/.env.example)
+#   - .venv is activated, or Python is on PATH
+#   - Node.js is installed
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+API_ENV="$REPO_ROOT/api/.env"
+WEB_ENV="$REPO_ROOT/web/.env.local"
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+die() { echo "error: $*" >&2; exit 1; }
+
+check_env_file() {
+    local file="$1" example="$2" label="$3"
+    if [[ ! -f "$file" ]]; then
+        die "$label env file not found: $file\n  Copy $example and fill in your values."
+    fi
+}
+
+start_api() {
+    check_env_file "$API_ENV" "api/.env.example" "API"
+    echo "→ Starting FastAPI (http://localhost:8000)"
+    cd "$REPO_ROOT/api"
+    # Load env vars and start uvicorn; PYTHONPATH lets routes import from project root
+    env $(grep -v '^#' "$API_ENV" | xargs) PYTHONPATH="$REPO_ROOT" \
+        uvicorn main:app --reload --host 0.0.0.0 --port 8000
+}
+
+start_web() {
+    check_env_file "$WEB_ENV" "web/.env.example" "Web"
+    echo "→ Starting Next.js (http://localhost:3000)"
+    cd "$REPO_ROOT/web"
+    npm run dev
+}
+
+# ── main ───────────────────────────────────────────────────────────────────────
+
+TARGET="${1:-all}"
+
+case "$TARGET" in
+    api)
+        start_api
+        ;;
+    web)
+        start_web
+        ;;
+    all)
+        # Run both in parallel; kill both when either exits or Ctrl-C is pressed
+        trap 'kill 0' INT TERM EXIT
+        start_api &
+        API_PID=$!
+        start_web &
+        WEB_PID=$!
+        wait "$API_PID" "$WEB_PID"
+        ;;
+    *)
+        echo "Usage: $0 [api|web|all]" >&2
+        exit 1
+        ;;
+esac

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -1,0 +1,135 @@
+"""Unit tests for /admin routes."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+# Stub modal before routes.admin imports it so the C-extension dance never happens.
+MODAL_STUB = MagicMock()
+sys.modules.setdefault("modal", MODAL_STUB)
+
+from main import app  # noqa: E402  (must come after sys.modules stub)
+
+ENV = {
+    "DATABASE_URL": "postgresql://test",
+    "SUPABASE_JWT_SECRET": "secret",
+    "ADMIN_SECRET_TOKEN": "test-admin-token",
+}
+
+
+@pytest.fixture()
+def client():
+    """Return a TestClient with required env vars set and side-effects mocked."""
+    with patch.dict(os.environ, ENV):
+        with patch("psycopg.connect"):
+            from fastapi.testclient import TestClient
+
+            with TestClient(app) as c:
+                yield c
+
+
+@pytest.fixture(autouse=True)
+def reset_modal():
+    """Reset the modal stub between tests so call counts don't bleed over."""
+    MODAL_STUB.reset_mock()
+
+
+def test_ingest_returns_202(client):
+    mock_fn = MagicMock()
+    MODAL_STUB.Function.lookup.return_value = mock_fn
+
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "AAPL"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert body["ticker"] == "AAPL"
+    mock_fn.spawn.assert_called_once_with("AAPL")
+
+
+def test_ingest_uppercases_ticker(client):
+    mock_fn = MagicMock()
+    MODAL_STUB.Function.lookup.return_value = mock_fn
+
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "aapl"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    assert resp.status_code == 202
+    assert resp.json()["ticker"] == "AAPL"
+    mock_fn.spawn.assert_called_once_with("AAPL")
+
+
+def test_ingest_missing_token_returns_403(client):
+    resp = client.post("/admin/ingest", json={"ticker": "AAPL"})
+    assert resp.status_code == 403
+
+
+def test_ingest_wrong_token_returns_403(client):
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "AAPL"},
+        headers={"X-Admin-Token": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+def test_ingest_missing_ticker_returns_422(client):
+    resp = client.post(
+        "/admin/ingest",
+        json={},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_invalid_ticker_too_short_returns_422(client):
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "A"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_invalid_ticker_too_long_returns_422(client):
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "TOOLONG"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_invalid_ticker_non_alpha_returns_422(client):
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "AP1L"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+    assert resp.status_code == 422
+
+
+def test_ingest_looks_up_correct_modal_function(client):
+    mock_fn = MagicMock()
+    MODAL_STUB.Function.lookup.return_value = mock_fn
+
+    client.post(
+        "/admin/ingest",
+        json={"ticker": "MSFT"},
+        headers={"X-Admin-Token": "test-admin-token"},
+    )
+
+    MODAL_STUB.Function.lookup.assert_called_with("earnings-ingestion", "ingest_ticker")


### PR DESCRIPTION
## Summary

- Implements `POST /admin/ingest` in `api/routes/admin.py` — thin dispatcher to the Modal ingestion pipeline; returns 202 immediately, no blocking
- Ticker validated and uppercased before dispatch (regex `^[A-Z]{2,5}$`); 422 on malformed input
- Auth via the existing `verify_admin_token` dependency (403 if token missing or wrong)
- `modal` package added to `api/requirements.txt`
- Adds `dev.sh` — reads `api/.env` and `web/.env.local` directly, starts API + Next.js in parallel (`./dev.sh`) or individually (`./dev.sh api`, `./dev.sh web`); replaces the manual `source set_env.sh && uvicorn ...` workflow
- README local dev section rewritten to document the `.env` file approach and `dev.sh`

## Test plan

- [x] `pytest tests/unit/api/test_admin.py -v` — 9 tests pass (auth, all validation paths, dispatch, uppercase normalisation, Modal function lookup)
- [x] `pytest tests/unit/api/ -v` — all 28 API unit tests pass
- [ ] Smoke-test: `curl -X POST http://localhost:8000/admin/ingest -H "X-Admin-Token: $ADMIN_SECRET_TOKEN" -H "Content-Type: application/json" -d '{"ticker":"AAPL"}'` — verify 202 and Modal function triggered (requires Modal deployed)
- [ ] Verify `./dev.sh` starts both tiers cleanly from a fresh shell (no prior `source set_env.sh`)

Closes #124