### PR TITLE
feat: suggested starter topics on Feynman chat page

### DIFF
--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { ChatThread } from "@/components/chat/ChatThread";
 import { ChatInput } from "@/components/chat/ChatInput";
 import { streamChat } from "@/lib/chat";
+import { api } from "@/lib/api";
+import { buildSuggestions } from "@/lib/suggestions";
 import type { ChatMessage } from "@/lib/chat";
+import type { CallDetail } from "@/components/transcript/types";
 
 /** Feynman-style learning chat for a given ticker's transcript. */
 export default function LearnPage({
@@ -21,6 +24,18 @@ export default function LearnPage({
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<CallDetail>(`/api/calls/${ticker}`)
+      .then((detail) => setSuggestions(buildSuggestions(detail.themes, detail.keywords)))
+      .catch(() => {
+        // Silent degradation — suggestions are a progressive enhancement
+      })
+      .finally(() => setLoadingSuggestions(false));
+  }, [ticker]);
 
   async function handleSend(message: string) {
     setError(null);
@@ -94,7 +109,13 @@ export default function LearnPage({
       )}
 
       {/* Chat thread */}
-      <ChatThread messages={messages} streamingContent={streamingContent} />
+      <ChatThread
+        messages={messages}
+        streamingContent={streamingContent}
+        suggestions={suggestions}
+        loadingSuggestions={loadingSuggestions}
+        onSuggestionClick={handleSend}
+      />
 
       {/* Input */}
       <div className="mt-4">

--- a/web/components/chat/ChatThread.tsx
+++ b/web/components/chat/ChatThread.tsx
@@ -6,10 +6,13 @@ import type { ChatMessage } from "@/lib/chat";
 interface ChatThreadProps {
   messages: ChatMessage[];
   streamingContent: string;
+  suggestions?: string[];
+  loadingSuggestions?: boolean;
+  onSuggestionClick?: (suggestion: string) => void;
 }
 
 /** Renders the full conversation history plus any in-progress streamed assistant response. */
-export function ChatThread({ messages, streamingContent }: ChatThreadProps) {
+export function ChatThread({ messages, streamingContent, suggestions, loadingSuggestions, onSuggestionClick }: ChatThreadProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -18,8 +21,29 @@ export function ChatThread({ messages, streamingContent }: ChatThreadProps) {
 
   if (messages.length === 0 && !streamingContent) {
     return (
-      <div className="flex flex-1 items-center justify-center text-sm text-zinc-400">
-        Ask a question about this earnings call to get started.
+      <div className="flex flex-1 flex-col items-center justify-center gap-6">
+        <p className="text-sm text-zinc-400">
+          Ask a question about this earnings call to get started.
+        </p>
+        {loadingSuggestions ? (
+          <div className="flex flex-wrap justify-center gap-2">
+            <div className="animate-pulse rounded-full bg-zinc-100 px-4 py-2 text-sm text-zinc-400">
+              Loading suggested starter questions…
+            </div>
+          </div>
+        ) : suggestions && suggestions.length > 0 ? (
+          <div className="flex flex-wrap justify-center gap-2">
+            {suggestions.map((suggestion) => (
+              <button
+                key={suggestion}
+                onClick={() => onSuggestionClick?.(suggestion)}
+                className="rounded-full border border-zinc-200 bg-white px-4 py-2 text-sm text-zinc-600 transition-colors hover:border-zinc-400 hover:text-zinc-900"
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/web/lib/suggestions.ts
+++ b/web/lib/suggestions.ts
@@ -1,0 +1,16 @@
+/** Derives up to 4 question-phrased starter topics from a call's themes and keywords. */
+export function buildSuggestions(themes: string[], keywords: string[]): string[] {
+  const suggestions: string[] = [];
+
+  for (const theme of themes) {
+    if (suggestions.length >= 4) break;
+    suggestions.push(`Explain "${theme}" in simple terms`);
+  }
+
+  for (const keyword of keywords) {
+    if (suggestions.length >= 4) break;
+    suggestions.push(`What does "${keyword}" mean for investors?`);
+  }
+
+  return suggestions;
+}


### PR DESCRIPTION
Closes #153

## Summary
- Fetches `CallDetail` client-side on the learn page and derives 3–4 question-phrased chips from `themes` and `keywords` via a new pure `buildSuggestions` utility
- Chips render in `ChatThread`'s empty state; clicking one fires `handleSend` (same path as typing)
- While loading, a pulsing pill reads "Loading suggested starter questions…"; silent degradation if the fetch fails
- Suggestions disappear once the conversation starts and reappear after "New session"

## Test plan
- [ ] Load `/calls/[ticker]/learn` — pulsing pill appears briefly, then 3–4 chips render
- [ ] Click a chip — it sends as the first message and chips disappear
- [ ] Type and send manually — chips also disappear
- [ ] Click "New session" — chips reappear
- [ ] Test with a ticker that has no themes/keywords — page works, no chips shown