### PR TITLE
feat: admin ingestion history panel (#171)

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -180,12 +180,35 @@ def analytics_feynman(_: RequireAdminDep) -> dict:
     return {"by_stage": by_stage}
 
 
+@router.get("/analytics/ingestions")
+def analytics_ingestions(_: RequireAdminDep) -> dict:
+    """Return ingestion_requested events ordered by recency."""
+    with psycopg.connect(_db_url()) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT properties->>'ticker', created_at
+                FROM analytics_events
+                WHERE event_name = 'ingestion_requested'
+                ORDER BY created_at DESC
+                LIMIT 100
+                """
+            )
+            ingestions = [
+                {"ticker": row[0], "requested_at": row[1].isoformat()}
+                for row in cur.fetchall()
+                if row[0]
+            ]
+    return {"ingestions": ingestions}
+
+
 @router.post("/ingest", status_code=202)
 async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""
     fn = modal.Function.lookup("earnings-ingestion", "ingest_ticker")
     fn.spawn(body.ticker)
     logger.info("Ingestion dispatched: ticker=%s at=%s", body.ticker, datetime.now(UTC).isoformat())
+    track("ingestion_requested", properties={"ticker": body.ticker})
     return {
         "status": "accepted",
         "ticker": body.ticker,

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -35,6 +35,15 @@ interface FeynmanData {
   by_stage: StageCount[];
 }
 
+interface IngestionEntry {
+  ticker: string;
+  requested_at: string;
+}
+
+interface IngestionsData {
+  ingestions: IngestionEntry[];
+}
+
 async function getSession() {
   const supabase = await createSupabaseServerClient();
   const {
@@ -76,6 +85,25 @@ async function fetchFeynman(): Promise<FeynmanData | null> {
     });
     if (!resp.ok) return null;
     return resp.json() as Promise<FeynmanData>;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchIngestions(): Promise<IngestionsData | null> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return null;
+
+  const session = await getSession();
+  if (!session) return null;
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/ingestions`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    if (!resp.ok) return null;
+    return resp.json() as Promise<IngestionsData>;
   } catch {
     return null;
   }
@@ -131,11 +159,12 @@ function AnalyticsCard({ title, children }: { title: string; children: React.Rea
 }
 
 export default async function AdminAnalyticsPage() {
-  const [sessions, chat, costs, feynman] = await Promise.all([
+  const [sessions, chat, costs, feynman, ingestions] = await Promise.all([
     fetchSessions(),
     fetchChat(),
     fetchCosts(),
     fetchFeynman(),
+    fetchIngestions(),
   ]);
 
   const totalSessions = sessions?.reduce((sum, row) => sum + row.count, 0) ?? 0;
@@ -255,6 +284,32 @@ export default async function AdminAnalyticsPage() {
                   <tr key={row.stage} className="border-b border-zinc-50">
                     <td className="py-1.5 text-zinc-700">Stage {row.stage}</td>
                     <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </AnalyticsCard>
+        <AnalyticsCard title="Ingestion History — most recent 100 requests">
+          {ingestions === null ? (
+            <p className="text-sm text-red-500">Unable to load ingestion data.</p>
+          ) : ingestions.ingestions.length === 0 ? (
+            <p className="text-sm text-zinc-500">No ingestions recorded yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-100">
+                  <th className="py-1.5 text-left font-medium text-zinc-500">Ticker</th>
+                  <th className="py-1.5 text-right font-medium text-zinc-500">Requested At</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ingestions.ingestions.map((row, i) => (
+                  <tr key={i} className="border-b border-zinc-50">
+                    <td className="py-1.5 font-mono text-zinc-900">{row.ticker}</td>
+                    <td className="py-1.5 text-right text-zinc-700">
+                      {new Date(row.requested_at).toLocaleString()}
+                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/web/app/api/admin/analytics/ingestions/route.ts
+++ b/web/app/api/admin/analytics/ingestions/route.ts
@@ -1,0 +1,34 @@
+/** Server-side proxy for GET /admin/analytics/ingestions — forwards JWT to FastAPI. */
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(): Promise<NextResponse> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!apiUrl) {
+    return NextResponse.json(
+      { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl}/admin/analytics/ingestions`, {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}


### PR DESCRIPTION
## Summary

- Instruments `ingestion_requested` event in `trigger_ingestion` after `fn.spawn()` succeeds, capturing the ticker
- Adds `GET /admin/analytics/ingestions` returning the 100 most recent ingestion requests ordered by recency
- Adds Next.js proxy route `/api/admin/analytics/ingestions`
- Adds ingestion history table panel to the `/admin` analytics dashboard (ticker + timestamp, most recent first)

This completes all 5 open issues in the Observability milestone.

## Test plan

- [ ] Trigger an ingestion via `POST /admin/ingest` — confirm `ingestion_requested` row appears in `analytics_events`
- [ ] `GET /admin/analytics/ingestions` returns `{"ingestions": [{"ticker": "AAPL", "requested_at": "..."}]}`
- [ ] Navigate to `/admin` — ingestion history panel renders with ticker and timestamp columns

Closes #171