### PR TITLE
feat: Modal ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,27 @@ cp web/.env.example web/.env.local
 
 The script reads env vars from `api/.env` and `web/.env.local` directly — no need to source them manually.
 
-#### Modal ingestion pipeline (test run)
+#### Modal ingestion pipeline
+
+**One-time setup:**
+
+1. Authenticate: `modal setup` (opens browser)
+2. Create a custom secret named `earnings-secrets` in the [Modal dashboard](https://modal.com/secrets) with these keys:
+   - `DATABASE_URL`
+   - `API_NINJAS_KEY`
+   - `VOYAGE_API_KEY`
+   - `ANTHROPIC_API_KEY`
+
+**Test run** (executes in Modal cloud, streams logs locally):
 
 ```bash
 modal run pipeline/ingest.py --ticker AAPL
+```
+
+**Deploy** (required before the FastAPI admin endpoint can dispatch jobs):
+
+```bash
+modal deploy pipeline/ingest.py
 ```
 
 #### Verify the API is running
@@ -298,11 +315,11 @@ pytest tests/unit/api/ -v
 
 | Variable | Used by | Description |
 |---|---|---|
-| `API_NINJAS_KEY` | Legacy pipeline | API key for fetching raw transcripts ([api-ninjas.com](https://api-ninjas.com)) |
-| `VOYAGE_API_KEY` | Legacy pipeline, FastAPI `/search` | Voyage AI key for semantic embeddings ([voyageai.com](https://www.voyageai.com)) |
+| `API_NINJAS_KEY` | Modal pipeline, legacy pipeline | API key for fetching raw transcripts ([api-ninjas.com](https://api-ninjas.com)) |
+| `VOYAGE_API_KEY` | Modal pipeline, legacy pipeline, FastAPI `/search` | Voyage AI key for semantic embeddings ([voyageai.com](https://www.voyageai.com)) |
 | `PERPLEXITY_API_KEY` | Legacy pipeline | Perplexity key for Feynman learning chat ([perplexity.ai](https://www.perplexity.ai)) |
-| `ANTHROPIC_API_KEY` | Legacy pipeline | Anthropic key for the LLM ingestion pipeline ([console.anthropic.com](https://console.anthropic.com)) |
-| `DATABASE_URL` | Legacy pipeline, FastAPI | PostgreSQL connection string (default: `dbname=earnings_teacher`) |
+| `ANTHROPIC_API_KEY` | Modal pipeline, legacy pipeline | Anthropic key for the LLM ingestion pipeline ([console.anthropic.com](https://console.anthropic.com)) |
+| `DATABASE_URL` | Modal pipeline, legacy pipeline, FastAPI | PostgreSQL connection string (default: `dbname=earnings_teacher`) |
 | `SUPABASE_JWT_SECRET` | FastAPI | JWT secret — Supabase → Project Settings → API |
 | `ADMIN_SECRET_TOKEN` | FastAPI | Secret for admin-only routes — any strong random string |
 | `NEXT_PUBLIC_SUPABASE_URL` | Next.js frontend | Supabase project URL |

--- a/pipeline/ingest.py
+++ b/pipeline/ingest.py
@@ -1,10 +1,101 @@
-"""Modal ingestion pipeline — placeholder."""
+"""Modal ingestion pipeline — downloads and processes earnings transcripts."""
 
-# import modal
-#
-# app = modal.App("earnings-ingestion")
-#
-# @app.function(secrets=[modal.Secret.from_name("earnings-secrets")])
-# def ingest(ticker: str) -> None:
-#     """Download and ingest an earnings transcript for the given ticker."""
-#     pass
+import logging
+import os
+from pathlib import Path
+
+import modal
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Modal image — includes all core pipeline modules from the repo
+# ---------------------------------------------------------------------------
+
+# Kept inline (not in a separate file) so Modal evaluates this list locally
+# at image-build time without trying to read the file inside the container.
+_IGNORE = [
+    ".git/",
+    ".gitignore",
+    "__pycache__/",
+    "*.pyc",
+    "*.pyo",
+    ".venv/",
+    "*.egg-info/",
+    "tests/",
+    "coverage.xml",
+    ".coverage",
+    "transcripts/",
+    "transcript/",
+    "web/",
+    "node_modules/",
+    "docs/",
+    "ideation/",
+    "set_env.sh",
+    "set_env.sh.template",
+    "set_env.ps1.template",
+    "download_transcript.sh",
+    "reset_db.sh",
+    "dev.sh",
+    "*.md",
+    "test_query_out.txt",
+]
+
+_repo_root = Path(__file__).parent.parent
+
+_image = (
+    modal.Image.debian_slim(python_version="3.11")
+    .pip_install_from_requirements("pipeline/requirements.txt")
+    .env({"PYTHONPATH": "/root"})
+    .workdir("/root")
+    .add_local_dir(str(_repo_root), remote_path="/root", ignore=_IGNORE)
+)
+
+app = modal.App("earnings-ingestion", image=_image)
+
+
+# ---------------------------------------------------------------------------
+# Ingestion function
+# ---------------------------------------------------------------------------
+
+
+@app.function(
+    secrets=[modal.Secret.from_name("earnings-secrets")],
+    timeout=3600,
+)
+def ingest_ticker(ticker: str) -> None:
+    """Download and ingest an earnings transcript for the given ticker."""
+    import json
+
+    import httpx
+    from db.persistence import save_analysis
+    from services.orchestrator import analyze
+
+    ticker = ticker.upper()
+    logger.info("Starting ingestion for %s", ticker)
+
+    # 1. Download transcript JSON from API Ninjas
+    api_key = os.environ["API_NINJAS_KEY"]
+    url = f"https://api.api-ninjas.com/v1/earningstranscript?ticker={ticker}"
+    response = httpx.get(url, headers={"X-Api-Key": api_key}, timeout=60)
+    response.raise_for_status()
+
+    transcript_json = response.text
+    if not transcript_json or transcript_json.strip() in ("", "[]", "{}"):
+        raise ValueError(f"No transcript returned for ticker {ticker}")
+
+    # Validate it parses before writing
+    json.loads(transcript_json)
+
+    # 2. Write to ./transcripts/ — workdir is /root so this resolves correctly
+    os.makedirs("transcripts", exist_ok=True)
+    with open(f"transcripts/{ticker}.json", "w") as f:
+        f.write(transcript_json)
+
+    # 3. Run the full analysis pipeline
+    result = analyze(ticker)
+
+    # 4. Persist to Supabase
+    conn_str = os.environ["DATABASE_URL"]
+    save_analysis(conn_str, result)
+    logger.info("Ingestion complete for %s", ticker)

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,4 +1,7 @@
 modal>=0.64.0
+httpx>=0.27.0
 psycopg[binary]>=3.2.0
+pgvector>=0.3.0
+scikit-learn>=1.4
 voyageai>=0.3.0
 anthropic>=0.30.0


### PR DESCRIPTION
## Summary

- Implements `pipeline/ingest.py` — replaces the placeholder with a working Modal function (`ingest_ticker`) that downloads a transcript from API Ninjas, runs the full analysis pipeline, and persists results to Supabase
- Adds missing runtime dependencies to `pipeline/requirements.txt` (`httpx`, `pgvector`, `scikit-learn`)
- Expands README with Modal one-time setup, test run, and deploy instructions

## Test plan

- [ ] `modal setup` authenticated successfully
- [ ] `earnings-secrets` custom secret created in Modal dashboard with `DATABASE_URL`, `API_NINJAS_KEY`, `VOYAGE_API_KEY`, `ANTHROPIC_API_KEY`
- [ ] `modal run pipeline/ingest.py --ticker AAPL` completes without error and writes results to Supabase
- [ ] `modal deploy pipeline/ingest.py` deploys successfully
- [ ] `POST /admin/ingest` with a valid ticker returns `202 Accepted` and triggers the Modal function

Closes #137