### PR TITLE
fix: enable RLS and add SELECT policy on profiles table

### DIFF
--- a/db/migrations/010_profiles.sql
+++ b/db/migrations/010_profiles.sql
@@ -22,4 +22,13 @@ CREATE TRIGGER on_auth_user_created
     AFTER INSERT ON auth.users
     FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
 
+-- Allow authenticated users to read their own profile row.
+-- Required for the Next.js server client (anon key + user JWT) to query role.
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "users_read_own_profile"
+    ON public.profiles
+    FOR SELECT
+    USING (auth.uid() = id);
+
 INSERT INTO schema_version (version) VALUES (10) ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- Enables RLS on `public.profiles`
- Adds a `SELECT` policy so authenticated users can read their own row via the Supabase anon client

Without this, the Next.js server client returns `null` for the profile query, keeping `isAdmin = false` and blocking admin users from `/admin/*` routes and nav links.

The policy was already applied manually in production. This PR captures it in the migration for disaster recovery.

## Test plan

- [ ] Migration runs cleanly on a fresh install
- [ ] Admin user sees Admin Health / Admin Ingest nav links in production