### PR TITLE
feat: transcript browser and metadata panel (#128)

### DIFF
--- a/web/app/calls/[ticker]/page.tsx
+++ b/web/app/calls/[ticker]/page.tsx
@@ -1,3 +1,27 @@
+import Link from "next/link";
+import { TranscriptBrowser } from "@/components/transcript/TranscriptBrowser";
+import { MetadataPanel } from "@/components/transcript/MetadataPanel";
+import type { CallDetail } from "@/components/transcript/types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+/** Fetch call detail server-side; throws on error so Next.js renders the error boundary. */
+async function fetchCallDetail(ticker: string): Promise<CallDetail | null> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_API_URL is not configured");
+
+  const res = await fetch(`${API_URL}/api/calls/${ticker}`, {
+    next: { revalidate: 60 },
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const msg = await res.text().catch(() => res.statusText);
+    throw new Error(`API error ${res.status}: ${msg}`);
+  }
+
+  return res.json() as Promise<CallDetail>;
+}
+
 /** Transcript browser and metadata panel for a given ticker. */
 export default async function TranscriptPage({
   params,
@@ -5,15 +29,52 @@ export default async function TranscriptPage({
   params: Promise<{ ticker: string }>;
 }) {
   const { ticker } = await params;
+  const call = await fetchCallDetail(ticker.toUpperCase());
+
+  if (!call) {
+    return (
+      <div className="mx-auto w-full max-w-7xl px-6 py-12">
+        <p className="text-sm text-zinc-500">
+          No transcript found for <span className="font-semibold uppercase">{ticker}</span>.{" "}
+          <Link href="/" className="underline hover:text-zinc-700">
+            Back to library
+          </Link>
+        </p>
+      </div>
+    );
+  }
 
   return (
-    <div className="mx-auto w-full max-w-7xl px-6 py-12">
-      <h1 className="mb-2 text-3xl font-semibold text-zinc-900 uppercase">
-        {ticker}
-      </h1>
-      <p className="text-zinc-500">
-        Transcript browser and metadata panel — coming soon.
-      </p>
+    <div className="mx-auto w-full max-w-7xl px-6 py-8">
+      {/* Header */}
+      <div className="mb-6 flex items-baseline gap-3">
+        <h1 className="text-3xl font-bold tracking-tight text-zinc-900 uppercase">
+          {call.ticker}
+        </h1>
+        {call.company_name && (
+          <span className="text-lg text-zinc-500">{call.company_name}</span>
+        )}
+        {call.call_date && (
+          <span className="ml-auto text-sm text-zinc-400">{call.call_date}</span>
+        )}
+      </div>
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
+        {/* Left: transcript browser — client component */}
+        <TranscriptBrowser ticker={call.ticker} call={call} />
+
+        {/* Right: metadata panel — client component */}
+        <div className="lg:sticky lg:top-6 lg:self-start">
+          <MetadataPanel call={call} />
+          <Link
+            href={`/calls/${call.ticker}/learn`}
+            className="mt-4 block w-full rounded-lg bg-zinc-900 px-4 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-zinc-700"
+          >
+            Study with Feynman chat
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/components/transcript/EvasionCard.tsx
+++ b/web/components/transcript/EvasionCard.tsx
@@ -1,0 +1,30 @@
+/** Renders an evasion analysis item as a card. */
+
+import type { EvasionItem } from "./types";
+
+interface EvasionCardProps {
+  item: EvasionItem;
+}
+
+/** Maps defensiveness score (1–10) to a colour class. */
+function scoreColour(score: number): string {
+  if (score >= 8) return "text-red-700 bg-red-50";
+  if (score >= 5) return "text-amber-700 bg-amber-50";
+  return "text-green-700 bg-green-50";
+}
+
+export function EvasionCard({ item }: EvasionCardProps) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-medium text-zinc-800">{item.analyst_concern}</p>
+        <span
+          className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-semibold ${scoreColour(item.defensiveness_score)}`}
+        >
+          {item.defensiveness_score}/10
+        </span>
+      </div>
+      <p className="mt-2 text-sm text-zinc-500">{item.evasion_explanation}</p>
+    </div>
+  );
+}

--- a/web/components/transcript/KeywordList.tsx
+++ b/web/components/transcript/KeywordList.tsx
@@ -1,0 +1,24 @@
+/** Renders a ranked list of keyword chips. */
+
+interface KeywordListProps {
+  keywords: string[];
+}
+
+export function KeywordList({ keywords }: KeywordListProps) {
+  if (keywords.length === 0) {
+    return <p className="text-sm text-zinc-400">No keywords extracted.</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {keywords.map((kw, i) => (
+        <span
+          key={i}
+          className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700"
+        >
+          {kw}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import type { CallDetail } from "./types";
+import { KeywordList } from "./KeywordList";
+import { ThemeCard } from "./ThemeCard";
+import { EvasionCard } from "./EvasionCard";
+import { StrategicShiftCard } from "./StrategicShiftCard";
+
+type Tab = "summary" | "keywords" | "themes" | "evasion" | "shifts";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "summary", label: "Summary" },
+  { id: "keywords", label: "Keywords" },
+  { id: "themes", label: "Themes" },
+  { id: "evasion", label: "Evasion" },
+  { id: "shifts", label: "Shifts" },
+];
+
+interface MetadataPanelProps {
+  call: CallDetail;
+}
+
+/** Sidebar panel with tabbed metadata: summary, keywords, themes, evasion, strategic shifts. */
+export function MetadataPanel({ call }: MetadataPanelProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("summary");
+
+  return (
+    <div className="flex flex-col rounded-xl border border-zinc-200 bg-zinc-50">
+      {/* Tab bar */}
+      <div className="flex border-b border-zinc-200 overflow-x-auto">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`shrink-0 px-4 py-3 text-sm font-medium transition-colors ${
+              activeTab === tab.id
+                ? "border-b-2 border-zinc-900 text-zinc-900"
+                : "text-zinc-500 hover:text-zinc-700"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {activeTab === "summary" && <SummaryTab call={call} />}
+        {activeTab === "keywords" && <KeywordList keywords={call.keywords} />}
+        {activeTab === "themes" && <ThemesTab topics={call.topics} themes={call.themes} />}
+        {activeTab === "evasion" && <EvasionTab items={call.evasion_analyses} />}
+        {activeTab === "shifts" && <ShiftsTab shifts={call.strategic_shifts} />}
+      </div>
+    </div>
+  );
+}
+
+function SummaryTab({ call }: { call: CallDetail }) {
+  const { synthesis } = call;
+
+  if (!synthesis) {
+    return <p className="text-sm text-zinc-400">No summary available.</p>;
+  }
+
+  const rows = [
+    { label: "Overall sentiment", value: synthesis.overall_sentiment },
+    { label: "Executive tone", value: synthesis.executive_tone },
+    { label: "Analyst sentiment", value: synthesis.analyst_sentiment },
+  ];
+
+  return (
+    <dl className="space-y-4">
+      {rows.map(({ label, value }) =>
+        value ? (
+          <div key={label}>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+              {label}
+            </dt>
+            <dd className="mt-1 text-sm text-zinc-700">{value}</dd>
+          </div>
+        ) : null
+      )}
+    </dl>
+  );
+}
+
+function ThemesTab({ topics, themes }: { topics: string[][]; themes: string[] }) {
+  // topics is a list of term lists; themes is the same flat but labelled differently
+  // Use topics if available (richer), fall back to themes
+  const source = topics.length > 0 ? topics : themes.map((t) => [t]);
+
+  if (source.length === 0) {
+    return <p className="text-sm text-zinc-400">No themes extracted.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {source.map((terms, i) => (
+        <ThemeCard key={i} label={terms[0] ?? `Topic ${i + 1}`} terms={terms} />
+      ))}
+    </div>
+  );
+}
+
+function EvasionTab({ items }: { items: CallDetail["evasion_analyses"] }) {
+  if (items.length === 0) {
+    return <p className="text-sm text-zinc-400">No evasion patterns detected.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((item, i) => (
+        <EvasionCard key={i} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function ShiftsTab({ shifts }: { shifts: CallDetail["strategic_shifts"] }) {
+  if (shifts.length === 0) {
+    return <p className="text-sm text-zinc-400">No strategic shifts identified.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {shifts.map((shift, i) => (
+        <StrategicShiftCard key={i} shift={shift} />
+      ))}
+    </div>
+  );
+}

--- a/web/components/transcript/StrategicShiftCard.tsx
+++ b/web/components/transcript/StrategicShiftCard.tsx
@@ -1,0 +1,34 @@
+/** Renders a strategic shift item showing prior vs current position. */
+
+import type { StrategicShift } from "./types";
+
+interface StrategicShiftCardProps {
+  shift: StrategicShift;
+}
+
+export function StrategicShiftCard({ shift }: StrategicShiftCardProps) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+            Before
+          </p>
+          <p className="text-sm text-zinc-700">{shift.prior_position}</p>
+        </div>
+        <div>
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+            Now
+          </p>
+          <p className="text-sm text-zinc-700">{shift.current_position}</p>
+        </div>
+      </div>
+      <div className="mt-3 border-t border-zinc-100 pt-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+          Investor significance
+        </p>
+        <p className="mt-1 text-sm text-zinc-600">{shift.investor_significance}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/components/transcript/ThemeCard.tsx
+++ b/web/components/transcript/ThemeCard.tsx
@@ -1,0 +1,26 @@
+/** Renders a topic cluster as a card with a label and term chips. */
+
+interface ThemeCardProps {
+  /** The leading term used as the card label. */
+  label: string;
+  /** All terms in the topic cluster. */
+  terms: string[];
+}
+
+export function ThemeCard({ label, terms }: ThemeCardProps) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-4">
+      <p className="mb-2 text-sm font-semibold text-zinc-800">{label}</p>
+      <div className="flex flex-wrap gap-1.5">
+        {terms.map((term, i) => (
+          <span
+            key={i}
+            className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-700"
+          >
+            {term}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/components/transcript/TranscriptBrowser.tsx
+++ b/web/components/transcript/TranscriptBrowser.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import type {
+  CallDetail,
+  SearchResponse,
+  SearchResult,
+  SpanItem,
+  SpansResponse,
+} from "./types";
+
+type Section = "all" | "prepared" | "qa";
+
+interface TranscriptBrowserProps {
+  ticker: string;
+  call: CallDetail;
+}
+
+/** Returns a debounced version of a value, updating only after `delay` ms of silence. */
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(id);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+/** Left-pane transcript browser with section/speaker filtering, pagination, and semantic search. */
+export function TranscriptBrowser({ ticker, call }: TranscriptBrowserProps) {
+  const [section, setSection] = useState<Section>("all");
+  const [speaker, setSpeaker] = useState<string>("");
+  const [page, setPage] = useState(1);
+
+  const [spans, setSpans] = useState<SpanItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [pageSize, setPageSize] = useState(50);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedQuery = useDebounce(searchQuery, 400);
+  const [searchResults, setSearchResults] = useState<SearchResult[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  // Reset to page 1 when filters change
+  useEffect(() => {
+    setPage(1);
+  }, [section, speaker]);
+
+  // Fetch spans whenever filters or page change (and not in search mode)
+  useEffect(() => {
+    if (debouncedQuery.trim()) return; // search mode — skip span fetch
+
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({
+      section,
+      page: String(page),
+      page_size: "50",
+    });
+    if (speaker) params.set("speaker", speaker);
+
+    api
+      .get<SpansResponse>(`/api/calls/${ticker}/spans?${params}`)
+      .then((data) => {
+        setSpans(data.spans);
+        setTotal(data.total);
+        setPageSize(data.page_size);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load transcript.");
+      })
+      .finally(() => setLoading(false));
+  }, [ticker, section, speaker, page, debouncedQuery]);
+
+  // Semantic search
+  useEffect(() => {
+    const q = debouncedQuery.trim();
+    if (!q) {
+      setSearchResults(null);
+      setSearchError(null);
+      return;
+    }
+
+    setSearching(true);
+    setSearchError(null);
+
+    api
+      .get<SearchResponse>(`/api/calls/${ticker}/search?q=${encodeURIComponent(q)}`)
+      .then((data) => setSearchResults(data.results))
+      .catch((err: unknown) => {
+        setSearchError(err instanceof Error ? err.message : "Search failed.");
+        setSearchResults(null);
+      })
+      .finally(() => setSearching(false));
+  }, [ticker, debouncedQuery]);
+
+  const totalPages = Math.ceil(total / pageSize);
+  const inSearchMode = Boolean(debouncedQuery.trim());
+
+  const speakerNames = call.speakers.map((s) => s.name);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Section filter */}
+        <div className="flex rounded-lg border border-zinc-200 bg-white text-sm overflow-hidden">
+          {(["all", "prepared", "qa"] as Section[]).map((s) => (
+            <button
+              key={s}
+              onClick={() => { setSection(s); setSearchQuery(""); }}
+              className={`px-3 py-1.5 capitalize transition-colors ${
+                section === s && !inSearchMode
+                  ? "bg-zinc-900 text-white"
+                  : "text-zinc-600 hover:bg-zinc-50"
+              }`}
+            >
+              {s === "qa" ? "Q&A" : s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* Speaker filter */}
+        {speakerNames.length > 0 && (
+          <select
+            value={speaker}
+            onChange={(e) => { setSpeaker(e.target.value); setSearchQuery(""); }}
+            className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-400"
+          >
+            <option value="">All speakers</option>
+            {speakerNames.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {/* Semantic search */}
+        <div className="relative flex-1 min-w-[200px]">
+          <input
+            type="search"
+            placeholder="Semantic search…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm text-zinc-700 placeholder:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-zinc-400"
+          />
+          {searching && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-zinc-400">
+              Searching…
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Content area */}
+      {inSearchMode ? (
+        <SearchResultsView results={searchResults} error={searchError} query={debouncedQuery} />
+      ) : (
+        <>
+          <SpanListView spans={spans} loading={loading} error={error} />
+          {totalPages > 1 && !loading && !error && (
+            <Pagination page={page} totalPages={totalPages} onPageChange={setPage} />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// --- Sub-views ---
+
+function SpanListView({
+  spans,
+  loading,
+  error,
+}: {
+  spans: SpanItem[];
+  loading: boolean;
+  error: string | null;
+}) {
+  if (loading) return <SpanSkeleton />;
+
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    );
+  }
+
+  if (spans.length === 0) {
+    return (
+      <p className="rounded-lg border border-dashed border-zinc-200 px-6 py-10 text-center text-sm text-zinc-400">
+        No turns match the current filters.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {spans.map((span) => (
+        <SpanBlock key={span.sequence_order} span={span} />
+      ))}
+    </div>
+  );
+}
+
+function SpanBlock({ span }: { span: SpanItem }) {
+  const isAnalyst = span.section === "qa" && span.speaker.toLowerCase().includes("analyst");
+  return (
+    <div
+      className={`rounded-lg border p-4 ${
+        isAnalyst
+          ? "border-blue-100 bg-blue-50"
+          : "border-zinc-200 bg-white"
+      }`}
+    >
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-zinc-500">
+        {span.speaker}
+        <span className="ml-2 font-normal normal-case text-zinc-400">
+          · {span.section === "qa" ? "Q&A" : "Prepared"}
+        </span>
+      </p>
+      <p className="text-sm leading-relaxed text-zinc-800">{span.text}</p>
+    </div>
+  );
+}
+
+function SearchResultsView({
+  results,
+  error,
+  query,
+}: {
+  results: SearchResult[] | null;
+  error: string | null;
+  query: string;
+}) {
+  if (error) {
+    return (
+      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+    );
+  }
+
+  if (!results) return null;
+
+  if (results.length === 0) {
+    return (
+      <p className="text-sm text-zinc-400">
+        No results found for <em>{query}</em>.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-zinc-400">
+        {results.length} result{results.length !== 1 ? "s" : ""} for <em>{query}</em>
+      </p>
+      {results.map((r, i) => (
+        <div key={i} className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+              {r.speaker}
+              <span className="ml-2 font-normal normal-case text-zinc-400">
+                · {r.section === "qa" ? "Q&A" : "Prepared"}
+              </span>
+            </p>
+            <span className="text-xs text-zinc-400">
+              {Math.round(r.similarity * 100)}% match
+            </span>
+          </div>
+          <p className="text-sm leading-relaxed text-zinc-800">{r.text}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Pagination({
+  page,
+  totalPages,
+  onPageChange,
+}: {
+  page: number;
+  totalPages: number;
+  onPageChange: (p: number) => void;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-2">
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm text-zinc-600 disabled:opacity-40 hover:bg-zinc-50"
+      >
+        Prev
+      </button>
+      <span className="text-sm text-zinc-500">
+        {page} / {totalPages}
+      </span>
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        className="rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm text-zinc-600 disabled:opacity-40 hover:bg-zinc-50"
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
+function SpanSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="animate-pulse rounded-lg border border-zinc-200 bg-white p-4">
+          <div className="mb-2 h-3 w-32 rounded bg-zinc-100" />
+          <div className="space-y-1.5">
+            <div className="h-4 rounded bg-zinc-100" />
+            <div className="h-4 w-4/5 rounded bg-zinc-100" />
+            <div className="h-4 w-3/5 rounded bg-zinc-100" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/components/transcript/types.ts
+++ b/web/components/transcript/types.ts
@@ -1,0 +1,66 @@
+/** Shared type definitions for transcript browser and metadata panel. */
+
+export interface SynthesisInfo {
+  overall_sentiment: string | null;
+  executive_tone: string | null;
+  analyst_sentiment: string | null;
+}
+
+export interface EvasionItem {
+  analyst_concern: string;
+  defensiveness_score: number;
+  evasion_explanation: string;
+}
+
+export interface StrategicShift {
+  prior_position: string;
+  current_position: string;
+  investor_significance: string;
+}
+
+export interface SpeakerInfo {
+  name: string;
+  role: string;
+  title: string | null;
+  firm: string | null;
+}
+
+export interface CallDetail {
+  ticker: string;
+  company_name: string | null;
+  call_date: string | null;
+  industry: string | null;
+  synthesis: SynthesisInfo | null;
+  keywords: string[];
+  themes: string[];
+  topics: string[][];
+  evasion_analyses: EvasionItem[];
+  strategic_shifts: StrategicShift[];
+  speakers: SpeakerInfo[];
+}
+
+export interface SpanItem {
+  speaker: string;
+  section: string;
+  text: string;
+  sequence_order: number;
+}
+
+export interface SpansResponse {
+  total: number;
+  page: number;
+  page_size: number;
+  spans: SpanItem[];
+}
+
+export interface SearchResult {
+  speaker: string;
+  section: string;
+  text: string;
+  similarity: number;
+}
+
+export interface SearchResponse {
+  query: string;
+  results: SearchResult[];
+}


### PR DESCRIPTION
## Summary

- Server component fetches call detail at `/api/calls/{ticker}` with 60s revalidation; renders 404 message if ticker not found
- `TranscriptBrowser` (client): section filter (All/Prepared/Q&A), speaker dropdown, paginated span list, debounced semantic search via `/api/calls/{ticker}/search`
- `MetadataPanel` (client): tabbed sidebar — Summary, Keywords, Themes, Evasion, Shifts
- Sub-components: `EvasionCard` (colour-coded defensiveness score), `StrategicShiftCard` (before/now layout), `ThemeCard` (term chips), `KeywordList`
- Search and span panels load independently; search mode replaces the span list and shows similarity %

## Test plan

- [ ] Visit `/calls/<ticker>` for an ingested call — header, browser, and sidebar all render
- [ ] Section filter buttons switch between All/Prepared/Q&A and reset to page 1
- [ ] Speaker dropdown filters to a single speaker
- [ ] Pagination prev/next works; disabled at boundaries
- [ ] Typing in the search box triggers semantic search (debounced ~400ms); results show similarity %
- [ ] Clearing search restores the span list
- [ ] `/calls/<invalid>` shows the not-found message
- [ ] Sidebar tabs switch correctly; empty states render when no data

Closes #128