### PR TITLE
feat: admin system health dashboard

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -7,3 +7,4 @@ python-multipart>=0.0.9
 voyageai>=0.3.0
 pgvector>=0.3.0
 modal>=0.73.0
+httpx>=0.27.0

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -1,13 +1,17 @@
 """Admin routes — protected ingestion dispatch."""
 
+import asyncio
 import logging
+import os
 import re
 from datetime import UTC, datetime
 
+import httpx
 import modal
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, field_validator
 
+from db.repositories import SchemaRepository
 from dependencies import AdminDep
 
 logger = logging.getLogger(__name__)
@@ -28,6 +32,47 @@ class IngestRequest(BaseModel):
         if not _TICKER_RE.match(upper):
             raise ValueError("ticker must be 2–5 alphabetic characters")
         return upper
+
+
+_HEALTH_ENV_VARS = ["VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID", "SUPABASE_JWT_SECRET"]
+_VOYAGE_URL = "https://api.voyageai.com"
+_PERPLEXITY_URL = "https://api.perplexity.ai"
+
+
+@router.get("/health")
+async def system_health(_: AdminDep) -> dict:
+    """Return system health: DB connection, env var presence, and external API reachability."""
+    db_url = os.environ.get("DATABASE_URL", "")
+    repo = SchemaRepository(db_url)
+    version: int = await asyncio.to_thread(repo.get_current_version)
+
+    env_vars = {key: bool(os.environ.get(key)) for key in _HEALTH_ENV_VARS}
+
+    voyage_reachable = False
+    perplexity_reachable = False
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        try:
+            await client.head(_VOYAGE_URL)
+            voyage_reachable = True
+        except Exception:
+            pass
+        try:
+            await client.head(_PERPLEXITY_URL)
+            perplexity_reachable = True
+        except Exception:
+            pass
+
+    return {
+        "db": {
+            "connected": version > 0,
+            "schema_version": version,
+        },
+        "env_vars": env_vars,
+        "external_apis": {
+            "voyage": {"reachable": voyage_reachable},
+            "perplexity": {"reachable": perplexity_reachable},
+        },
+    }
 
 
 @router.post("/ingest", status_code=202)

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -133,3 +133,133 @@ def test_ingest_looks_up_correct_modal_function(client):
     )
 
     MODAL_STUB.Function.lookup.assert_called_with("earnings-ingestion", "ingest_ticker")
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/health
+# ---------------------------------------------------------------------------
+
+def _make_healthy_httpx_mock():
+    """Return a mock httpx module with AsyncClient that succeeds on HEAD."""
+    mock_response = MagicMock(status_code=200)
+    mock_http_client = AsyncMock()
+    mock_http_client.head = AsyncMock(return_value=mock_response)
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = mock_cm
+    return mock_httpx
+
+
+def _make_schema_repo_mock(version: int = 9):
+    """Return a patched SchemaRepository class whose instance returns `version`."""
+    mock_repo = MagicMock()
+    mock_repo.get_current_version.return_value = version
+    mock_cls = MagicMock(return_value=mock_repo)
+    return mock_cls
+
+
+def test_health_returns_200_with_valid_token(client):
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
+         patch("routes.admin.httpx", _make_healthy_httpx_mock()):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    assert resp.status_code == 200
+
+
+def test_health_missing_token_returns_403(client):
+    resp = client.get("/admin/health")
+    assert resp.status_code == 403
+
+
+def test_health_wrong_token_returns_403(client):
+    resp = client.get(
+        "/admin/health",
+        headers={"X-Admin-Token": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+def test_health_response_has_expected_keys(client):
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
+         patch("routes.admin.httpx", _make_healthy_httpx_mock()):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    body = resp.json()
+    assert "db" in body
+    assert "env_vars" in body
+    assert "external_apis" in body
+    assert "connected" in body["db"]
+    assert "schema_version" in body["db"]
+    assert {"VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID", "SUPABASE_JWT_SECRET"} == set(
+        body["env_vars"].keys()
+    )
+    assert "voyage" in body["external_apis"]
+    assert "perplexity" in body["external_apis"]
+
+
+def test_health_db_connected_when_version_nonzero(client):
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock(version=9)), \
+         patch("routes.admin.httpx", _make_healthy_httpx_mock()):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    body = resp.json()
+    assert body["db"]["connected"] is True
+    assert body["db"]["schema_version"] == 9
+
+
+def test_health_db_disconnected_when_version_zero(client):
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock(version=0)), \
+         patch("routes.admin.httpx", _make_healthy_httpx_mock()):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    body = resp.json()
+    assert body["db"]["connected"] is False
+    assert body["db"]["schema_version"] == 0
+
+
+def test_health_env_vars_present_when_set(client):
+    extra_env = {
+        "VOYAGE_API_KEY": "vk",
+        "PERPLEXITY_API_KEY": "pk",
+        "MODAL_TOKEN_ID": "mk",
+        "SUPABASE_JWT_SECRET": "sk",
+    }
+    with patch.dict(os.environ, extra_env), \
+         patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
+         patch("routes.admin.httpx", _make_healthy_httpx_mock()):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    body = resp.json()
+    assert all(body["env_vars"].values())
+
+
+def test_health_external_apis_unreachable_on_exception(client):
+    mock_http_client = AsyncMock()
+    mock_http_client.head = AsyncMock(side_effect=Exception("connection refused"))
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_http_client)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient.return_value = mock_cm
+
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
+         patch("routes.admin.httpx", mock_httpx):
+        resp = client.get(
+            "/admin/health",
+            headers={"X-Admin-Token": "test-admin-token"},
+        )
+    body = resp.json()
+    assert body["external_apis"]["voyage"]["reachable"] is False
+    assert body["external_apis"]["perplexity"]["reachable"] is False

