### PR TITLE
feat: admin chat activity panel (#166)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -100,6 +100,41 @@ def analytics_sessions(_: RequireAdminDep) -> list[dict]:
             return [{"date": str(row[0]), "count": row[1]} for row in cur.fetchall()]
 
 
+@router.get("/analytics/chat")
+def analytics_chat(_: RequireAdminDep) -> dict:
+    """Return daily chat_turn counts and average turns per session for the last 30 days."""
+    with psycopg.connect(_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT DATE(created_at) AS date, COUNT(*) AS turns
+                FROM analytics_events
+                WHERE event_name = 'chat_turn'
+                  AND created_at >= NOW() - INTERVAL '30 days'
+                GROUP BY date
+                ORDER BY date
+                """
+            )
+            daily = [{"date": str(row[0]), "turns": row[1]} for row in cur.fetchall()]
+
+            cur.execute(
+                """
+                SELECT AVG(turns_per_session)
+                FROM (
+                    SELECT session_id, COUNT(*) AS turns_per_session
+                    FROM analytics_events
+                    WHERE event_name = 'chat_turn'
+                      AND created_at >= NOW() - INTERVAL '30 days'
+                    GROUP BY session_id
+                ) sub
+                """
+            )
+            row = cur.fetchone()
+            avg = round(float(row[0]), 1) if row and row[0] is not None else 0.0
+
+    return {"daily": daily, "avg_turns_per_session": avg}
+
+
 @router.post("/ingest", status_code=202)
 async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import time
 import uuid
 from pathlib import Path
 
@@ -119,6 +120,7 @@ def _sse_stream(
     from services.llm import stream_chat
 
     accumulated: list[str] = []
+    start = time.monotonic()
     try:
         for chunk in stream_chat(messages, system_prompt):
             if isinstance(chunk, str):
@@ -129,6 +131,15 @@ def _sse_stream(
         assistant_turn = {"role": "assistant", "content": "".join(accumulated)}
         updated_messages = messages + [assistant_turn]
         _upsert_session(ticker, session_id, user_id, topic, stage, updated_messages, completed=False)
+        track(
+            "chat_turn",
+            session_id=session_id,
+            properties={
+                "turn_number": len(messages),
+                "message_length": len(messages[-1]["content"]),
+                "latency_ms": int((time.monotonic() - start) * 1000),
+            },
+        )
         yield f"data: {json.dumps({'type': 'done', 'session_id': session_id})}\n\n"
 
     except Exception as exc:

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -7,14 +7,29 @@ interface DailyCount {
   count: number;
 }
 
-async function fetchSessions(): Promise<DailyCount[] | null> {
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
-  if (!apiUrl) return null;
+interface DailyTurns {
+  date: string;
+  turns: number;
+}
 
+interface ChatData {
+  daily: DailyTurns[];
+  avg_turns_per_session: number;
+}
+
+async function getSession() {
   const supabase = await createSupabaseServerClient();
   const {
     data: { session },
   } = await supabase.auth.getSession();
+  return session;
+}
+
+async function fetchSessions(): Promise<DailyCount[] | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const session = await getSession();
   if (!session) return null;
 
   try {
@@ -24,6 +39,25 @@ async function fetchSessions(): Promise<DailyCount[] | null> {
     });
     if (!resp.ok) return null;
     return resp.json() as Promise<DailyCount[]>;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchChat(): Promise<ChatData | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const session = await getSession();
+  if (!session) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/chat`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<ChatData>;
   } catch {
     return null;
   }
@@ -41,9 +75,10 @@ function AnalyticsCard({ title, children }: { title: string; children: React.Rea
 }
 
 export default async function AdminAnalyticsPage() {
-  const sessions = await fetchSessions();
+  const [sessions, chat] = await Promise.all([fetchSessions(), fetchChat()]);
 
   const totalSessions = sessions?.reduce((sum, row) => sum + row.count, 0) ?? 0;
+  const totalTurns = chat?.daily.reduce((sum, row) => sum + row.turns, 0) ?? 0;
 
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
@@ -76,6 +111,33 @@ export default async function AdminAnalyticsPage() {
                   <tr key={row.date} className="border-b border-zinc-50">
                     <td className="py-1.5 text-zinc-700">{row.date}</td>
                     <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </AnalyticsCard>
+
+        <AnalyticsCard
+          title={`Chat Activity — last 30 days (${totalTurns} turns, avg ${chat?.avg_turns_per_session ?? 0} per session)`}
+        >
+          {chat === null ? (
+            <p className="text-sm text-red-500">Unable to load chat data.</p>
+          ) : chat.daily.length === 0 ? (
+            <p className="text-sm text-zinc-500">No chat turns recorded yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100">
+                  <th className="py-1.5 text-left font-medium text-zinc-500">Date</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Turns</th>
+                </tr>
+              </thead>
+              <tbody>
+                {chat.daily.map((row) => (
+                  <tr key={row.date} className="border-b border-zinc-50">
+                    <td className="py-1.5 text-zinc-700">{row.date}</td>
+                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.turns}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web/app/api/admin/analytics/chat/route.ts
+++ b/web/app/api/admin/analytics/chat/route.ts
@@ -1,0 +1,34 @@
+/** Server-side proxy for GET /admin/analytics/chat — forwards JWT to FastAPI. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/chat`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary

- Instruments `chat_turn` event in `_sse_stream` after each successful LLM response, capturing `turn_number`, `message_length`, and `latency_ms`
- Adds `GET /admin/analytics/chat` returning daily turn counts and average turns per session over 30 days
- Adds Next.js proxy route `/api/admin/analytics/chat`
- Adds chat activity panel to the `/admin` analytics dashboard alongside the sessions panel

## Test plan

- [ ] Send a chat message via the API — confirm `chat_turn` row appears in `analytics_events`
- [ ] `GET /admin/analytics/chat` returns `{"daily": [...], "avg_turns_per_session": N}`
- [ ] Navigate to `/admin` — chat panel renders next to the sessions panel

Closes #166