### PR TITLE
feat: user roles — schema and FastAPI enforcement

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -8,9 +8,6 @@ PERPLEXITY_API_KEY=
 ANTHROPIC_API_KEY=
 API_NINJAS_KEY=
 
-# Admin
-ADMIN_SECRET_TOKEN=
-
 # CORS — set in Railway to allow the Vercel production domain
 # Omit in local dev (http://localhost:3000 is always allowed)
 NEXT_PUBLIC_VERCEL_URL=

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,4 +1,4 @@
-"""Shared FastAPI dependencies: database connection, auth, admin token."""
+"""Shared FastAPI dependencies: database connection, auth, admin check."""
 
 import os
 from collections.abc import Generator
@@ -52,16 +52,21 @@ def get_current_user(authorization: Annotated[str | None, Header()] = None) -> s
     return user_id
 
 
-def verify_admin_token(x_admin_token: Annotated[str | None, Header()] = None) -> None:
-    """Raise 403 if X-Admin-Token header does not match ADMIN_SECRET_TOKEN env var."""
-    expected = os.environ.get("ADMIN_SECRET_TOKEN", "")
-    if not expected or x_admin_token != expected:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Invalid or missing admin token",
-        )
-
-
 DbDep = Annotated[psycopg.Connection, Depends(get_db)]
 CurrentUserDep = Annotated[str, Depends(get_current_user)]
-AdminDep = Annotated[None, Depends(verify_admin_token)]
+
+
+def require_admin(user_id: CurrentUserDep, conn: DbDep) -> str:
+    """Raise 403 if the authenticated user does not have the admin role in profiles."""
+    row = conn.execute(
+        "SELECT role FROM public.profiles WHERE id = %s", (user_id,)
+    ).fetchone()
+    if row is None or row[0] != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin role required",
+        )
+    return user_id
+
+
+RequireAdminDep = Annotated[str, Depends(require_admin)]

