### PR TITLE
feat: admin API cost panel (#167)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -135,6 +135,32 @@ def analytics_chat(_: RequireAdminDep) -> dict:
     return {"daily": daily, "avg_turns_per_session": avg}
 
 
+@router.get("/analytics/costs")
+def analytics_costs(_: RequireAdminDep) -> dict:
+    """Return token totals grouped by service for the last 30 days."""
+    with psycopg.connect(_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    properties->>'service' AS service,
+                    SUM((properties->>'input_tokens')::int) AS input_tokens,
+                    SUM((properties->>'output_tokens')::int) AS output_tokens
+                FROM analytics_events
+                WHERE event_name = 'api_call_completed'
+                  AND created_at >= NOW() - INTERVAL '30 days'
+                GROUP BY service
+                ORDER BY service
+                """
+            )
+            by_service = {
+                row[0]: {"input_tokens": row[1] or 0, "output_tokens": row[2] or 0}
+                for row in cur.fetchall()
+                if row[0]
+            }
+    return {"by_service": by_service}
+
+
 @router.post("/ingest", status_code=202)
 async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""

--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -6,6 +6,7 @@ import psycopg
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel
 
+from db.analytics import track
 from db.repositories import AnalysisRepository, CallRepository
 
 router = APIRouter(prefix="/api/calls", tags=["calls"])
@@ -257,7 +258,17 @@ def search_transcript(
     from pgvector.psycopg import register_vector
 
     client = voyageai.Client(api_key=api_key)
-    query_vector = client.embed([q], model="voyage-finance-2").embeddings[0]
+    embed_result = client.embed([q], model="voyage-finance-2")
+    query_vector = embed_result.embeddings[0]
+    track(
+        "api_call_completed",
+        properties={
+            "service": "voyage",
+            "operation": "search",
+            "input_tokens": embed_result.total_tokens,
+            "output_tokens": 0,
+        },
+    )
 
     with psycopg.connect(_db_url()) as conn:
         register_vector(conn)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -120,13 +120,15 @@ def _sse_stream(
     from services.llm import stream_chat
 
     accumulated: list[str] = []
+    usage: dict | None = None
     start = time.monotonic()
     try:
         for chunk in stream_chat(messages, system_prompt):
             if isinstance(chunk, str):
                 accumulated.append(chunk)
                 yield f"data: {json.dumps({'type': 'token', 'content': chunk})}\n\n"
-            # usage dict is silently skipped — not surfaced to the client
+            elif isinstance(chunk, dict) and "usage" in chunk:
+                usage = chunk
 
         assistant_turn = {"role": "assistant", "content": "".join(accumulated)}
         updated_messages = messages + [assistant_turn]
@@ -140,6 +142,17 @@ def _sse_stream(
                 "latency_ms": int((time.monotonic() - start) * 1000),
             },
         )
+        if usage:
+            track(
+                "api_call_completed",
+                session_id=session_id,
+                properties={
+                    "service": "perplexity",
+                    "operation": "feynman",
+                    "input_tokens": usage["usage"].get("prompt_tokens", 0),
+                    "output_tokens": usage["usage"].get("completion_tokens", 0),
+                },
+            )
         yield f"data: {json.dumps({'type': 'done', 'session_id': session_id})}\n\n"
 
     except Exception as exc:

--- a/services/llm.py
+++ b/services/llm.py
@@ -5,7 +5,7 @@ import logging
 import requests
 import threading
 import time
-from typing import Dict, Any
+from typing import Any, Dict
 from tenacity import retry, wait_exponential_jitter, stop_after_attempt, retry_if_exception
 
 # Matches Perplexity inline citation markers: [1], [2], [transcript_context], etc.
@@ -168,6 +168,22 @@ class AgenticExtractor:
         self.tier3_model = "claude-haiku-4-5-20251001"
         self.rate_limiter = RateLimiter(requests_per_minute=rpm_limit, requests_per_second=rps_limit)
 
+    def _track_usage(self, message, operation: str) -> None:
+        """Fire-and-forget analytics event for a completed Claude API call."""
+        try:
+            from db.analytics import track
+            track(
+                "api_call_completed",
+                properties={
+                    "service": "claude",
+                    "operation": operation,
+                    "input_tokens": message.usage.input_tokens,
+                    "output_tokens": message.usage.output_tokens,
+                },
+            )
+        except Exception:
+            pass  # tracking must never block extraction
+
     def _parse_response(self, message) -> Dict[str, Any]:
         """Parse an Anthropic message response into a result dict with usage stats."""
         content = message.content[0].text.strip()
@@ -211,6 +227,7 @@ class AgenticExtractor:
             system=TIER_1_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
+        self._track_usage(message, "tier1")
         return self._parse_response(message)
 
     @retry(
@@ -229,6 +246,7 @@ class AgenticExtractor:
             system=TIER_2_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
+        self._track_usage(message, "tier2")
         return self._parse_response(message)
 
     @retry(
@@ -247,7 +265,9 @@ class AgenticExtractor:
             system=TIER_3_SYNTHESIS_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
+        self._track_usage(message, "tier3")
         return self._parse_response(message)
+
     @retry(
         wait=wait_exponential_jitter(initial=2, max=60),
         stop=stop_after_attempt(5),
@@ -264,6 +284,7 @@ class AgenticExtractor:
             system=HAIKU_NLP_SYNTHESIS_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
+        self._track_usage(message, "nlp_synthesis")
         return self._parse_response(message)
 
     @retry(
@@ -287,4 +308,5 @@ class AgenticExtractor:
             system=QA_DETECTION_SYSTEM_PROMPT,
             messages=[{"role": "user", "content": user_prompt}]
         )
+        self._track_usage(message, "qa_detection")
         return self._parse_response(message)

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -17,6 +17,15 @@ interface ChatData {
   avg_turns_per_session: number;
 }
 
+interface ServiceTokens {
+  input_tokens: number;
+  output_tokens: number;
+}
+
+interface CostsData {
+  by_service: Record<string, ServiceTokens>;
+}
+
 async function getSession() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -39,6 +48,25 @@ async function fetchSessions(): Promise<DailyCount[] | null> {
     });
     if (!resp.ok) return null;
     return resp.json() as Promise<DailyCount[]>;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchCosts(): Promise<CostsData | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const session = await getSession();
+  if (!session) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/costs`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<CostsData>;
   } catch {
     return null;
   }
@@ -75,7 +103,7 @@ function AnalyticsCard({ title, children }: { title: string; children: React.Rea
 }
 
 export default async function AdminAnalyticsPage() {
-  const [sessions, chat] = await Promise.all([fetchSessions(), fetchChat()]);
+  const [sessions, chat, costs] = await Promise.all([fetchSessions(), fetchChat(), fetchCosts()]);
 
   const totalSessions = sessions?.reduce((sum, row) => sum + row.count, 0) ?? 0;
   const totalTurns = chat?.daily.reduce((sum, row) => sum + row.turns, 0) ?? 0;
@@ -111,6 +139,37 @@ export default async function AdminAnalyticsPage() {
                   <tr key={row.date} className="border-b border-zinc-50">
                     <td className="py-1.5 text-zinc-700">{row.date}</td>
                     <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </AnalyticsCard>
+
+        <AnalyticsCard title="API Cost — last 30 days (tokens by service)">
+          {costs === null ? (
+            <p className="text-sm text-red-500">Unable to load cost data.</p>
+          ) : Object.keys(costs.by_service).length === 0 ? (
+            <p className="text-sm text-zinc-500">No API calls recorded yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100">
+                  <th className="py-1.5 text-left font-medium text-zinc-500">Service</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Input</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Output</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(costs.by_service).map(([service, tokens]) => (
+                  <tr key={service} className="border-b border-zinc-50">
+                    <td className="py-1.5 capitalize text-zinc-700">{service}</td>
+                    <td className="py-1.5 text-right tabular-nums text-zinc-900">
+                      {tokens.input_tokens.toLocaleString()}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums text-zinc-900">
+                      {tokens.output_tokens.toLocaleString()}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/app/api/admin/analytics/costs/route.ts
+++ b/web/app/api/admin/analytics/costs/route.ts
@@ -1,0 +1,34 @@
+/** Server-side proxy for GET /admin/analytics/costs — forwards JWT to FastAPI. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/costs`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary

- Instruments `api_call_completed` events at all three LLM call sites:
  - **Perplexity**: captures `prompt_tokens` / `completion_tokens` from the usage dict already yielded by `stream_chat` (previously silently skipped)
  - **Voyage**: captures `total_tokens` from the `EmbedObject` returned by `client.embed()` in the semantic search route
  - **Claude/Anthropic**: adds `_track_usage()` helper to `AgenticExtractor` and calls it in `extract_tier1`, `extract_tier2`, `extract_synthesis`, `extract_nlp_synthesis`, and `detect_qa_transition`
- Adds `GET /admin/analytics/costs` returning token totals grouped by service for last 30 days
- Adds Next.js proxy route `/api/admin/analytics/costs`
- Adds costs panel (service × input/output tokens table) to the `/admin` analytics dashboard

## Test plan

- [ ] Run a semantic search — confirm `api_call_completed` row with `service=voyage` appears in `analytics_events`
- [ ] Send a Feynman chat message — confirm row with `service=perplexity` appears
- [ ] Run ingestion pipeline (Modal) — confirm rows with `service=claude` appear
- [ ] `GET /admin/analytics/costs` returns `{"by_service": {"perplexity": {...}, "voyage": {...}}}`
- [ ] Navigate to `/admin` — costs panel renders with token counts by service

Closes #167