### PR TITLE
feat: library page (#127)

### DIFF
--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,4 +1,6 @@
+import { redirect } from "next/navigation";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { CallList } from "@/components/CallList";
 
 /** Library page — lists all ingested earnings call transcripts. */
 export default async function LibraryPage() {
@@ -7,15 +9,19 @@ export default async function LibraryPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
+  if (!user) {
+    redirect("/auth/sign-in");
+  }
+
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       <h1 className="mb-2 text-3xl font-semibold text-zinc-900">
         Transcript Library
       </h1>
-      <p className="text-zinc-500">
-        Welcome, {user?.email}. Your ingested earnings transcripts will appear
-        here.
+      <p className="mb-8 text-zinc-500">
+        Select a transcript to study.
       </p>
+      <CallList />
     </div>
   );
 }

--- a/web/components/CallCard.tsx
+++ b/web/components/CallCard.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+
+export interface CallSummary {
+  ticker: string;
+  company_name: string | null;
+  call_date: string | null;
+  industry: string | null;
+}
+
+interface CallCardProps {
+  call: CallSummary;
+}
+
+/** Card displaying summary metadata for a single earnings call. */
+export function CallCard({ call }: CallCardProps) {
+  return (
+    <Link
+      href={`/calls/${call.ticker}`}
+      className="block rounded-xl border border-zinc-200 bg-white p-6 shadow-sm transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <span className="text-2xl font-bold tracking-tight text-zinc-900">
+          {call.ticker}
+        </span>
+        {call.call_date && (
+          <span className="shrink-0 text-sm text-zinc-400">{call.call_date}</span>
+        )}
+      </div>
+      {call.company_name && (
+        <p className="mt-1 text-sm font-medium text-zinc-700">
+          {call.company_name}
+        </p>
+      )}
+      {call.industry && (
+        <span className="mt-3 inline-block rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs text-zinc-600">
+          {call.industry}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/web/components/CallList.tsx
+++ b/web/components/CallList.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { CallCard, type CallSummary } from "./CallCard";
+
+/** Skeleton placeholder shown while call list is loading. */
+function CallCardSkeleton() {
+  return (
+    <div className="animate-pulse rounded-xl border border-zinc-200 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="h-7 w-16 rounded bg-zinc-200" />
+        <div className="h-4 w-24 rounded bg-zinc-100" />
+      </div>
+      <div className="mt-2 h-4 w-40 rounded bg-zinc-100" />
+      <div className="mt-3 h-5 w-20 rounded-full bg-zinc-100" />
+    </div>
+  );
+}
+
+/** Fetches the call list from the API and renders it as a grid of cards. */
+export function CallList() {
+  const [calls, setCalls] = useState<CallSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .get<CallSummary[]>("/api/calls")
+      .then(setCalls)
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load calls.");
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <CallCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+        {error}
+      </div>
+    );
+  }
+
+  if (calls.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-zinc-300 bg-white px-8 py-16 text-center">
+        <p className="text-lg font-medium text-zinc-700">No transcripts yet</p>
+        <p className="mt-1 text-sm text-zinc-400">
+          Ingest an earnings call to get started.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {calls.map((call) => (
+        <CallCard key={call.ticker} call={call} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Implements `web/app/page.tsx` — fetches call list from `GET /api/calls`, renders card grid
- Adds `CallCard` component (`web/components/CallCard.tsx`) — shows ticker, company name, industry, call date; links to `/calls/[ticker]`
- Adds `CallList` client component with animated loading skeleton (6 placeholder cards), empty state, and error state
- Unauthenticated users are redirected to `/auth/sign-in` via `redirect()` in the server component

## Test plan
- [ ] Sign out and visit `/` — should redirect to `/auth/sign-in`
- [ ] Sign in and visit `/` — should show loading skeleton briefly, then call grid
- [ ] With no ingested calls, empty state ("No transcripts yet") should appear
- [ ] With calls in the DB, cards should render with correct ticker/company/date/industry
- [ ] Clicking a card navigates to `/calls/[ticker]`

Closes #127