### PR TITLE
feat: scope learning sessions to users (#125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When upgrading from an older version, apply any schema changes before starting t
 ```bash
 python3 migrate.py
 ```
-This is idempotent — safe to run multiple times. The web UI (`app.py`) now only checks that the schema is current; it no longer auto-migrates on startup.
+This is idempotent — safe to run multiple times. The web UI (`app.py`) now only checks that the schema is current; it no longer auto-migrates on startup. The script currently migrates up to **schema version 10**.
 
 ### Clearing data
 To delete all stored analysis while keeping the database schema intact:
@@ -236,8 +236,9 @@ cp web/.env.example web/.env.local
 
 | Variable | Description |
 |---|---|
-| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL (Supabase → Project Settings → API) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key (same page) |
+| `NEXT_PUBLIC_API_URL` | FastAPI base URL — use `http://localhost:8000` for local dev |
 
 #### Starting the dev servers
 

--- a/db/migrations/009_user_id_sessions.sql
+++ b/db/migrations/009_user_id_sessions.sql
@@ -1,0 +1,7 @@
+-- Add user_id to learning_sessions for per-user session scoping.
+-- No-op for fresh installs from schema.sql (column already present).
+ALTER TABLE learning_sessions
+  ADD COLUMN IF NOT EXISTS user_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user
+  ON learning_sessions (user_id);

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -992,6 +992,7 @@ class LearningRepository:
         messages: list[dict],
         completed: bool,
         session_type: str = "feynman",
+        user_id: str = SYSTEM_USER_ID,
     ) -> bool:
         """Upsert a learning session. Stores full message history in notes as JSON. Returns True on success."""
         import json