--- a/api/main.py
+++ b/api/main.py
@@ -14,7 +14,7 @@ from routes import admin, calls, chat
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown hooks."""
     # Startup: validate required environment variables are present
-    required = ["DATABASE_URL", "SUPABASE_JWT_SECRET", "ADMIN_SECRET_TOKEN"]
+    required = ["DATABASE_URL", "SUPABASE_JWT_SECRET"]
     missing = [var for var in required if not os.environ.get(var)]
     if missing:
         raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, field_validator
 
 from db.repositories import SchemaRepository
-from dependencies import AdminDep
+from dependencies import RequireAdminDep
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ _PERPLEXITY_URL = "https://api.perplexity.ai"
 
 
 @router.get("/health")
-async def system_health(_: AdminDep) -> dict:
+async def system_health(_: RequireAdminDep) -> dict:
     """Return system health: DB connection, env var presence, and external API reachability."""
     db_url = os.environ.get("DATABASE_URL", "")
     repo = SchemaRepository(db_url)
@@ -76,7 +76,7 @@ async def system_health(_: AdminDep) -> dict:
 
 
 @router.post("/ingest", status_code=202)
-async def trigger_ingestion(body: IngestRequest, _: AdminDep) -> dict:
+async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""
     fn = modal.Function.lookup("earnings-ingestion", "ingest_ticker")
     fn.spawn(body.ticker)

--- a/db/migrations/010_profiles.sql
+++ b/db/migrations/010_profiles.sql
@@ -1,0 +1,25 @@
+-- Migration 010: Add profiles table for per-user role-based access control.
+-- Replaces ADMIN_SECRET_TOKEN with a DB-backed role lookup.
+
+CREATE TYPE public.user_role AS ENUM ('admin', 'learner');
+
+CREATE TABLE public.profiles (
+    id   UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    role public.user_role NOT NULL DEFAULT 'learner'
+);
+
+-- Auto-insert a learner profile when a new auth user is created.
+-- SECURITY DEFINER is required because auth.users is in the Supabase-managed schema.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO public.profiles (id, role) VALUES (NEW.id, 'learner');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -256,3 +256,27 @@ CREATE TABLE competitors (
 
 CREATE INDEX idx_competitors_call ON competitors(call_id);
 
+-- ============================================================
+-- User Roles
+-- ============================================================
+
+CREATE TYPE public.user_role AS ENUM ('admin', 'learner');
+
+CREATE TABLE public.profiles (
+    id   UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    role public.user_role NOT NULL DEFAULT 'learner'
+);
+
+-- Auto-insert a learner profile when a new auth user is created.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO public.profiles (id, role) VALUES (NEW.id, 'learner');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE TRIGGER on_auth_user_created
+    AFTER INSERT ON auth.users
+    FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -46,6 +46,7 @@ create extension if not exists vector;
 
 From the repo root, using the **Session mode pooler** connection string (port 5432, not 6543):
 
+
 ```bash
 source .venv/bin/activate
 DATABASE_URL="postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supabase.com:5432/postgres" \
@@ -53,6 +54,21 @@ DATABASE_URL="postgresql://postgres.[ref]:[password]@aws-0-[region].pooler.supab
 ```
 
 Migrations are in `db/migrations/` and are applied in order. The `schema_version` table tracks which have run.
+
+### 1.3a Provision the admin user role (one-time manual step)
+
+After running migrations, backfill existing users and promote the first admin. Run in the Supabase SQL Editor:
+
+```sql
+-- Backfill any users who signed up before this migration
+INSERT INTO public.profiles (id, role)
+  SELECT id, 'learner' FROM auth.users ON CONFLICT DO NOTHING;
+
+-- Promote your admin user (find the UUID in Authentication → Users)
+UPDATE public.profiles SET role = 'admin' WHERE id = '<user-uuid>';
+```
+
+All future sign-ups get a learner row automatically via the trigger.
 
 ### 1.4 Configure Google OAuth
 
@@ -115,7 +131,6 @@ Set these in both **production** and **staging** environments (with different va
 |---|---|
 | `DATABASE_URL` | Supabase Session mode pooler connection string (port 5432) |
 | `SUPABASE_JWT_SECRET` | From Supabase → Settings → API → JWT Settings |
-| `ADMIN_SECRET_TOKEN` | Secret token for `POST /admin/ingest` (generate a strong random string) |
 | `NEXT_PUBLIC_VERCEL_URL` | The bare Vercel production domain, e.g. `earningsfluency.vercel.app` — used to build the CORS allow-list |
 | `CORS_ORIGIN_REGEX` | Regex matching allowed Vercel origins, e.g. `https://earningsfluency(-[a-z0-9-]+)?\.vercel\.app` — covers production and all preview deployments |
 | `VOYAGE_API_KEY` | VoyageAI API key (semantic embeddings) |
@@ -151,10 +166,8 @@ In Vercel project → Settings → Environment Variables, add these with the cor
 | `NEXT_PUBLIC_SUPABASE_URL` | Production Supabase URL | Staging Supabase URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Production anon key | Staging anon key |
 | `NEXT_PUBLIC_API_URL` | Railway production URL | Railway staging URL |
-| `ADMIN_SECRET_TOKEN` | Same value as Railway | Same value as Railway staging |
 
 > **How to scope**: When adding each variable, check only the environment checkboxes that apply (Production / Preview / Development).
-> **`ADMIN_SECRET_TOKEN` on Vercel**: required server-side by the `/admin/health` proxy route handler — it is never exposed to the browser.
 
 ### 3.3 Automatic preview deployments
 
@@ -215,11 +228,11 @@ This builds the Docker image, pushes it to Modal, and registers the `ingest_tick
 
 ### 4.4 Verify
 
-Trigger a test ingestion via the API:
+Trigger a test ingestion via the API (requires an admin user JWT — obtain from the Supabase dashboard under Authentication → Users → select admin user → copy access token, or from a signed-in browser session):
 
 ```bash
 curl -X POST https://[railway-domain]/admin/ingest \
-  -H "X-Admin-Token: [ADMIN_SECRET_TOKEN]" \
+  -H "Authorization: Bearer <admin-user-jwt>" \
   -H "Content-Type: application/json" \
   -d '{"ticker": "AAPL"}'
 # Expected: 202 Accepted
@@ -231,8 +244,8 @@ You can also verify overall system health:
 
 ```bash
 curl https://[railway-domain]/admin/health \
-  -H "X-Admin-Token: [ADMIN_SECRET_TOKEN]"
-# Expected: {"db":{"connected":true,"schema_version":9},"env_vars":{...},"external_apis":{...}}
+  -H "Authorization: Bearer <admin-user-jwt>"
+# Expected: {"db":{"connected":true,"schema_version":10},"env_vars":{...},"external_apis":{...}}
 ```
 
 ---
@@ -246,7 +259,6 @@ Complete reference of all env vars, grouped by where they're set:
 ```
 DATABASE_URL=postgresql://postgres.[ref]:[pw]@aws-0-[region].pooler.supabase.com:5432/postgres
 SUPABASE_JWT_SECRET=
-ADMIN_SECRET_TOKEN=
 NEXT_PUBLIC_VERCEL_URL=
 CORS_ORIGIN_REGEX=
 VOYAGE_API_KEY=
@@ -261,7 +273,6 @@ API_NINJAS_KEY=
 NEXT_PUBLIC_SUPABASE_URL=https://[ref].supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 NEXT_PUBLIC_API_URL=http://localhost:8000
-ADMIN_SECRET_TOKEN=
 ```
 
 ### Modal (secrets group `earnings-secrets`)
@@ -282,10 +293,12 @@ If starting from zero:
 - [ ] Create Supabase production project
 - [ ] Enable pgvector extension on production
 - [ ] Run migrations on production (`python migrate.py`)
+- [ ] Backfill profiles table and promote admin user on production (see §1.3a)
 - [ ] Configure Google OAuth on production (redirect URLs)
 - [ ] Create Supabase staging project
 - [ ] Enable pgvector extension on staging
 - [ ] Run migrations on staging
+- [ ] Backfill profiles table and promote admin user on staging (see §1.3a)
 - [ ] Configure Google OAuth on staging (redirect URLs)
 - [ ] Create Railway project from GitHub repo
 - [ ] Set production env vars in Railway

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -4,6 +4,7 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import jwt as pyjwt
 import pytest
 
 API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
@@ -19,15 +20,27 @@ from main import app  # noqa: E402  (must come after sys.modules stub)
 ENV = {
     "DATABASE_URL": "postgresql://test",
     "SUPABASE_JWT_SECRET": "secret",
-    "ADMIN_SECRET_TOKEN": "test-admin-token",
 }
+
+ADMIN_UUID = "00000000-0000-0000-0000-000000000001"
+LEARNER_UUID = "00000000-0000-0000-0000-000000000002"
+
+ADMIN_AUTH = {"Authorization": f"Bearer {pyjwt.encode({'sub': ADMIN_UUID}, 'secret', algorithm='HS256')}"}
+LEARNER_AUTH = {"Authorization": f"Bearer {pyjwt.encode({'sub': LEARNER_UUID}, 'secret', algorithm='HS256')}"}
+
+
+def _make_mock_conn(role: str = "admin") -> MagicMock:
+    """Return a mock psycopg connection whose execute().fetchone() returns the given role."""
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchone.return_value = (role,)
+    return mock_conn
 
 
 @pytest.fixture()
 def client():
-    """Return a TestClient with required env vars set and side-effects mocked."""
+    """Return a TestClient with required env vars set and the DB mocked for an admin user."""
     with patch.dict(os.environ, ENV):
-        with patch("psycopg.connect"):
+        with patch("psycopg.connect", return_value=_make_mock_conn("admin")):
             from fastapi.testclient import TestClient
 
             with TestClient(app) as c:
@@ -47,7 +60,7 @@ def test_ingest_returns_202(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "AAPL"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
 
     assert resp.status_code == 202
@@ -64,7 +77,7 @@ def test_ingest_uppercases_ticker(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "aapl"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
 
     assert resp.status_code == 202
@@ -72,17 +85,27 @@ def test_ingest_uppercases_ticker(client):
     mock_fn.spawn.assert_called_once_with("AAPL")
 
 
-def test_ingest_missing_token_returns_403(client):
+def test_ingest_missing_auth_returns_401(client):
     resp = client.post("/admin/ingest", json={"ticker": "AAPL"})
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
-def test_ingest_wrong_token_returns_403(client):
+def test_ingest_invalid_jwt_returns_401(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "AAPL"},
-        headers={"X-Admin-Token": "wrong"},
+        headers={"Authorization": "Bearer not-a-real-jwt"},
     )
+    assert resp.status_code == 401
+
+
+def test_ingest_learner_role_returns_403(client):
+    with patch("psycopg.connect", return_value=_make_mock_conn("learner")):
+        resp = client.post(
+            "/admin/ingest",
+            json={"ticker": "AAPL"},
+            headers=LEARNER_AUTH,
+        )
     assert resp.status_code == 403
 
 
@@ -90,7 +113,7 @@ def test_ingest_missing_ticker_returns_422(client):
     resp = client.post(
         "/admin/ingest",
         json={},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
     assert resp.status_code == 422
 
@@ -99,7 +122,7 @@ def test_ingest_invalid_ticker_too_short_returns_422(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "A"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
     assert resp.status_code == 422
 
@@ -108,7 +131,7 @@ def test_ingest_invalid_ticker_too_long_returns_422(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "TOOLONG"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
     assert resp.status_code == 422
 
@@ -117,7 +140,7 @@ def test_ingest_invalid_ticker_non_alpha_returns_422(client):
     resp = client.post(
         "/admin/ingest",
         json={"ticker": "AP1L"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
     assert resp.status_code == 422
 
@@ -129,7 +152,7 @@ def test_ingest_looks_up_correct_modal_function(client):
     client.post(
         "/admin/ingest",
         json={"ticker": "MSFT"},
-        headers={"X-Admin-Token": "test-admin-token"},
+        headers=ADMIN_AUTH,
     )
 
     MODAL_STUB.Function.lookup.assert_called_with("earnings-ingestion", "ingest_ticker")
@@ -160,36 +183,36 @@ def _make_schema_repo_mock(version: int = 9):
     return mock_cls
 
 
-def test_health_returns_200_with_valid_token(client):
+def test_health_returns_200(client):
     with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     assert resp.status_code == 200
 
 
-def test_health_missing_token_returns_403(client):
+def test_health_missing_auth_returns_401(client):
     resp = client.get("/admin/health")
-    assert resp.status_code == 403
+    assert resp.status_code == 401
 
 
-def test_health_wrong_token_returns_403(client):
+def test_health_invalid_jwt_returns_401(client):
     resp = client.get(
         "/admin/health",
-        headers={"X-Admin-Token": "wrong"},
+        headers={"Authorization": "Bearer not-a-real-jwt"},
     )
+    assert resp.status_code == 401
+
+
+def test_health_learner_role_returns_403(client):
+    with patch("psycopg.connect", return_value=_make_mock_conn("learner")):
+        resp = client.get("/admin/health", headers=LEARNER_AUTH)
     assert resp.status_code == 403
 
 
 def test_health_response_has_expected_keys(client):
     with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
     assert "db" in body
     assert "env_vars" in body
@@ -206,10 +229,7 @@ def test_health_response_has_expected_keys(client):
 def test_health_db_connected_when_version_nonzero(client):
     with patch("routes.admin.SchemaRepository", _make_schema_repo_mock(version=9)), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
     assert body["db"]["connected"] is True
     assert body["db"]["schema_version"] == 9
@@ -218,10 +238,7 @@ def test_health_db_connected_when_version_nonzero(client):
 def test_health_db_disconnected_when_version_zero(client):
     with patch("routes.admin.SchemaRepository", _make_schema_repo_mock(version=0)), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
     assert body["db"]["connected"] is False
     assert body["db"]["schema_version"] == 0
@@ -232,15 +249,12 @@ def test_health_env_vars_present_when_set(client):
         "VOYAGE_API_KEY": "vk",
         "PERPLEXITY_API_KEY": "pk",
         "MODAL_TOKEN_ID": "mk",
-        "SUPABASE_JWT_SECRET": "sk",
+        "SUPABASE_JWT_SECRET": "secret",  # must match the key used to sign ADMIN_AUTH
     }
     with patch.dict(os.environ, extra_env), \
          patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
     assert all(body["env_vars"].values())
 
@@ -256,10 +270,7 @@ def test_health_external_apis_unreachable_on_exception(client):
 
     with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
          patch("routes.admin.httpx", mock_httpx):
-        resp = client.get(
-            "/admin/health",
-            headers={"X-Admin-Token": "test-admin-token"},
-        )
+        resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
     assert body["external_apis"]["voyage"]["reachable"] is False
     assert body["external_apis"]["perplexity"]["reachable"] is False

--- a/web/app/api/admin/health/route.ts
+++ b/web/app/api/admin/health/route.ts
@@ -1,23 +1,31 @@
-/** Server-side proxy for GET /admin/health — keeps ADMIN_SECRET_TOKEN off the client. */
+/** Server-side proxy for GET /admin/health — reads Supabase session and forwards JWT. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  const adminToken = process.env.ADMIN_SECRET_TOKEN;
 
-  if (!apiUrl || !adminToken) {
+  if (!apiUrl) {
     return NextResponse.json(
-      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL or ADMIN_SECRET_TOKEN is not set" },
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
       { status: 500 }
     );
   }
 
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
   try {
     const resp = await fetch(`${apiUrl}/admin/health`, {
-      headers: { "X-Admin-Token": adminToken },
+      headers: { Authorization: `Bearer ${session.access_token}` },
       cache: "no-store",
     });
-
     const data: unknown = await resp.json();
     return NextResponse.json(data, { status: resp.status });
   } catch {

--- a/web/env.example
+++ b/web/env.example
@@ -1,4 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_API_URL=http://localhost:8000
-ADMIN_SECRET_TOKEN=                        # same value as Railway — used server-side by /admin/health proxy


### PR DESCRIPTION
Closes #180

## Summary

- Replaces `ADMIN_SECRET_TOKEN` (shared secret, no per-user identity) with a `profiles` table that stores a `role` (`admin` | `learner`) for every Supabase user
- New `require_admin` FastAPI dependency: verifies the Supabase JWT, then does a single indexed `profiles` lookup — 401 if unauthenticated, 403 if not admin
- Admin endpoints (`GET /admin/health`, `POST /admin/ingest`) now require an authenticated admin JWT instead of the `X-Admin-Token` header
- The `/api/admin/health` Next.js proxy reads the session from cookies and forwards the user's JWT as `Authorization: Bearer`
- `ADMIN_SECRET_TOKEN` removed from all code, env var tables, and example configs

**Auth approach chosen: DB lookup** (not JWT hook). Admin endpoints are infrequent; the extra round trip is negligible, and this avoids manual Supabase dashboard configuration that is hard to reproduce.

## Test plan

- [ ] `pytest tests/unit/api/test_admin.py -v` — 19 tests, all pass
- [ ] Full suite `pytest` — 115 tests, all pass
- [ ] After deploying to staging: `curl -i https://[railway-domain]/admin/health` → 401 (no auth)
- [ ] With a learner JWT → 403
- [ ] With an admin JWT → 200
- [ ] Sign in as admin on Vercel preview, navigate to admin health dashboard → loads correctly
- [ ] Confirm `ADMIN_SECRET_TOKEN` removed from Railway and Vercel env vars after deploy

## ⚠️ Manual ops required before deploying

1. Run migration 010 on each environment (`python migrate.py`)
2. Backfill existing users and promote admin (see §1.3a in `docs/disaster-recovery.md`):
   ```sql
   INSERT INTO public.profiles (id, role)
     SELECT id, 'learner' FROM auth.users ON CONFLICT DO NOTHING;
   UPDATE public.profiles SET role = 'admin' WHERE id = '<your-uuid>';
   ```
3. Deploy backend, then frontend
4. Remove `ADMIN_SECRET_TOKEN` from Railway and Vercel env vars