### PR TITLE
feat: gate /admin/* routes and show admin nav links based on role

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -29,6 +29,16 @@ export default async function RootLayout({
     data: { user },
   } = await supabase.auth.getUser();
 
+  let isAdmin = false;
+  if (user) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+    isAdmin = profile?.role === "admin";
+  }
+
   return (
     <html
       lang="en"
@@ -45,6 +55,22 @@ export default async function RootLayout({
                 EarningsFluency
               </a>
               <div className="flex items-center gap-4">
+                {isAdmin && (
+                  <>
+                    <a
+                      href="/admin/health"
+                      className="text-sm text-zinc-500 hover:text-zinc-700"
+                    >
+                      Admin Health
+                    </a>
+                    <a
+                      href="/admin/ingest"
+                      className="text-sm text-zinc-500 hover:text-zinc-700"
+                    >
+                      Admin Ingest
+                    </a>
+                  </>
+                )}
                 <span className="text-sm text-zinc-500">{user.email}</span>
                 <SignOutButton />
               </div>

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -40,6 +40,20 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(signInUrl);
   }
 
+  if (user && pathname.startsWith("/admin")) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .single();
+
+    if (profile?.role !== "admin") {
+      const homeUrl = request.nextUrl.clone();
+      homeUrl.pathname = "/";
+      return NextResponse.redirect(homeUrl);
+    }
+  }
+
   return supabaseResponse;
 }
 


### PR DESCRIPTION
## Summary

- `proxy.ts`: queries `profiles` table on every `/admin/*` request; redirects authenticated non-admins to `/` (unauthenticated users hit the existing sign-in redirect first)
- `web/app/layout.tsx`: fetches profile role and conditionally renders Admin Health / Admin Ingest nav links — learners see neither
- `web/app/api/admin/health/route.ts`: no changes needed — already forwards JWT as `Authorization: Bearer`

Implements the DB lookup strategy (consistent with #180's `require_admin` dependency).

## Test plan

- [ ] Unauthenticated user → `/admin/health` → redirected to `/auth/sign-in`
- [ ] Learner user → `/admin/health` → redirected to `/`
- [ ] Admin user → `/admin/health` → page loads
- [ ] Learner: no Admin Health / Admin Ingest links in nav
- [ ] Admin: both admin links visible and functional

Closes #181