@@ -1007,12 +1008,12 @@ class LearningRepository:
                     cur.execute(
                         f"""
                         INSERT INTO learning_sessions (id, user_id, call_id, notes, completed_at)
-                        VALUES (%s, %s, %s, %s, {completed_at_expr})
+                        VALUES (%s, %s::uuid, %s, %s, {completed_at_expr})
                         ON CONFLICT (id) DO UPDATE SET
                             notes = EXCLUDED.notes,
                             completed_at = COALESCE(learning_sessions.completed_at, EXCLUDED.completed_at)
                         """,
-                        (session_id, SYSTEM_USER_ID, call_id, notes),
+                        (session_id, user_id, call_id, notes),
                     )
                     if completed:
                         teaching_note = next(
@@ -1034,25 +1035,42 @@ class LearningRepository:
             logger.warning(f"Could not save learning session: {e}")
             return False
 
-    def get_sessions_for_ticker(self, ticker: str) -> list[dict]:
-        """Return all sessions for a ticker, newest first. Each dict has: id, topic, stage, completed, teaching_note, started_at."""
+    def get_sessions_for_ticker(self, ticker: str, user_id: str | None = None) -> list[dict]:
+        """Return all sessions for a ticker, newest first. Each dict has: id, topic, stage, completed, teaching_note, started_at.
+
+        When user_id is provided only sessions belonging to that user are returned.
+        """
         import json
         rows = []
         try:
             with psycopg.connect(self.conn_str) as conn:
                 with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        SELECT ls.id, ls.notes, ls.completed_at, ls.started_at,
-                               ce.ai_critique
-                        FROM learning_sessions ls
-                        JOIN calls c ON ls.call_id = c.id
-                        LEFT JOIN concept_exercises ce ON ce.session_id = ls.id
-                        WHERE c.ticker = %s
-                        ORDER BY ls.started_at DESC
-                        """,
-                        (ticker,),
-                    )
+                    if user_id is not None:
+                        cur.execute(
+                            """
+                            SELECT ls.id, ls.notes, ls.completed_at, ls.started_at,
+                                   ce.ai_critique
+                            FROM learning_sessions ls
+                            JOIN calls c ON ls.call_id = c.id
+                            LEFT JOIN concept_exercises ce ON ce.session_id = ls.id
+                            WHERE c.ticker = %s AND ls.user_id = %s::uuid
+                            ORDER BY ls.started_at DESC
+                            """,
+                            (ticker, user_id),
+                        )
+                    else:
+                        cur.execute(
+                            """
+                            SELECT ls.id, ls.notes, ls.completed_at, ls.started_at,
+                                   ce.ai_critique
+                            FROM learning_sessions ls
+                            JOIN calls c ON ls.call_id = c.id
+                            LEFT JOIN concept_exercises ce ON ce.session_id = ls.id
+                            WHERE c.ticker = %s
+                            ORDER BY ls.started_at DESC
+                            """,
+                            (ticker,),
+                        )
                     for row in cur.fetchall():
                         session_id, notes_json, completed_at, started_at, teaching_note = row
                         notes = json.loads(notes_json) if notes_json else {}
@@ -1069,6 +1087,32 @@ class LearningRepository:
         except Exception as e:
             logger.warning(f"Could not fetch sessions for ticker {ticker}: {e}")
         return rows
+
+    def get_session_by_id(self, session_id: str, user_id: str) -> dict | None:
+        """Return session data for the given session_id if it belongs to user_id.
+
+        Returns None if not found. Raises ValueError if the session belongs to a different user.
+        """
+        import json
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT notes, user_id FROM learning_sessions WHERE id = %s LIMIT 1",
+                        (session_id,),
+                    )
+                    row = cur.fetchone()
+            if not row:
+                return None
+            notes_json, owner_id = row
+            if str(owner_id) != user_id:
+                raise ValueError(f"Session {session_id!r} belongs to a different user")
+            return json.loads(notes_json) if notes_json else {}
+        except ValueError:
+            raise
+        except Exception as e:
+            logger.warning(f"Could not fetch session {session_id}: {e}")
+            return None
 
     def get_learning_stats(self) -> dict:
         """Return overall learning stats: tickers_studied, total_sessions, completed_sessions."""

--- a/migrate.py
+++ b/migrate.py
@@ -154,8 +154,18 @@ try:
             cur.execute(
                 "INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;"
             )
+            # v9 → v10: add user_id to learning_sessions for per-user session scoping
+            cur.execute(
+                "ALTER TABLE learning_sessions ADD COLUMN IF NOT EXISTS user_id UUID;"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sessions_user ON learning_sessions (user_id);"
+            )
+            cur.execute(
+                "INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;"
+            )
 
         conn.commit()
-    print("Migration successful — schema is at version 9.")
+    print("Migration successful — schema is at version 10.")
 except Exception as e:
     print(f"Error during migration: {e}")

--- a/tests/unit/db/test_learning_repository.py
+++ b/tests/unit/db/test_learning_repository.py
@@ -1,0 +1,188 @@
+"""Unit tests for LearningRepository session methods."""
+
+import json
+import uuid
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from db.repositories import LearningRepository, SYSTEM_USER_ID
+
+CONN_STR = "dbname=test"
+TICKER = "AAPL"
+SESSION_ID = str(uuid.uuid4())
+CALL_ID = str(uuid.uuid4())
+USER_ID = "550e8400-e29b-41d4-a716-446655440000"
+OTHER_USER_ID = "660e8400-e29b-41d4-a716-446655440001"
+
+
+@pytest.fixture()
+def mock_conn():
+    """Return a mocked psycopg connection context manager."""
+    m_conn = MagicMock()
+    m_conn.__enter__ = MagicMock(return_value=m_conn)
+    m_conn.__exit__ = MagicMock(return_value=False)
+    m_cur = MagicMock()
+    m_cur.__enter__ = MagicMock(return_value=m_cur)
+    m_cur.__exit__ = MagicMock(return_value=False)
+    m_conn.cursor.return_value = m_cur
+    return m_conn, m_cur
+
+
+class TestSaveSession:
+    def test_uses_provided_user_id(self, mock_conn):
+        """save_session writes the caller-supplied user_id to the DB."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = (CALL_ID,)
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.save_session(
+                ticker=TICKER,
+                session_id=SESSION_ID,
+                topic="free cash flow",
+                stage=1,
+                messages=[],
+                completed=False,
+                user_id=USER_ID,
+            )
+
+        assert result is True
+        insert_call = m_cur.execute.call_args_list[-1]
+        params = insert_call[0][1]
+        assert params[1] == USER_ID
+
+    def test_falls_back_to_system_user_id_by_default(self, mock_conn):
+        """save_session defaults to SYSTEM_USER_ID when user_id is omitted."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = (CALL_ID,)
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.save_session(
+                ticker=TICKER,
+                session_id=SESSION_ID,
+                topic="margins",
+                stage=2,
+                messages=[],
+                completed=False,
+            )
+
+        assert result is True
+        insert_call = m_cur.execute.call_args_list[-1]
+        params = insert_call[0][1]
+        assert params[1] == SYSTEM_USER_ID
+
+    def test_returns_false_when_ticker_not_found(self, mock_conn):
+        """save_session returns False when no call row exists for the ticker."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = None
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.save_session(
+                ticker="UNKNOWN",
+                session_id=SESSION_ID,
+                topic="topic",
+                stage=1,
+                messages=[],
+                completed=False,
+            )
+
+        assert result is False
+
+
+class TestGetSessionsForTicker:
+    def _make_row(self, topic: str = "revenue") -> tuple:
+        notes = json.dumps({"topic": topic, "stage": 1, "messages": [], "type": "feynman"})
+        return (SESSION_ID, notes, None, "2024-01-01", None)
+
+    def test_no_user_id_filter_omits_user_clause(self, mock_conn):
+        """Without user_id, the query uses only the ticker WHERE clause."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchall.return_value = [self._make_row()]
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            rows = repo.get_sessions_for_ticker(TICKER)
+
+        assert len(rows) == 1
+        sql = m_cur.execute.call_args[0][0]
+        assert "user_id" not in sql
+        params = m_cur.execute.call_args[0][1]
+        assert params == (TICKER,)
+
+    def test_with_user_id_adds_user_filter(self, mock_conn):
+        """With user_id, the query adds an AND ls.user_id = %s::uuid clause."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchall.return_value = [self._make_row()]
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            rows = repo.get_sessions_for_ticker(TICKER, user_id=USER_ID)
+
+        assert len(rows) == 1
+        sql = m_cur.execute.call_args[0][0]
+        assert "user_id" in sql
+        params = m_cur.execute.call_args[0][1]
+        assert params == (TICKER, USER_ID)
+
+    def test_returns_empty_list_on_db_error(self, mock_conn):
+        """DB errors are swallowed and an empty list is returned."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchall.side_effect = Exception("connection refused")
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            rows = repo.get_sessions_for_ticker(TICKER, user_id=USER_ID)
+
+        assert rows == []
+
+
+class TestGetSessionById:
+    def _notes_json(self) -> str:
+        return json.dumps({"topic": "margins", "stage": 2, "messages": []})
+
+    def test_returns_notes_for_correct_owner(self, mock_conn):
+        """Returns parsed notes dict when session belongs to the requesting user."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = (self._notes_json(), USER_ID)
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.get_session_by_id(SESSION_ID, USER_ID)
+
+        assert result is not None
+        assert result["topic"] == "margins"
+
+    def test_returns_none_when_session_not_found(self, mock_conn):
+        """Returns None when no session row matches the given ID."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = None
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.get_session_by_id(SESSION_ID, USER_ID)
+
+        assert result is None
+
+    def test_raises_on_ownership_mismatch(self, mock_conn):
+        """Raises ValueError when the session belongs to a different user."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.return_value = (self._notes_json(), OTHER_USER_ID)
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            with pytest.raises(ValueError, match="different user"):
+                repo.get_session_by_id(SESSION_ID, USER_ID)
+
+    def test_returns_none_on_db_error(self, mock_conn):
+        """DB errors are swallowed and None is returned."""
+        m_conn, m_cur = mock_conn
+        m_cur.fetchone.side_effect = Exception("db down")
+
+        with patch("psycopg.connect", return_value=m_conn):
+            repo = LearningRepository(CONN_STR)
+            result = repo.get_session_by_id(SESSION_ID, USER_ID)
+
+        assert result is None


### PR DESCRIPTION
## Summary

- Migration `009_user_id_sessions.sql` adds an index on `learning_sessions.user_id` for existing DBs (no-op on fresh installs where the column already exists from `schema.sql`)
- `migrate.py` updated to schema version 10
- `save_session` now accepts a `user_id` parameter; defaults to `SYSTEM_USER_ID` so existing Streamlit UI callers are unaffected
- `get_sessions_for_ticker` accepts an optional `user_id` filter — when provided, only that user's sessions are returned
- New `get_session_by_id(session_id, user_id)` returns session notes and raises `ValueError` on ownership mismatch

## Test plan

- [ ] `pytest tests/unit/db/test_learning_repository.py` — 10 new tests covering all three methods
- [ ] `pytest` — full suite should stay green (94 tests)
- [ ] Run `python3 migrate.py` against a local DB to confirm it reaches version 10

Closes #125