### PR TITLE
fix: harden admin API auth and close OAuth open redirect

### DIFF
--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -36,7 +36,7 @@ class IngestRequest(BaseModel):
         return upper
 
 
-_HEALTH_ENV_VARS = ["VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID", "SUPABASE_JWT_SECRET"]
+_HEALTH_ENV_VARS = ["VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID"]
 _VOYAGE_URL = "https://api.voyageai.com"
 _PERPLEXITY_URL = "https://api.perplexity.ai"
 

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -250,7 +250,7 @@ def test_health_response_has_expected_keys(client):
     assert "external_apis" in body
     assert "connected" in body["db"]
     assert "schema_version" in body["db"]
-    assert {"VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID", "SUPABASE_JWT_SECRET"} == set(
+    assert {"VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID"} == set(
         body["env_vars"].keys()
     )
     assert "voyage" in body["external_apis"]
@@ -280,7 +280,6 @@ def test_health_env_vars_present_when_set(client):
         "VOYAGE_API_KEY": "vk",
         "PERPLEXITY_API_KEY": "pk",
         "MODAL_TOKEN_ID": "mk",
-        "SUPABASE_JWT_SECRET": "sk",
     }
     with patch.dict(os.environ, extra_env), \
          patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \

--- a/web/app/api/admin/analytics/chat/route.ts
+++ b/web/app/api/admin/analytics/chat/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/analytics/chat — forwards JWT to FastAPI. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/analytics/chat — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/analytics/chat`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/analytics/costs/route.ts
+++ b/web/app/api/admin/analytics/costs/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/analytics/costs — forwards JWT to FastAPI. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/analytics/costs — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/analytics/costs`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/analytics/feynman/route.ts
+++ b/web/app/api/admin/analytics/feynman/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/analytics/feynman — forwards JWT to FastAPI. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/analytics/feynman — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/analytics/feynman`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/analytics/ingestions/route.ts
+++ b/web/app/api/admin/analytics/ingestions/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/analytics/ingestions — forwards JWT to FastAPI. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/analytics/ingestions — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/analytics/ingestions`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/analytics/sessions/route.ts
+++ b/web/app/api/admin/analytics/sessions/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/analytics/sessions — forwards JWT to FastAPI. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/analytics/sessions — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/analytics/sessions`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/health/route.ts
+++ b/web/app/api/admin/health/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for GET /admin/health — reads Supabase session and forwards JWT. */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for GET /admin/health — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextResponse } from "next/server";
 
 export async function GET(): Promise<NextResponse> {
@@ -12,18 +12,12 @@ export async function GET(): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   try {
     const resp = await fetch(`${apiUrl}/admin/health`, {
-      headers: { Authorization: `Bearer ${session.access_token}` },
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
       cache: "no-store",
     });
     const data: unknown = await resp.json();

--- a/web/app/api/admin/ingest/route.ts
+++ b/web/app/api/admin/ingest/route.ts
@@ -1,5 +1,5 @@
-/** Server-side proxy for POST /admin/ingest — JWT forwarded to FastAPI (RBAC enforced there). */
-import { createSupabaseServerClient } from "@/lib/supabase/server";
+/** Server-side proxy for POST /admin/ingest — verifies admin role, forwards JWT to FastAPI. */
+import { requireAdminUser } from "@/lib/admin-auth";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -12,14 +12,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  const supabase = await createSupabaseServerClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
 
   let body: unknown;
   try {
@@ -32,7 +26,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const resp = await fetch(`${apiUrl}/admin/ingest`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${session.access_token}`,
+        Authorization: `Bearer ${authResult.accessToken}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -5,7 +5,9 @@ import { NextRequest, NextResponse } from "next/server";
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  // Reject absolute URLs and protocol-relative paths (//) to prevent open redirect.
+  const rawNext = searchParams.get("next") ?? "/";
+  const next = rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
 
   if (!code) {
     return NextResponse.redirect(`${origin}/auth/sign-in?error=missing_code`);

--- a/web/lib/admin-auth.ts
+++ b/web/lib/admin-auth.ts
@@ -1,0 +1,40 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+/** Verifies the request is from an authenticated admin user.
+ *
+ * Uses getUser() (server-side JWT validation) rather than getSession() (cookie cache)
+ * to prevent session spoofing. Returns the user ID and access token on success,
+ * or a NextResponse error (401/403) on failure.
+ */
+export async function requireAdminUser(): Promise<
+  { userId: string; accessToken: string } | NextResponse
+> {
+  const supabase = await createSupabaseServerClient();
+
+  // getUser() contacts the Supabase auth server — more secure than getSession()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  if (profile?.role !== "admin") {
+    return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+  }
+
+  // getSession() is safe here — identity already confirmed via getUser() above
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  return { userId: user.id, accessToken: session?.access_token ?? "" };
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -40,7 +40,8 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(signInUrl);
   }
 
-  if (user && pathname.startsWith("/admin")) {
+  const isAdminPath = pathname.startsWith("/admin") || pathname.startsWith("/api/admin");
+  if (user && isAdminPath) {
     const { data: profile } = await supabase
       .from("profiles")
       .select("role")
@@ -48,6 +49,10 @@ export async function proxy(request: NextRequest) {
       .single();
 
     if (profile?.role !== "admin") {
+      // Return JSON for API routes; redirect page routes to home.
+      if (pathname.startsWith("/api/")) {
+        return NextResponse.json({ error: "Admin role required" }, { status: 403 });
+      }
       const homeUrl = request.nextUrl.clone();
       homeUrl.pathname = "/";
       return NextResponse.redirect(homeUrl);


### PR DESCRIPTION
## Summary

- Replaced `getSession()` with `getUser()` (server-side JWT validation) in all 7 `/api/admin/*` route handlers, plus an explicit admin role check via the `profiles` table — extracted into a shared `web/lib/admin-auth.ts` utility
- Extended the middleware admin-path guard to cover `/api/admin/*`, returning JSON 403 for API callers rather than a page redirect
- Validated the OAuth callback `next` parameter is a relative path (`/...` but not `//...`) to prevent open redirect
- Removed `SUPABASE_JWT_SECRET` from the health check env-var inventory to avoid information leakage

## Test plan

- [ ] Unauthenticated request to `/api/admin/health` returns 401
- [ ] Authenticated non-admin request returns 403 (both from route handler and middleware)
- [ ] OAuth callback with `next=https://evil.com` redirects to `/`
- [ ] OAuth callback with `next=//evil.com` redirects to `/`
- [ ] OAuth callback with `next=/dashboard` redirects to `/dashboard`
- [ ] `SUPABASE_JWT_SECRET` absent from health check response body
- [ ] `pytest` passes (115 tests)

Closes #212