--- a/web/app/admin/health/page.tsx
+++ b/web/app/admin/health/page.tsx
@@ -1,0 +1,114 @@
+/** Admin health page — shows DB, env var, and external API status. Server component. */
+
+interface DbStatus {
+  connected: boolean;
+  schema_version: number;
+}
+
+interface ServiceStatus {
+  reachable: boolean;
+}
+
+interface HealthData {
+  db: DbStatus;
+  env_vars: Record<string, boolean>;
+  external_apis: Record<string, ServiceStatus>;
+}
+
+const ENV_VAR_LABELS: Record<string, string> = {
+  VOYAGE_API_KEY: "Voyage AI API Key",
+  PERPLEXITY_API_KEY: "Perplexity API Key",
+  MODAL_TOKEN_ID: "Modal Token ID",
+  SUPABASE_JWT_SECRET: "Supabase JWT Secret",
+};
+
+async function fetchHealth(): Promise<HealthData | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const adminToken = process.env.ADMIN_SECRET_TOKEN;
+
+  if (!apiUrl || !adminToken) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/health`, {
+      headers: { "X-Admin-Token": adminToken },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<HealthData>;
+  } catch {
+    return null;
+  }
+}
+
+function StatusDot({ ok }: { ok: boolean }) {
+  return (
+    <span
+      className={`inline-block h-3 w-3 flex-shrink-0 rounded-full ${ok ? "bg-green-500" : "bg-red-500"}`}
+    />
+  );
+}
+
+function StatusRow({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <div className="flex items-center gap-3 py-1.5">
+      <StatusDot ok={ok} />
+      <span className="text-sm text-zinc-700">{label}</span>
+    </div>
+  );
+}
+
+function StatusCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-5">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+export default async function AdminHealthPage() {
+  const health = await fetchHealth();
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      <div className="mb-6">
+        <a href="/admin/ingest" className="text-sm text-blue-600 hover:underline">
+          ← Admin Ingest
+        </a>
+      </div>
+      <h1 className="mb-8 text-3xl font-semibold text-zinc-900">Admin — System Health</h1>
+
+      {health === null ? (
+        <p className="text-red-500">Unable to fetch health data. Check server configuration.</p>
+      ) : (
+        <div className="grid gap-6 sm:grid-cols-3">
+          <StatusCard title="Database">
+            <StatusRow label="Connected" ok={health.db.connected} />
+            <StatusRow
+              label={`Schema v${health.db.schema_version}`}
+              ok={health.db.connected}
+            />
+          </StatusCard>
+
+          <StatusCard title="Environment Variables">
+            {Object.entries(health.env_vars).map(([key, present]) => (
+              <StatusRow key={key} label={ENV_VAR_LABELS[key] ?? key} ok={present} />
+            ))}
+          </StatusCard>
+
+          <StatusCard title="External APIs">
+            {Object.entries(health.external_apis).map(([name, status]) => (
+              <StatusRow
+                key={name}
+                label={name.charAt(0).toUpperCase() + name.slice(1)}
+                ok={status.reachable}
+              />
+            ))}
+          </StatusCard>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -2,6 +2,11 @@
 export default function AdminIngestPage() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      <div className="mb-6">
+        <a href="/admin/health" className="text-sm text-blue-600 hover:underline">
+          System Health →
+        </a>
+      </div>
       <h1 className="mb-2 text-3xl font-semibold text-zinc-900">
         Admin — Ingest
       </h1>

--- a/web/app/api/admin/health/route.ts
+++ b/web/app/api/admin/health/route.ts
@@ -1,0 +1,26 @@
+/** Server-side proxy for GET /admin/health — keeps ADMIN_SECRET_TOKEN off the client. */
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const adminToken = process.env.ADMIN_SECRET_TOKEN;
+
+  if (!apiUrl || !adminToken) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL or ADMIN_SECRET_TOKEN is not set" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/health`, {
+      headers: { "X-Admin-Token": adminToken },
+      cache: "no-store",
+    });
+
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /admin/health` FastAPI endpoint (protected by `X-Admin-Token`) returning DB connection + schema version, env var presence (boolean only, never values), and external API reachability for Voyage AI and Perplexity
- Adds `web/app/api/admin/health/route.ts` — server-side Next.js proxy that injects `ADMIN_SECRET_TOKEN` so it never reaches the client
- Adds `web/app/admin/health/page.tsx` — server component with a 3-column status grid (green/red indicators per service)
- Links the health page from the admin ingest page

## Test plan

- [ ] `pytest tests/unit/api/test_admin.py -v` — 17 tests, all pass
- [ ] Start API (`uvicorn main:app --reload` in `api/`), hit `GET /admin/health` with valid `X-Admin-Token` — verify JSON shape
- [ ] Hit without token — verify 403
- [ ] Start Next.js (`npm run dev` in `web/`), navigate to `/admin/health` — verify status grid renders
- [ ] Confirm `ADMIN_SECRET_TOKEN` is not required in `web/.env.local` for the page to render (add it server-side only)

Closes #164