### PR TITLE
feat: admin session activity panel (#165)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -8,9 +8,11 @@ from datetime import UTC, datetime
 
 import httpx
 import modal
+import psycopg
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, field_validator
 
+from db.analytics import track
 from db.repositories import SchemaRepository
 from dependencies import RequireAdminDep
 
@@ -73,6 +75,29 @@ async def system_health(_: RequireAdminDep) -> dict:
             "perplexity": {"reachable": perplexity_reachable},
         },
     }
+
+
+def _db_url() -> str:
+    """Return the database connection URL from environment."""
+    return os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
+
+
+@router.get("/analytics/sessions")
+def analytics_sessions(_: RequireAdminDep) -> list[dict]:
+    """Return daily session_start counts for the last 30 days."""
+    with psycopg.connect(_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT DATE(created_at) AS date, COUNT(*) AS count
+                FROM analytics_events
+                WHERE event_name = 'session_start'
+                  AND created_at >= NOW() - INTERVAL '30 days'
+                GROUP BY date
+                ORDER BY date
+                """
+            )
+            return [{"date": str(row[0]), "count": row[1]} for row in cur.fetchall()]
 
 
 @router.post("/ingest", status_code=202)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, HTTPException, status
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from db.analytics import track
 from dependencies import CurrentUserDep
 
 router = APIRouter(prefix="/api/calls", tags=["chat"])
@@ -187,6 +188,7 @@ def chat(
         topic = body.message
         stage = max(1, min(body.stage, 5))
         history = []
+        track("session_start", session_id=session_id, properties={"ticker": ticker, "stage": stage})
 
     system_prompt = _load_prompt(stage)
     messages = history + [{"role": "user", "content": body.message}]

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import os
 
 import streamlit as st
 
+from db.analytics import track
 from db.repositories import LearningRepository, SchemaRepository
 from ui.data_loaders import load_analyst_view, load_call_summary, load_metadata, load_qa_evasion, load_speaker_dynamics, load_speakers, load_step_progress, load_strategic_shifts, load_transcript_spans
 from ui.feynman import render_chat_interface
@@ -49,6 +50,10 @@ if "feynman_synthesis_notes" not in st.session_state:
 
 if "confirm_reset" not in st.session_state:
     st.session_state.confirm_reset = False
+
+if "analytics_tracked_start" not in st.session_state:
+    st.session_state.analytics_tracked_start = True
+    track("session_start", properties={"source": "streamlit"})
 
 if "transcript_search_term" not in st.session_state:
     st.session_state.transcript_search_term = ""

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -1,0 +1,42 @@
+"""Analytics event tracking — fire-and-forget inserts into analytics_events."""
+
+import logging
+import os
+import threading
+from typing import Any
+
+import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def _insert_event(event_name: str, session_id: str | None, properties: dict[str, Any] | None) -> None:
+    """Execute the DB insert; run in a background thread."""
+    try:
+        db_url = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
+        with psycopg.connect(db_url) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO analytics_events (event_name, session_id, properties)
+                    VALUES (%s, %s::uuid, %s::jsonb)
+                    """,
+                    (event_name, session_id, psycopg.types.json.Jsonb(properties or {})),
+                )
+            conn.commit()
+    except Exception as exc:
+        logger.warning("analytics.track failed for event=%r: %s", event_name, exc)
+
+
+def track(
+    event_name: str,
+    session_id: str | None = None,
+    properties: dict[str, Any] | None = None,
+) -> None:
+    """Record an analytics event without blocking the caller.
+
+    Spawns a daemon thread to perform the DB insert. Logs a warning on failure
+    and never raises — safe to call on any code path.
+    """
+    t = threading.Thread(target=_insert_event, args=(event_name, session_id, properties), daemon=True)
+    t.start()

