### PR TITLE
fix: establish consistent error contract across API layer

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,11 +1,15 @@
 """FastAPI application entry point — CORS, lifespan, router registration."""
 
+import logging
 import os
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
 
 from routes import admin, calls, chat
 
@@ -53,6 +57,13 @@ app.add_middleware(
 app.include_router(calls.router)
 app.include_router(chat.router)
 app.include_router(admin.router)
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Catch unhandled exceptions and return a generic 500 without leaking internals."""
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+    return JSONResponse(status_code=500, content={"error": "Internal server error"})
 
 
 @app.get("/health")

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 import httpx
 import modal
 import psycopg
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
 from db.analytics import track
@@ -85,121 +85,141 @@ def _db_url() -> str:
 @router.get("/analytics/sessions")
 def analytics_sessions(_: RequireAdminDep) -> list[dict]:
     """Return daily session_start counts for the last 30 days."""
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT DATE(created_at) AS date, COUNT(*) AS count
-                FROM analytics_events
-                WHERE event_name = 'session_start'
-                  AND created_at >= NOW() - INTERVAL '30 days'
-                GROUP BY date
-                ORDER BY date
-                """
-            )
-            return [{"date": str(row[0]), "count": row[1]} for row in cur.fetchall()]
+    try:
+        with psycopg.connect(_db_url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT DATE(created_at) AS date, COUNT(*) AS count
+                    FROM analytics_events
+                    WHERE event_name = 'session_start'
+                      AND created_at >= NOW() - INTERVAL '30 days'
+                    GROUP BY date
+                    ORDER BY date
+                    """
+                )
+                return [{"date": str(row[0]), "count": row[1]} for row in cur.fetchall()]
+    except psycopg.Error as e:
+        logger.error("DB error in analytics_sessions: %s", e)
+        raise HTTPException(status_code=503, detail="Database unavailable")
 
 
 @router.get("/analytics/chat")
 def analytics_chat(_: RequireAdminDep) -> dict:
     """Return daily chat_turn counts and average turns per session for the last 30 days."""
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT DATE(created_at) AS date, COUNT(*) AS turns
-                FROM analytics_events
-                WHERE event_name = 'chat_turn'
-                  AND created_at >= NOW() - INTERVAL '30 days'
-                GROUP BY date
-                ORDER BY date
-                """
-            )
-            daily = [{"date": str(row[0]), "turns": row[1]} for row in cur.fetchall()]
-
-            cur.execute(
-                """
-                SELECT AVG(turns_per_session)
-                FROM (
-                    SELECT session_id, COUNT(*) AS turns_per_session
+    try:
+        with psycopg.connect(_db_url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT DATE(created_at) AS date, COUNT(*) AS turns
                     FROM analytics_events
                     WHERE event_name = 'chat_turn'
                       AND created_at >= NOW() - INTERVAL '30 days'
-                    GROUP BY session_id
-                ) sub
-                """
-            )
-            row = cur.fetchone()
-            avg = round(float(row[0]), 1) if row and row[0] is not None else 0.0
+                    GROUP BY date
+                    ORDER BY date
+                    """
+                )
+                daily = [{"date": str(row[0]), "turns": row[1]} for row in cur.fetchall()]
 
-    return {"daily": daily, "avg_turns_per_session": avg}
+                cur.execute(
+                    """
+                    SELECT AVG(turns_per_session)
+                    FROM (
+                        SELECT session_id, COUNT(*) AS turns_per_session
+                        FROM analytics_events
+                        WHERE event_name = 'chat_turn'
+                          AND created_at >= NOW() - INTERVAL '30 days'
+                        GROUP BY session_id
+                    ) sub
+                    """
+                )
+                row = cur.fetchone()
+                avg = round(float(row[0]), 1) if row and row[0] is not None else 0.0
+
+        return {"daily": daily, "avg_turns_per_session": avg}
+    except psycopg.Error as e:
+        logger.error("DB error in analytics_chat: %s", e)
+        raise HTTPException(status_code=503, detail="Database unavailable")
 
 
 @router.get("/analytics/costs")
 def analytics_costs(_: RequireAdminDep) -> dict:
     """Return token totals grouped by service for the last 30 days."""
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT
-                    properties->>'service' AS service,
-                    SUM((properties->>'input_tokens')::int) AS input_tokens,
-                    SUM((properties->>'output_tokens')::int) AS output_tokens
-                FROM analytics_events
-                WHERE event_name = 'api_call_completed'
-                  AND created_at >= NOW() - INTERVAL '30 days'
-                GROUP BY service
-                ORDER BY service
-                """
-            )
-            by_service = {
-                row[0]: {"input_tokens": row[1] or 0, "output_tokens": row[2] or 0}
-                for row in cur.fetchall()
-                if row[0]
-            }
-    return {"by_service": by_service}
+    try:
+        with psycopg.connect(_db_url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT
+                        properties->>'service' AS service,
+                        SUM((properties->>'input_tokens')::int) AS input_tokens,
+                        SUM((properties->>'output_tokens')::int) AS output_tokens
+                    FROM analytics_events
+                    WHERE event_name = 'api_call_completed'
+                      AND created_at >= NOW() - INTERVAL '30 days'
+                    GROUP BY service
+                    ORDER BY service
+                    """
+                )
+                by_service = {
+                    row[0]: {"input_tokens": row[1] or 0, "output_tokens": row[2] or 0}
+                    for row in cur.fetchall()
+                    if row[0]
+                }
+        return {"by_service": by_service}
+    except psycopg.Error as e:
+        logger.error("DB error in analytics_costs: %s", e)
+        raise HTTPException(status_code=503, detail="Database unavailable")
 
 
 @router.get("/analytics/feynman")
 def analytics_feynman(_: RequireAdminDep) -> dict:
     """Return feynman_stage_completed counts grouped by stage for the last 30 days."""
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT (properties->>'stage')::int AS stage, COUNT(*) AS count
-                FROM analytics_events
-                WHERE event_name = 'feynman_stage_completed'
-                  AND created_at >= NOW() - INTERVAL '30 days'
-                GROUP BY stage
-                ORDER BY stage
-                """
-            )
-            by_stage = [{"stage": row[0], "count": row[1]} for row in cur.fetchall() if row[0]]
-    return {"by_stage": by_stage}
+    try:
+        with psycopg.connect(_db_url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT (properties->>'stage')::int AS stage, COUNT(*) AS count
+                    FROM analytics_events
+                    WHERE event_name = 'feynman_stage_completed'
+                      AND created_at >= NOW() - INTERVAL '30 days'
+                    GROUP BY stage
+                    ORDER BY stage
+                    """
+                )
+                by_stage = [{"stage": row[0], "count": row[1]} for row in cur.fetchall() if row[0]]
+        return {"by_stage": by_stage}
+    except psycopg.Error as e:
+        logger.error("DB error in analytics_feynman: %s", e)
+        raise HTTPException(status_code=503, detail="Database unavailable")
 
 
 @router.get("/analytics/ingestions")
 def analytics_ingestions(_: RequireAdminDep) -> dict:
     """Return ingestion_requested events ordered by recency."""
-    with psycopg.connect(_db_url()) as conn:
-        with conn.cursor() as cur:
-            cur.execute(
-                """
-                SELECT properties->>'ticker', created_at
-                FROM analytics_events
-                WHERE event_name = 'ingestion_requested'
-                ORDER BY created_at DESC
-                LIMIT 100
-                """
-            )
-            ingestions = [
-                {"ticker": row[0], "requested_at": row[1].isoformat()}
-                for row in cur.fetchall()
-                if row[0]
-            ]
-    return {"ingestions": ingestions}
+    try:
+        with psycopg.connect(_db_url()) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT properties->>'ticker', created_at
+                    FROM analytics_events
+                    WHERE event_name = 'ingestion_requested'
+                    ORDER BY created_at DESC
+                    LIMIT 100
+                    """
+                )
+                ingestions = [
+                    {"ticker": row[0], "requested_at": row[1].isoformat()}
+                    for row in cur.fetchall()
+                    if row[0]
+                ]
+        return {"ingestions": ingestions}
+    except psycopg.Error as e:
+        logger.error("DB error in analytics_ingestions: %s", e)
+        raise HTTPException(status_code=503, detail="Database unavailable")
 
 
 @router.post("/ingest", status_code=202)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -153,10 +153,19 @@ def _sse_stream(
                     "output_tokens": usage["usage"].get("completion_tokens", 0),
                 },
             )
