### PR TITLE
fix: support Vercel preview origins via CORS_ORIGIN_REGEX

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,11 +34,17 @@ def build_cors_origins() -> list[str]:
     return origins
 
 
+def build_cors_origin_regex() -> str | None:
+    """Return a regex matching allowed origin patterns from CORS_ORIGIN_REGEX env var."""
+    return os.environ.get("CORS_ORIGIN_REGEX") or None
+
+
 app = FastAPI(title="EarningsFluency API", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=build_cors_origins(),
+    allow_origin_regex=build_cors_origin_regex(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary

- Adds `allow_origin_regex` to `CORSMiddleware` in `api/main.py`, driven by a new `CORS_ORIGIN_REGEX` env var on Railway
- Fixes `NetworkError` / missing `Access-Control-Allow-Origin` on Vercel preview deployments, where the origin changes with every push

## Railway setup required

Set this env var on the Railway service (no redeploy needed after the env var is set, but this code change must be deployed first):

```
CORS_ORIGIN_REGEX=https://earnings-transcript-teacher(-[a-z0-9-]+)?\.vercel\.app
```

## Test plan

- [ ] Deploy to Railway and set `CORS_ORIGIN_REGEX` as above
- [ ] Open a Vercel preview URL and sign in — library page should load without CORS errors
- [ ] Confirm `http://localhost:3000` still works (covered by existing `allow_origins` list)
- [ ] Confirm an unrelated origin (e.g. `https://evil.com`) is still blocked