--- a/db/migrations/011_analytics_events.sql
+++ b/db/migrations/011_analytics_events.sql
@@ -1,0 +1,15 @@
+-- Migration 011: analytics_events table for observability instrumentation.
+-- Stores fire-and-forget events emitted by API, Streamlit, and CLI layers.
+
+CREATE TABLE analytics_events (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_name  TEXT NOT NULL,
+    session_id  UUID,
+    properties  JSONB,
+    created_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_analytics_event_name ON analytics_events (event_name);
+CREATE INDEX idx_analytics_created_at  ON analytics_events (created_at);
+
+INSERT INTO schema_version (version) VALUES (11);

--- a/main.py
+++ b/main.py
@@ -43,6 +43,8 @@ if __name__ == "__main__":
     # If run without arguments (and mode is cli), use interactive menu
     if not args.ticker:
         try:
+            from db.analytics import track
+            track("session_start", properties={"source": "cli"})
             interactive_menu()
         except KeyboardInterrupt:
             print("\nGoodbye!")

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -1,0 +1,88 @@
+/** Admin analytics dashboard — aggregated observability panels. Server component. */
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+interface DailyCount {
+  date: string;
+  count: number;
+}
+
+async function fetchSessions(): Promise<DailyCount[] | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/sessions`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<DailyCount[]>;
+  } catch {
+    return null;
+  }
+}
+
+function AnalyticsCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-zinc-200 bg-white p-5">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+        {title}
+      </h2>
+      {children}
+    </div>
+  );
+}
+
+export default async function AdminAnalyticsPage() {
+  const sessions = await fetchSessions();
+
+  const totalSessions = sessions?.reduce((sum, row) => sum + row.count, 0) ?? 0;
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      <div className="mb-6 flex gap-4 text-sm">
+        <a href="/admin/health" className="text-blue-600 hover:underline">
+          System Health
+        </a>
+        <a href="/admin/ingest" className="text-blue-600 hover:underline">
+          Ingest
+        </a>
+      </div>
+      <h1 className="mb-8 text-3xl font-semibold text-zinc-900">Admin — Analytics</h1>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <AnalyticsCard title={`Session Activity — last 30 days (${totalSessions} total)`}>
+          {sessions === null ? (
+            <p className="text-sm text-red-500">Unable to load session data.</p>
+          ) : sessions.length === 0 ? (
+            <p className="text-sm text-zinc-500">No sessions recorded yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100">
+                  <th className="py-1.5 text-left font-medium text-zinc-500">Date</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Sessions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sessions.map((row) => (
+                  <tr key={row.date} className="border-b border-zinc-50">
+                    <td className="py-1.5 text-zinc-700">{row.date}</td>
+                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </AnalyticsCard>
+      </div>
+    </div>
+  );
+}

--- a/web/app/api/admin/analytics/sessions/route.ts
+++ b/web/app/api/admin/analytics/sessions/route.ts
@@ -1,0 +1,34 @@
+/** Server-side proxy for GET /admin/analytics/sessions — forwards JWT to FastAPI. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/sessions`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -58,6 +58,12 @@ export default async function RootLayout({
                 {isAdmin && (
                   <>
                     <a
+                      href="/admin"
+                      className="text-sm text-zinc-500 hover:text-zinc-700"
+                    >
+                      Admin Analytics
+                    </a>
+                    <a
                       href="/admin/health"
                       className="text-sm text-zinc-500 hover:text-zinc-700"
                     >


### PR DESCRIPTION
## Summary

- Adds `db/migrations/011_analytics_events.sql` — shared `analytics_events` table used by all observability slices
- Adds `db/analytics.py` — fire-and-forget `track()` helper (daemon thread, logs warning on failure, never raises)
- Instruments `session_start` in API chat route, Streamlit app startup, and CLI menu entry
- Adds `GET /admin/analytics/sessions` FastAPI endpoint returning daily counts for last 30 days
- Adds Next.js proxy route and `/admin` analytics dashboard page with sessions-per-day table
- Adds "Admin Analytics" nav link for admin users

## Migration

After merging, run `python3 migrate.py` against the database to apply `011_analytics_events.sql`.

## Test plan

- [ ] Run `python3 migrate.py` — confirms "Applied 011_analytics_events.sql"
- [ ] Start a new chat session via the API — query `SELECT * FROM analytics_events` in Supabase SQL Editor, confirm `session_start` row appears
- [ ] Open Streamlit app — confirm `session_start` row with `source=streamlit` appears
- [ ] Navigate to `/admin` as an admin user — sessions panel renders (empty table is fine if no events yet)
- [ ] Confirm non-admin users cannot access `/admin/analytics/sessions` (403)

Closes #165