### PR TITLE
feat: Feynman chat page (/calls/[ticker]/learn) (#129)

### DIFF
--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -1,17 +1,105 @@
+"use client";
+
+import { use, useState } from "react";
+import Link from "next/link";
+import { ChatThread } from "@/components/chat/ChatThread";
+import { ChatInput } from "@/components/chat/ChatInput";
+import { streamChat } from "@/lib/chat";
+import type { ChatMessage } from "@/lib/chat";
+
 /** Feynman-style learning chat for a given ticker's transcript. */
-export default async function LearnPage({
+export default function LearnPage({
   params,
 }: {
   params: Promise<{ ticker: string }>;
 }) {
-  const { ticker } = await params;
+  const { ticker } = use(params);
+  const upperTicker = ticker.toUpperCase();
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [streamingContent, setStreamingContent] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSend(message: string) {
+    setError(null);
+    setIsStreaming(true);
+    setStreamingContent("");
+    setMessages((prev) => [...prev, { role: "user", content: message }]);
+
+    let accumulated = "";
+
+    await streamChat(ticker, message, sessionId, {
+      onToken(token) {
+        accumulated += token;
+        setStreamingContent(accumulated);
+      },
+      onDone(newSessionId) {
+        setSessionId(newSessionId);
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: accumulated },
+        ]);
+        setStreamingContent("");
+        setIsStreaming(false);
+      },
+      onError(msg) {
+        setError(msg);
+        setStreamingContent("");
+        setIsStreaming(false);
+      },
+    });
+  }
+
+  function handleNewSession() {
+    setMessages([]);
+    setStreamingContent("");
+    setSessionId(null);
+    setError(null);
+  }
 
   return (
-    <div className="mx-auto w-full max-w-7xl px-6 py-12">
-      <h1 className="mb-2 text-3xl font-semibold text-zinc-900">
-        Learn: <span className="uppercase">{ticker}</span>
-      </h1>
-      <p className="text-zinc-500">Feynman chat — coming soon.</p>
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-6 py-8" style={{ height: "calc(100vh - 64px)" }}>
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <div className="flex items-baseline gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
+            Learn:{" "}
+            <span className="uppercase">{upperTicker}</span>
+          </h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleNewSession}
+            disabled={isStreaming}
+            className="text-sm text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline disabled:opacity-40"
+          >
+            New session
+          </button>
+          <Link
+            href={`/calls/${upperTicker}`}
+            className="text-sm text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline"
+          >
+            ← Back
+          </Link>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* Chat thread */}
+      <ChatThread messages={messages} streamingContent={streamingContent} />
+
+      {/* Input */}
+      <div className="mt-4">
+        <ChatInput onSend={handleSend} isStreaming={isStreaming} />
+      </div>
     </div>
   );
 }

