### PR TITLE
fix: wrap startCommand in sh -c so PORT variable expansion works

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,5 +3,5 @@ builder = "dockerfile"
 dockerfilePath = "api/Dockerfile"
 
 [deploy]
-startCommand = "uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}"
+startCommand = "sh -c 'uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000}'"
 healthcheckPath = "/health"


### PR DESCRIPTION
`railway.toml`'s `startCommand` is exec'd directly by the container runtime, not a shell — so `${PORT:-8000}` was passed as a literal string to uvicorn, causing:

```
Error: Invalid value for '--port': '${PORT:-8000}' is not a valid integer.
```

Wrapping with `sh -c` routes the command through bash first so the substitution works.

## Test plan
- [ ] Healthcheck passes
- [ ] Runtime logs show uvicorn starting on the Railway-assigned PORT