### PR TITLE
fix: use Railway PORT env var in uvicorn start command

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,5 +3,5 @@ builder = "dockerfile"
 dockerfilePath = "api/Dockerfile"
 
 [deploy]
-startCommand = "uvicorn main:app --host 0.0.0.0 --port 8000"
+startCommand = "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"
 healthcheckPath = "/health"


### PR DESCRIPTION
Railway injects a \`PORT\` env var and routes healthcheck traffic to that port. Hardcoding \`--port 8000\` causes the healthcheck to fail if Railway assigns a different port.

Uses \`${PORT:-8000}\` so it falls back to 8000 in local dev where \`PORT\` isn't set.

## Test plan
- [ ] Railway deploy succeeds and healthcheck passes
- [ ] \`curl https://<railway-domain>/health\` returns \`{"status":"ok"}\`