### PR TITLE
chore: production deploy scaffolding (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ earnings-transcript-teacher/
 
 ```bash
 cp api/.env.example api/.env
-cp web/.env.example web/.env.local
+cp web/env.example web/.env.local
 ```
 
 **`api/.env` variables:**
@@ -311,6 +311,29 @@ pytest tests/unit/api/ -v
 
 ---
 
+## Deployment
+
+### Railway (FastAPI API)
+
+1. railway.app → **New Project** → **Deploy from GitHub repo** → select this repo
+2. Service → **Variables** — add the env vars from the table below (API column)
+3. Saving variables auto-triggers a redeploy; verify at `https://<railway-domain>/health`
+4. Copy the Railway public domain — you'll need it for the Vercel `NEXT_PUBLIC_API_URL` var
+
+> **DATABASE_URL**: use the Supabase **Transaction pooler** URL (port 6543), not the direct connection (port 5432). The direct connection has DNS reliability issues on newer Supabase projects.
+
+### Vercel (Next.js frontend)
+
+1. vercel.com → **Add New → Project** → import this repo
+2. Set **Root Directory** to `web`
+3. Add env vars (Frontend column below) under **Environment Variables → Production**
+4. After deploy, copy the Vercel production domain
+5. Back in Railway → Variables → set `NEXT_PUBLIC_VERCEL_URL` to the Vercel domain (without `https://`)
+
+Vercel automatically creates preview deployments for every PR. To allow a preview URL through Railway's CORS, add it to `CORS_EXTRA_ORIGINS` (comma-separated) in the Railway staging environment.
+
+---
+
 ## Environment variable reference
 
 | Variable | Used by | Description |
@@ -321,7 +344,9 @@ pytest tests/unit/api/ -v
 | `ANTHROPIC_API_KEY` | Modal pipeline, legacy pipeline | Anthropic key for the LLM ingestion pipeline ([console.anthropic.com](https://console.anthropic.com)) |
 | `DATABASE_URL` | Modal pipeline, legacy pipeline, FastAPI | PostgreSQL connection string (default: `dbname=earnings_teacher`) |
 | `SUPABASE_JWT_SECRET` | FastAPI | JWT secret — Supabase → Project Settings → API |
-| `ADMIN_SECRET_TOKEN` | FastAPI | Secret for admin-only routes — any strong random string |
+| `ADMIN_SECRET_TOKEN` | FastAPI | Secret for admin-only routes — generate with `openssl rand -hex 32` |
 | `NEXT_PUBLIC_SUPABASE_URL` | Next.js frontend | Supabase project URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Next.js frontend | Supabase anon key |
-| `NEXT_PUBLIC_VERCEL_URL` | FastAPI CORS | Set automatically by Vercel; omit in local dev |
+| `NEXT_PUBLIC_API_URL` | Next.js frontend | FastAPI base URL (Railway domain in production, `http://localhost:8000` locally) |
+| `NEXT_PUBLIC_VERCEL_URL` | FastAPI CORS | Vercel production domain (without `https://`) — set in Railway production |
+| `CORS_EXTRA_ORIGINS` | FastAPI CORS | Optional comma-separated extra allowed origins (e.g. Vercel preview URLs in staging) |

--- a/api/.env.example
+++ b/api/.env.example
@@ -10,3 +10,9 @@ API_NINJAS_KEY=
 
 # Admin
 ADMIN_SECRET_TOKEN=
+
+# CORS — set in Railway to allow the Vercel production domain
+# Omit in local dev (http://localhost:3000 is always allowed)
+NEXT_PUBLIC_VERCEL_URL=
+# Optional: comma-separated extra origins, e.g. Vercel preview URLs in staging
+CORS_EXTRA_ORIGINS=

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
+COPY api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY api/ .
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -28,6 +28,9 @@ def build_cors_origins() -> list[str]:
     production_url = os.environ.get("NEXT_PUBLIC_VERCEL_URL")
     if production_url:
         origins.append(f"https://{production_url}")
+    extra = os.environ.get("CORS_EXTRA_ORIGINS", "")
+    if extra:
+        origins.extend(o.strip() for o in extra.split(",") if o.strip())
     return origins
 
 


### PR DESCRIPTION
## Summary

- Fixes `api/Dockerfile` so Railway builds succeed — Railway uses the repo root as the build context, but the Dockerfile was copying `requirements.txt` from that root (the old Streamlit pipeline with no uvicorn) instead of `api/requirements.txt`
- Adds `CORS_EXTRA_ORIGINS` env var to `api/main.py` — lets staging/preview URLs be added without a code change
- Adds CORS vars to `api/.env.example` and a Deployment section to `README.md`

## Test plan

- [ ] Railway deploy succeeds and `curl https://<railway-domain>/health` returns `{"status":"ok"}`
- [ ] Vercel deploy succeeds and the app loads at the production URL
- [ ] Auth flow works end-to-end (Supabase → Next.js → FastAPI)

Closes #138