+        # Fire stage_completed after the first response in a new session (len == 1 means
+        # only the opening user message was in the list — no prior assistant turns).
+        if len(messages) == 1:
+            track(
+                "feynman_stage_completed",
+                session_id=session_id,
+                properties={"stage": stage, "ticker": ticker},
+            )
         yield f"data: {json.dumps({'type': 'done', 'session_id': session_id})}\n\n"
 
-    except Exception as exc:
-        yield f"data: {json.dumps({'type': 'error', 'message': str(exc)})}\n\n"
+    except Exception:
+        logger.exception("SSE stream error for session %s", session_id)
+        yield f"data: {json.dumps({'type': 'error', 'message': 'Stream error'})}\n\n"
 
 
 # --- Request model ---
@@ -213,7 +222,6 @@ def chat(
         stage = max(1, min(body.stage, 5))
         history = []
         track("session_start", session_id=session_id, properties={"ticker": ticker, "stage": stage})
-        track("feynman_stage_completed", session_id=session_id, properties={"stage": stage, "ticker": ticker})
 
     system_prompt = _load_prompt(stage)
     messages = history + [{"role": "user", "content": body.message}]

--- a/db/repositories.py
+++ b/db/repositories.py
@@ -13,6 +13,11 @@ class OutdatedSchemaError(Exception):
     """Exception raised when the database schema is out of date."""
     pass
 
+
+class RepositoryError(Exception):
+    """Raised when a repository operation fails due to a database error."""
+    pass
+
 REQUIRED_SCHEMA_VERSION = 9
 
 


### PR DESCRIPTION
## Summary

- Added a global FastAPI exception handler in `api/main.py` — unhandled exceptions now return `{"error": "Internal server error"}` (500) instead of leaking stack traces
- Wrapped all 5 analytics route handlers in `api/routes/admin.py` with `try/except psycopg.Error` — DB outages return 503 instead of 500/unhandled exception
- SSE stream errors in `api/routes/chat.py` are now logged server-side and surfaced to the client as a generic `"Stream error"` message (was `str(exc)`)
- Fixed `feynman_stage_completed` tracking bug: removed the incorrect fire from session creation (before any messages were exchanged); the event now fires after the first successful assistant response in a new session
- Added `RepositoryError` to `db/repositories.py` as the canonical exception type for database failures (foundation for #214)

## Test plan

- [ ] With DB unavailable, analytics endpoints return 503 `{"detail": "Database unavailable"}`
- [ ] SSE stream error event body is `{"type": "error", "message": "Stream error"}`, not an exception string
- [ ] `feynman_stage_completed` event not present in analytics until first chat response is received
- [ ] Unhandled exception returns `{"error": "Internal server error"}` (not a stack trace)
- [ ] `pytest` passes (115 tests)

Closes #213