### PR TITLE
fix: copy full repo into container so root-level modules are importable

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.venv/
+web/node_modules/
+web/.next/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.git/
+.github/
+transcripts/
+coverage.xml
+.coverage

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,16 @@
 FROM python:3.12-slim
 
-WORKDIR /app
+WORKDIR /repo
 
-COPY api/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY api/requirements.txt api/requirements.txt
+RUN pip install --no-cache-dir -r api/requirements.txt
 
-COPY api/ .
+# Copy the full repo so root-level modules (db/, core/, prompts/) are importable
+COPY . .
+
+# Match the PYTHONPATH that dev.sh sets so `from db.repositories import ...` works
+ENV PYTHONPATH=/repo
+
+WORKDIR /repo/api
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## What was failing

The API routes import from project root modules (`db/`, `core/`) and `chat.py` resolves the prompts directory relative to the repo root. The previous Dockerfile only copied `api/` into the container, so Python crashed immediately on import with no visible logs — Railway only showed "service unavailable" from the healthcheck monitor.

## Fix

- `COPY . .` the full repo into `/repo`, then `WORKDIR /repo/api` so `uvicorn main:app` still finds `main.py` without changing any import paths
- `ENV PYTHONPATH=/repo` mirrors what `dev.sh` does locally with `PYTHONPATH="$REPO_ROOT"`
- Add `.dockerignore` to exclude `.venv/`, `web/node_modules/`, `.git/`, etc. so the build context stays small

## Test plan

- [ ] Railway build succeeds
- [ ] Healthcheck passes (`/health` returns `{"status":"ok"}`)
- [ ] Runtime logs show uvicorn startup (no ImportError)