--- a/web/components/chat/ChatInput.tsx
+++ b/web/components/chat/ChatInput.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+interface ChatInputProps {
+  onSend: (message: string) => void;
+  isStreaming: boolean;
+}
+
+/** Textarea with send button. Submits on Enter; Shift+Enter inserts a newline. */
+export function ChatInput({ onSend, isStreaming }: ChatInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleSubmit() {
+    const trimmed = value.trim();
+    if (!trimmed || isStreaming) return;
+    onSend(trimmed);
+    setValue("");
+    textareaRef.current?.focus();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  return (
+    <div className="flex items-end gap-2 border-t border-zinc-200 pt-4">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={isStreaming}
+        rows={3}
+        placeholder="Ask a question… (Enter to send, Shift+Enter for newline)"
+        className="flex-1 resize-none rounded-lg border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 placeholder-zinc-400 focus:border-zinc-500 focus:outline-none disabled:opacity-50"
+      />
+      <button
+        onClick={handleSubmit}
+        disabled={isStreaming || !value.trim()}
+        className="mb-0.5 rounded-lg bg-zinc-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {isStreaming ? "…" : "Send"}
+      </button>
+    </div>
+  );
+}

--- a/web/components/chat/ChatThread.tsx
+++ b/web/components/chat/ChatThread.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { ChatMessage } from "@/lib/chat";
+
+interface ChatThreadProps {
+  messages: ChatMessage[];
+  streamingContent: string;
+}
+
+/** Renders the full conversation history plus any in-progress streamed assistant response. */
+export function ChatThread({ messages, streamingContent }: ChatThreadProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingContent]);
+
+  if (messages.length === 0 && !streamingContent) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-zinc-400">
+        Ask a question about this earnings call to get started.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-1 py-2">
+      {messages.map((msg, i) => (
+        <MessageBubble key={i} role={msg.role} content={msg.content} />
+      ))}
+      {streamingContent && (
+        <MessageBubble role="assistant" content={streamingContent} streaming />
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+interface MessageBubbleProps {
+  role: "user" | "assistant";
+  content: string;
+  streaming?: boolean;
+}
+
+function MessageBubble({ role, content, streaming = false }: MessageBubbleProps) {
+  const isUser = role === "user";
+
+  return (
+    <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap ${
+          isUser
+            ? "bg-zinc-900 text-white"
+            : "bg-zinc-100 text-zinc-900"
+        }`}
+      >
+        {content}
+        {streaming && (
+          <span className="ml-1 inline-block h-3 w-0.5 animate-pulse bg-current" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/lib/chat.ts
+++ b/web/lib/chat.ts
@@ -1,0 +1,95 @@
+import { createSupabaseBrowserClient } from "./supabase/client";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+if (!API_URL) {
+  throw new Error("NEXT_PUBLIC_API_URL is not configured");
+}
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface StreamChatCallbacks {
+  onToken: (token: string) => void;
+  onDone: (sessionId: string) => void;
+  onError: (message: string) => void;
+}
+
+/** Stream a Feynman chat response via SSE. Uses fetch + ReadableStream because EventSource cannot POST. */
+export async function streamChat(
+  ticker: string,
+  message: string,
+  sessionId: string | null,
+  callbacks: StreamChatCallbacks
+): Promise<void> {
+  const supabase = createSupabaseBrowserClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (session?.access_token) {
+    headers["Authorization"] = `Bearer ${session.access_token}`;
+  }
+
+  const response = await fetch(`${API_URL}/api/calls/${ticker}/chat`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ message, session_id: sessionId }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    callbacks.onError(`API error ${response.status}: ${text}`);
+    return;
+  }
+
+  if (!response.body) {
+    callbacks.onError("Response body is empty");
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+
+    // SSE events are separated by double newlines
+    const events = buffer.split("\n\n");
+    // Keep the last (potentially incomplete) chunk in the buffer
+    buffer = events.pop() ?? "";
+
+    for (const event of events) {
+      const dataLine = event
+        .split("\n")
+        .find((line) => line.startsWith("data: "));
+      if (!dataLine) continue;
+
+      const jsonStr = dataLine.slice("data: ".length);
+      let parsed: { type: string; content?: string; session_id?: string; message?: string };
+      try {
+        parsed = JSON.parse(jsonStr);
+      } catch {
+        continue;
+      }
+
+      if (parsed.type === "token" && parsed.content !== undefined) {
+        callbacks.onToken(parsed.content);
+      } else if (parsed.type === "done" && parsed.session_id !== undefined) {
+        callbacks.onDone(parsed.session_id);
+      } else if (parsed.type === "error") {
+        callbacks.onError(parsed.message ?? "Unknown error");
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the placeholder at `/calls/[ticker]/learn` with a working streaming Feynman chat UI
- SSE tokens stream progressively via `fetch` + `ReadableStream` (not `EventSource`, which can't POST)
- Session state (create / persist / reset) managed in component state; `session_id` returned in the `done` event and sent with subsequent messages

## Test plan

- [ ] Send a first message — verify a new session is created and tokens stream in progressively
- [ ] Send a follow-up message — verify conversation history is maintained (session_id reused)
- [ ] Click "New session" — verify messages clear and the next send creates a fresh session
- [ ] Verify the back link returns to `/calls/[ticker]`
- [ ] Verify the input is disabled and the send button shows "…" while streaming
- [ ] Verify an API error (e.g. bad ticker) shows the red error banner

Closes #129