### PR TITLE
refactor: make migrate.py a file-based runner (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ When upgrading from an older version, apply any schema changes before starting t
 ```bash
 python3 migrate.py
 ```
-This is idempotent — safe to run multiple times. The web UI (`app.py`) now only checks that the schema is current; it no longer auto-migrates on startup. The script currently migrates up to **schema version 10**.
+This is idempotent — safe to run multiple times. The web UI (`app.py`) now only checks that the schema is current; it no longer auto-migrates on startup. Migration files live in `db/migrations/` as `NNN_name.sql`; add a new file there to introduce future schema changes.
 
 ### Clearing data
 To delete all stored analysis while keeping the database schema intact:

--- a/db/migrations/001_explanation.sql
+++ b/db/migrations/001_explanation.sql
@@ -1,0 +1,4 @@
+-- Migration 001: Add contextual explanation column to extracted_terms
+ALTER TABLE extracted_terms ADD COLUMN IF NOT EXISTS explanation TEXT DEFAULT '';
+
+INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;

--- a/db/migrations/002_add_industry_to_calls.sql
+++ b/db/migrations/002_add_industry_to_calls.sql
@@ -1,3 +1,0 @@
--- Migration 002: Add industry column to calls table
-ALTER TABLE calls ADD COLUMN IF NOT EXISTS industry TEXT;
-INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;

--- a/db/migrations/002_competitors.sql
+++ b/db/migrations/002_competitors.sql
@@ -1,0 +1,15 @@
+-- Migration 002: Add competitors table
+CREATE TABLE IF NOT EXISTS competitors (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    call_id                 UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
+    competitor_name         TEXT NOT NULL,
+    competitor_ticker       TEXT,
+    description             TEXT,
+    mentioned_in_transcript BOOLEAN NOT NULL DEFAULT FALSE,
+    fetched_at              TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (call_id, competitor_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_competitors_call ON competitors(call_id);
+
+INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;

--- a/db/migrations/003_strategic_shifts_array.sql
+++ b/db/migrations/003_strategic_shifts_array.sql
@@ -1,5 +1,17 @@
 -- Migration 003: Convert strategic_shifts from TEXT to TEXT[]
-ALTER TABLE call_synthesis
-    ALTER COLUMN strategic_shifts TYPE TEXT[]
-    USING ARRAY[strategic_shifts];
-INSERT INTO schema_version (version) VALUES (4) ON CONFLICT DO NOTHING;
+-- Guarded: no-op if the column is already TEXT[] or JSONB[].
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'call_synthesis'
+          AND column_name = 'strategic_shifts'
+          AND data_type = 'text'
+    ) THEN
+        ALTER TABLE call_synthesis
+            ALTER COLUMN strategic_shifts TYPE TEXT[]
+            USING ARRAY[strategic_shifts];
+    END IF;
+END $$;
+
+INSERT INTO schema_version (version) VALUES (3) ON CONFLICT DO NOTHING;

--- a/db/migrations/004_evasion_analysis_qa_fields.sql
+++ b/db/migrations/004_evasion_analysis_qa_fields.sql
@@ -4,4 +4,4 @@ ALTER TABLE evasion_analysis
     ADD COLUMN IF NOT EXISTS question_topic TEXT,
     ADD COLUMN IF NOT EXISTS question_text  TEXT,
     ADD COLUMN IF NOT EXISTS answer_text    TEXT;
-INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (4) ON CONFLICT DO NOTHING;

--- a/db/migrations/005_call_summary.sql
+++ b/db/migrations/005_call_summary.sql
@@ -1,3 +1,3 @@
 -- Migration 005: Add call_summary to call_synthesis
 ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS call_summary TEXT;
-INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;

--- a/db/migrations/006_strategic_shifts_jsonb.sql
+++ b/db/migrations/006_strategic_shifts_jsonb.sql
@@ -1,22 +1,39 @@
 -- Migration 006: Convert strategic_shifts from TEXT[] to JSONB[]
--- PostgreSQL does not allow subqueries in ALTER COLUMN TYPE ... USING,
--- so we add a new column, populate it via UPDATE, then rename.
-ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS strategic_shifts_new JSONB[] DEFAULT '{}';
+-- Guarded: no-op if the column is already JSONB[].
+-- Uses a new-column + UPDATE + rename approach because PostgreSQL does not
+-- allow subqueries in ALTER COLUMN TYPE ... USING.
+DO $$
+DECLARE
+    col_type TEXT;
+BEGIN
+    SELECT udt_name INTO col_type
+    FROM information_schema.columns
+    WHERE table_name = 'call_synthesis' AND column_name = 'strategic_shifts';
 
-UPDATE call_synthesis
-SET strategic_shifts_new = (
-    SELECT array_agg(
-        jsonb_build_object(
-            'prior_position', '',
-            'current_position', s,
-            'investor_significance', ''
+    IF col_type = '_jsonb' THEN
+        RETURN; -- Already migrated
+    END IF;
+
+    ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS strategic_shifts_new JSONB[] DEFAULT '{}';
+
+    IF col_type = '_text' THEN
+        UPDATE call_synthesis
+        SET strategic_shifts_new = (
+            SELECT array_agg(
+                jsonb_build_object(
+                    'prior_position', '',
+                    'current_position', s,
+                    'investor_significance', ''
+                )
+            )
+            FROM unnest(strategic_shifts) AS s
         )
-    )
-    FROM unnest(strategic_shifts) AS s
-)
-WHERE strategic_shifts IS NOT NULL AND array_length(strategic_shifts, 1) > 0;
+        WHERE strategic_shifts IS NOT NULL AND array_length(strategic_shifts, 1) > 0;
 
-ALTER TABLE call_synthesis DROP COLUMN strategic_shifts;
-ALTER TABLE call_synthesis RENAME COLUMN strategic_shifts_new TO strategic_shifts;
+        ALTER TABLE call_synthesis DROP COLUMN strategic_shifts;
+    END IF;
 
-INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;
+    ALTER TABLE call_synthesis RENAME COLUMN strategic_shifts_new TO strategic_shifts;
+END $$;
+
+INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;

--- a/db/migrations/007_transcript_progress.sql
+++ b/db/migrations/007_transcript_progress.sql
@@ -9,4 +9,4 @@ CREATE TABLE IF NOT EXISTS transcript_progress (
 
 CREATE INDEX IF NOT EXISTS idx_transcript_progress_call ON transcript_progress(call_id);
 
-INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;

--- a/db/migrations/008_topic_name.sql
+++ b/db/migrations/008_topic_name.sql
@@ -1,4 +1,4 @@
 -- Migration 008: Add topic_name column to call_topics for Haiku NLP synthesis
 ALTER TABLE call_topics ADD COLUMN IF NOT EXISTS topic_name TEXT DEFAULT '';
 
-INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;
+INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;

--- a/db/migrations/009_user_id_sessions.sql
+++ b/db/migrations/009_user_id_sessions.sql
@@ -1,7 +1,9 @@
--- Add user_id to learning_sessions for per-user session scoping.
+-- Migration 009: Add user_id to learning_sessions for per-user session scoping.
 -- No-op for fresh installs from schema.sql (column already present).
 ALTER TABLE learning_sessions
   ADD COLUMN IF NOT EXISTS user_id UUID;
 
 CREATE INDEX IF NOT EXISTS idx_sessions_user
   ON learning_sessions (user_id);
+
+INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;

--- a/migrate.py
+++ b/migrate.py
@@ -1,171 +1,130 @@
-"""Database migration script. Run this before starting the app."""
+"""Database migration runner.
+
+Run before starting the app:
+    python3 migrate.py
+
+Migration files live in db/migrations/ as NNN_name.sql, where NNN is the
+integer version number. The runner applies every file whose version is not yet
+recorded in the schema_version table, in ascending order.
+
+The .sql files are the single source of truth. Each file is self-contained:
+it performs the schema change and ends with an INSERT into schema_version so
+that both this runner and manual runs (e.g. via the Supabase SQL Editor) keep
+the version table in sync.
+"""
 import os
+import re
+import sys
+from pathlib import Path
+
 import psycopg
 
-conn_str = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
+MIGRATIONS_DIR = Path(__file__).parent / "db" / "migrations"
+_CONN_STR = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
 
-try:
+
+def _split_statements(sql: str) -> list[str]:
+    """Split a SQL script into individual statements.
+
+    Handles dollar-quoted blocks (DO $$ ... $$) by tracking open/close tags
+    so that semicolons inside those blocks are not treated as statement ends.
+    Only $$ (anonymous dollar-quoting) is supported — sufficient for our files.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    in_dollar_quote = False
+    i = 0
+
+    while i < len(sql):
+        if sql[i : i + 2] == "$$":
+            in_dollar_quote = not in_dollar_quote
+            buf.append("$$")
+            i += 2
+            continue
+
+        if not in_dollar_quote and sql[i] == ";":
+            buf.append(";")
+            stmt = "".join(buf).strip()
+            # Strip comment-only statements
+            non_comment = "\n".join(
+                line for line in stmt.splitlines() if not line.strip().startswith("--")
+            ).strip()
+            if non_comment.rstrip(";").strip():
+                statements.append(stmt)
+            buf = []
+        else:
+            buf.append(sql[i])
+
+        i += 1
+
+    # Trailing content without a final semicolon
+    remaining = "".join(buf).strip()
+    if remaining:
+        non_comment = "\n".join(
+            line for line in remaining.splitlines() if not line.strip().startswith("--")
+        ).strip()
+        if non_comment:
+            statements.append(remaining)
+
+    return statements
+
+
+def run(conn_str: str = _CONN_STR) -> None:
+    """Apply all pending migrations and print a summary."""
     with psycopg.connect(conn_str) as conn:
         with conn.cursor() as cur:
-            # Ensure schema_version table exists
+            # Bootstrap: create schema_version if it doesn't exist yet.
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS schema_version (
                     version      INTEGER PRIMARY KEY,
                     installed_at TIMESTAMPTZ DEFAULT now()
                 );
             """)
-
-            # v1 → v2: add explanation column to extracted_terms
-            cur.execute(
-                "ALTER TABLE extracted_terms ADD COLUMN IF NOT EXISTS explanation TEXT DEFAULT '';"
-            )
-
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;"
-            )
-
-            # v2 → v3: add competitors table
-            cur.execute("""
-                CREATE TABLE IF NOT EXISTS competitors (
-                    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                    call_id                 UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
-                    competitor_name         TEXT NOT NULL,
-                    competitor_ticker       TEXT,
-                    description             TEXT,
-                    mentioned_in_transcript BOOLEAN NOT NULL DEFAULT FALSE,
-                    fetched_at              TIMESTAMPTZ DEFAULT now(),
-                    UNIQUE (call_id, competitor_name)
-                );
-            """)
-            cur.execute(
-                "CREATE INDEX IF NOT EXISTS idx_competitors_call ON competitors(call_id);"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (3) ON CONFLICT DO NOTHING;"
-            )
-
-            # v3 → v4: convert strategic_shifts from TEXT to TEXT[]
-            cur.execute(
-                """
-                ALTER TABLE call_synthesis
-                    ALTER COLUMN strategic_shifts TYPE TEXT[]
-                    USING ARRAY[strategic_shifts];
-                """
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (4) ON CONFLICT DO NOTHING;"
-            )
-            # v4 → v5: add structured Q&A fields to evasion_analysis
-            cur.execute(
-                "ALTER TABLE evasion_analysis ADD COLUMN IF NOT EXISTS analyst_name TEXT;"
-            )
-            cur.execute(
-                "ALTER TABLE evasion_analysis ADD COLUMN IF NOT EXISTS question_topic TEXT;"
-            )
-            cur.execute(
-                "ALTER TABLE evasion_analysis ADD COLUMN IF NOT EXISTS question_text TEXT;"
-            )
-            cur.execute(
-                "ALTER TABLE evasion_analysis ADD COLUMN IF NOT EXISTS answer_text TEXT;"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (5) ON CONFLICT DO NOTHING;"
-            )
-
-            # v5 → v6: add call_summary to call_synthesis
-            cur.execute(
-                "ALTER TABLE call_synthesis ADD COLUMN IF NOT EXISTS call_summary TEXT;"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (6) ON CONFLICT DO NOTHING;"
-            )
-
-            # v6 → v7: convert strategic_shifts from TEXT[] to JSONB[]
-            # Uses a new-column+UPDATE+rename approach because PostgreSQL does not
-            # allow subqueries in ALTER COLUMN TYPE ... USING.
-            # The block is written to be safe to re-run after a partial failure:
-            #   - inspect actual column state before each step
-            #   - only execute steps that have not already completed
-            cur.execute("""
-                SELECT column_name, udt_name
-                FROM information_schema.columns
-                WHERE table_name = 'call_synthesis'
-                  AND column_name IN ('strategic_shifts', 'strategic_shifts_new')
-            """)
-            existing = {row[0]: row[1] for row in cur.fetchall()}
-
-            shifts_type = existing.get("strategic_shifts")        # '_text', '_jsonb', or None
-            shifts_new_exists = "strategic_shifts_new" in existing
-
-            if shifts_type == "_jsonb":
-                # Already migrated — nothing to do
-                pass
-            else:
-                if not shifts_new_exists:
-                    cur.execute(
-                        "ALTER TABLE call_synthesis ADD COLUMN strategic_shifts_new JSONB[] DEFAULT '{}';"
-                    )
-                if shifts_type == "_text":
-                    # Populate from the TEXT[] column
-                    cur.execute(
-                        """
-                        UPDATE call_synthesis
-                        SET strategic_shifts_new = (
-                            SELECT array_agg(
-                                jsonb_build_object(
-                                    'prior_position', '',
-                                    'current_position', s,
-                                    'investor_significance', ''
-                                )
-                            )
-                            FROM unnest(strategic_shifts) AS s
-                        )
-                        WHERE strategic_shifts IS NOT NULL
-                          AND array_length(strategic_shifts, 1) > 0;
-                        """
-                    )
-                    cur.execute("ALTER TABLE call_synthesis DROP COLUMN strategic_shifts;")
-                cur.execute(
-                    "ALTER TABLE call_synthesis RENAME COLUMN strategic_shifts_new TO strategic_shifts;"
-                )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (7) ON CONFLICT DO NOTHING;"
-            )
-            # v7 → v8: add transcript_progress table for per-step completion tracking
-            cur.execute("""
-                CREATE TABLE IF NOT EXISTS transcript_progress (
-                    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                    call_id     UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE,
-                    step_number INTEGER NOT NULL CHECK (step_number BETWEEN 1 AND 6),
-                    viewed_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
-                    UNIQUE (call_id, step_number)
-                );
-            """)
-            cur.execute(
-                "CREATE INDEX IF NOT EXISTS idx_transcript_progress_call ON transcript_progress(call_id);"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (8) ON CONFLICT DO NOTHING;"
-            )
-            # v8 → v9: add topic_name column to call_topics for Haiku NLP synthesis
-            cur.execute(
-                "ALTER TABLE call_topics ADD COLUMN IF NOT EXISTS topic_name TEXT DEFAULT '';"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (9) ON CONFLICT DO NOTHING;"
-            )
-            # v9 → v10: add user_id to learning_sessions for per-user session scoping
-            cur.execute(
-                "ALTER TABLE learning_sessions ADD COLUMN IF NOT EXISTS user_id UUID;"
-            )
-            cur.execute(
-                "CREATE INDEX IF NOT EXISTS idx_sessions_user ON learning_sessions (user_id);"
-            )
-            cur.execute(
-                "INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;"
-            )
-
         conn.commit()
-    print("Migration successful — schema is at version 10.")
-except Exception as e:
-    print(f"Error during migration: {e}")
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT version FROM schema_version")
+            applied: set[int] = {row[0] for row in cur.fetchall()}
+
+        # Discover migration files sorted by their numeric prefix.
+        pattern = re.compile(r"^(\d+)_.+\.sql$")
+        migration_files = sorted(
+            (f for f in MIGRATIONS_DIR.iterdir() if pattern.match(f.name)),
+            key=lambda f: int(pattern.match(f.name).group(1)),
+        )
+
+        pending = [
+            f for f in migration_files
+            if int(pattern.match(f.name).group(1)) not in applied
+        ]
+
+        if not pending:
+            print("No migrations to apply — schema is up to date.")
+            return
+
+        applied_count = 0
+        for sql_file in pending:
+            version = int(pattern.match(sql_file.name).group(1))
+            sql = sql_file.read_text(encoding="utf-8")
+            statements = _split_statements(sql)
+            try:
+                with conn.cursor() as cur:
+                    for stmt in statements:
+                        cur.execute(stmt)
+                conn.commit()
+                print(f"  Applied {sql_file.name}")
+                applied_count += 1
+            except Exception as exc:
+                conn.rollback()
+                print(f"  ERROR applying {sql_file.name}: {exc}", file=sys.stderr)
+                raise
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT MAX(version) FROM schema_version")
+            final_version = cur.fetchone()[0]
+
+        print(f"Migration complete — {applied_count} file(s) applied, schema is at version {final_version}.")
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/unit/test_migrate.py
+++ b/tests/unit/test_migrate.py
@@ -1,0 +1,190 @@
+"""Unit tests for the migrate.py file-based runner."""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_migrate():
+    """Import migrate.py from the project root, bypassing any cached version."""
+    project_root = Path(__file__).parent.parent.parent
+    spec = importlib.util.spec_from_file_location("migrate", project_root / "migrate.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+migrate = _load_migrate()
+split_statements = migrate._split_statements
+
+
+# ---------------------------------------------------------------------------
+# _split_statements
+# ---------------------------------------------------------------------------
+
+class TestSplitStatements:
+    def test_single_statement(self):
+        sql = "ALTER TABLE foo ADD COLUMN bar TEXT;"
+        result = split_statements(sql)
+        assert result == ["ALTER TABLE foo ADD COLUMN bar TEXT;"]
+
+    def test_multiple_statements(self):
+        sql = (
+            "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+            "CREATE INDEX IF NOT EXISTS idx_foo ON foo (bar);\n"
+            "INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;\n"
+        )
+        result = split_statements(sql)
+        assert len(result) == 3
+
+    def test_dollar_quote_block_preserved(self):
+        sql = """\
+DO $$
+BEGIN
+    IF true THEN
+        ALTER TABLE foo ADD COLUMN baz INT;
+    END IF;
+END $$;
+
+INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;
+"""
+        result = split_statements(sql)
+        # The DO block is one statement; the INSERT is another.
+        assert len(result) == 2
+        assert result[0].startswith("DO $$")
+        assert "schema_version" in result[1]
+
+    def test_semicolons_inside_dollar_quote_not_split(self):
+        sql = "DO $$\nBEGIN\n  RETURN;\nEND $$;\n"
+        result = split_statements(sql)
+        assert len(result) == 1
+
+    def test_comment_only_lines_ignored(self):
+        sql = "-- just a comment\n\nALTER TABLE foo ADD COLUMN bar TEXT;\n"
+        result = split_statements(sql)
+        assert len(result) == 1
+
+    def test_empty_input(self):
+        assert split_statements("") == []
+
+    def test_only_comments(self):
+        sql = "-- Migration 001: something\n-- another comment\n"
+        assert split_statements(sql) == []
+
+
+# ---------------------------------------------------------------------------
+# run() — migration runner
+# ---------------------------------------------------------------------------
+
+class TestRun:
+    """Tests for migrate.run() with a mocked psycopg connection."""
+
+    def _make_mock_conn(self, applied_versions: set[int]):
+        """Build a mock psycopg connection with schema_version pre-populated."""
+        m_conn = MagicMock()
+        m_conn.__enter__ = MagicMock(return_value=m_conn)
+        m_conn.__exit__ = MagicMock(return_value=False)
+
+        m_cur = MagicMock()
+        m_cur.__enter__ = MagicMock(return_value=m_cur)
+        m_cur.__exit__ = MagicMock(return_value=False)
+        m_conn.cursor.return_value = m_cur
+
+        # fetchall returns rows for applied versions; fetchone returns max version
+        m_cur.fetchall.return_value = [(v,) for v in applied_versions]
+        max_v = max(applied_versions) if applied_versions else 0
+        m_cur.fetchone.return_value = (max_v,)
+
+        return m_conn, m_cur
+
+    def test_no_pending_migrations_prints_up_to_date(self, tmp_path, capsys):
+        """When all file versions are already applied, runner prints 'up to date'."""
+        sql_file = tmp_path / "001_test.sql"
+        sql_file.write_text(
+            "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+            "INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;\n"
+        )
+
+        m_conn, m_cur = self._make_mock_conn(applied_versions={1})
+
+        with (
+            patch("psycopg.connect", return_value=m_conn),
+            patch.object(migrate, "MIGRATIONS_DIR", tmp_path),
+        ):
+            migrate.run("fake_conn")
+
+        captured = capsys.readouterr()
+        assert "up to date" in captured.out
+
+    def test_pending_migration_is_executed(self, tmp_path, capsys):
+        """A file whose version is not in schema_version is executed."""
+        sql_file = tmp_path / "001_test.sql"
+        sql_file.write_text(
+            "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+            "INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;\n"
+        )
+
+        m_conn, m_cur = self._make_mock_conn(applied_versions=set())
+        m_cur.fetchone.return_value = (1,)
+
+        with (
+            patch("psycopg.connect", return_value=m_conn),
+            patch.object(migrate, "MIGRATIONS_DIR", tmp_path),
+        ):
+            migrate.run("fake_conn")
+
+        captured = capsys.readouterr()
+        assert "001_test.sql" in captured.out
+        assert "Applied" in captured.out
+
+    def test_already_applied_files_are_skipped(self, tmp_path, capsys):
+        """Files whose version is already in schema_version are not re-executed."""
+        (tmp_path / "001_a.sql").write_text(
+            "ALTER TABLE a ADD COLUMN x TEXT;\n"
+            "INSERT INTO schema_version (version) VALUES (1) ON CONFLICT DO NOTHING;\n"
+        )
+        (tmp_path / "002_b.sql").write_text(
+            "ALTER TABLE b ADD COLUMN y TEXT;\n"
+            "INSERT INTO schema_version (version) VALUES (2) ON CONFLICT DO NOTHING;\n"
+        )
+
+        # Only version 1 is applied; version 2 should run.
+        m_conn, m_cur = self._make_mock_conn(applied_versions={1})
+        m_cur.fetchone.return_value = (2,)
+
+        with (
+            patch("psycopg.connect", return_value=m_conn),
+            patch.object(migrate, "MIGRATIONS_DIR", tmp_path),
+        ):
+            migrate.run("fake_conn")
+
+        captured = capsys.readouterr()
+        assert "001_a.sql" not in captured.out
+        assert "002_b.sql" in captured.out
+
+    def test_failed_migration_rolls_back(self, tmp_path):
+        """If a migration raises, rollback is called and the error propagates."""
+        sql_file = tmp_path / "001_bad.sql"
+        sql_file.write_text("ALTER TABLE nonexistent ADD COLUMN x TEXT;\n")
+
+        m_conn, m_cur = self._make_mock_conn(applied_versions=set())
+        # execute calls in order: (1) CREATE TABLE schema_version bootstrap,
+        # (2) SELECT version FROM schema_version, (3) the migration statement.
+        m_cur.execute.side_effect = [None, None, Exception("relation does not exist")]
+
+        with (
+            patch("psycopg.connect", return_value=m_conn),
+            patch.object(migrate, "MIGRATIONS_DIR", tmp_path),
+        ):
+            with pytest.raises(Exception, match="relation does not exist"):
+                migrate.run("fake_conn")
+
+        m_conn.rollback.assert_called_once()


### PR DESCRIPTION
## Summary

- `migrate.py` is now a thin runner — no inline SQL. It discovers and applies files from `db/migrations/` in numeric order, tracking applied versions in `schema_version`.
- `db/migrations/NNN_name.sql` files are the single source of truth. Each file is self-contained and ends with `INSERT INTO schema_version` so manual Supabase SQL Editor runs also update version tracking.
- `_split_statements()` handles multi-statement files including `DO $$ ... $$` dollar-quoted blocks.

## Migration file fixes

| File | Change |
|------|--------|
| `001_explanation.sql` | New — was only in `migrate.py` inline |
| `002_competitors.sql` | New — was only in `migrate.py` inline |
| `002_add_industry_to_calls.sql` | Deleted — orphan; column already in `schema.sql` |
| `003_strategic_shifts_array.sql` | Fixed version 4→3; wrapped in `DO $$` guard |
| `004_evasion_analysis_qa_fields.sql` | Fixed version 5→4 |
| `005_call_summary.sql` | Fixed version 6→5 |
| `006_strategic_shifts_jsonb.sql` | Fixed version 7→6; wrapped in `DO $$` guard |
| `007_transcript_progress.sql` | Fixed version 8→7 |
| `008_topic_name.sql` | Fixed version 9→8 |
| `009_user_id_sessions.sql` | Added missing `schema_version` insert (version 9) |

## Backward compatibility

- Existing local DBs that ran the old `migrate.py` have `schema_version` rows 1–10. The runner sees all files (001–009, versions 1–9) as already applied and is a no-op.
- Fresh installs from `schema.sql` have an empty `schema_version`. The runner applies all 9 files; `IF NOT EXISTS` / `DO $$` guards make every file safe to run against an up-to-date schema.

## Test plan

- [ ] `pytest tests/unit/test_migrate.py` — 11 tests (7 splitter, 4 runner)
- [ ] `pytest` — full suite should stay green (105 tests)
- [ ] `python3 migrate.py` against a local DB at v10 — should print "up to date"
- [ ] `python3 migrate.py` against a fresh DB (schema.sql applied, schema_version empty) — should apply 001–009

Closes #145