### PR TITLE
feat: admin Feynman engagement panel (#170)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -161,6 +161,25 @@ def analytics_costs(_: RequireAdminDep) -> dict:
     return {"by_service": by_service}
 
 
+@router.get("/analytics/feynman")
+def analytics_feynman(_: RequireAdminDep) -> dict:
+    """Return feynman_stage_completed counts grouped by stage for the last 30 days."""
+    with psycopg.connect(_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT (properties->>'stage')::int AS stage, COUNT(*) AS count
+                FROM analytics_events
+                WHERE event_name = 'feynman_stage_completed'
+                  AND created_at >= NOW() - INTERVAL '30 days'
+                GROUP BY stage
+                ORDER BY stage
+                """
+            )
+            by_stage = [{"stage": row[0], "count": row[1]} for row in cur.fetchall() if row[0]]
+    return {"by_stage": by_stage}
+
+
 @router.post("/ingest", status_code=202)
 async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -213,6 +213,7 @@ def chat(
         stage = max(1, min(body.stage, 5))
         history = []
         track("session_start", session_id=session_id, properties={"ticker": ticker, "stage": stage})
+        track("feynman_stage_completed", session_id=session_id, properties={"stage": stage, "ticker": ticker})
 
     system_prompt = _load_prompt(stage)
     messages = history + [{"role": "user", "content": body.message}]

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -26,6 +26,15 @@ interface CostsData {
   by_service: Record<string, ServiceTokens>;
 }
 
+interface StageCount {
+  stage: number;
+  count: number;
+}
+
+interface FeynmanData {
+  by_stage: StageCount[];
+}
+
 async function getSession() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -48,6 +57,25 @@ async function fetchSessions(): Promise<DailyCount[] | null> {
     });
     if (!resp.ok) return null;
     return resp.json() as Promise<DailyCount[]>;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFeynman(): Promise<FeynmanData | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const session = await getSession();
+  if (!session) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/feynman`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<FeynmanData>;
   } catch {
     return null;
   }
@@ -103,7 +131,12 @@ function AnalyticsCard({ title, children }: { title: string; children: React.Rea
 }
 
 export default async function AdminAnalyticsPage() {
-  const [sessions, chat, costs] = await Promise.all([fetchSessions(), fetchChat(), fetchCosts()]);
+  const [sessions, chat, costs, feynman] = await Promise.all([
+    fetchSessions(),
+    fetchChat(),
+    fetchCosts(),
+    fetchFeynman(),
+  ]);
 
   const totalSessions = sessions?.reduce((sum, row) => sum + row.count, 0) ?? 0;
   const totalTurns = chat?.daily.reduce((sum, row) => sum + row.turns, 0) ?? 0;
@@ -197,6 +230,31 @@ export default async function AdminAnalyticsPage() {
                   <tr key={row.date} className="border-b border-zinc-50">
                     <td className="py-1.5 text-zinc-700">{row.date}</td>
                     <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.turns}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </AnalyticsCard>
+
+        <AnalyticsCard title="Feynman Engagement — stage funnel, last 30 days">
+          {feynman === null ? (
+            <p className="text-sm text-red-500">Unable to load Feynman data.</p>
+          ) : feynman.by_stage.length === 0 ? (
+            <p className="text-sm text-zinc-500">No Feynman sessions recorded yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100">
+                  <th className="py-1.5 text-left font-medium text-zinc-500">Stage</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Sessions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {feynman.by_stage.map((row) => (
+                  <tr key={row.stage} className="border-b border-zinc-50">
+                    <td className="py-1.5 text-zinc-700">Stage {row.stage}</td>
+                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web/app/api/admin/analytics/feynman/route.ts
+++ b/web/app/api/admin/analytics/feynman/route.ts
@@ -1,0 +1,34 @@
+/** Server-side proxy for GET /admin/analytics/feynman — forwards JWT to FastAPI. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/feynman`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary

- Instruments `feynman_stage_completed` event when a new Feynman session is created, using the `stage` parameter as a proxy for progression depth (stage 1 = user started learning, stage 2+ = user advanced beyond initial explanation, etc.)
- Adds `GET /admin/analytics/feynman` returning counts grouped by stage for the last 30 days
- Adds Next.js proxy route `/api/admin/analytics/feynman`
- Adds Feynman funnel panel to the `/admin` analytics dashboard

## Note on instrumentation approach

The event fires on every new session creation with the stage the user chose. Since the frontend creates a new session when advancing to a new stage, the counts show how many sessions were started at each stage — a funnel showing depth of engagement with the Feynman method.

## Test plan

- [ ] Start a new Feynman session at stage 1 — confirm `feynman_stage_completed` row with `stage=1` in `analytics_events`
- [ ] Start a session at stage 3 — confirm row with `stage=3`
- [ ] `GET /admin/analytics/feynman` returns `{"by_stage": [{"stage": 1, "count": N}, ...]}`
- [ ] Navigate to `/admin` — Feynman panel renders with stage funnel table

Closes #170