### PR TITLE
feat(#225): rate limiting and input bounds on paid API paths

### DIFF
--- a/api/limiter.py
+++ b/api/limiter.py
@@ -1,0 +1,28 @@
+"""Shared slowapi Limiter instance with user-aware rate-limit key function."""
+
+import jwt as pyjwt
+from fastapi import Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+
+def _user_key(request: Request) -> str:
+    """Return the user UUID from the Bearer JWT, or the remote IP as fallback.
+
+    Does not verify the signature — auth is enforced separately by get_current_user.
+    The key is used only for rate-limit bucketing.
+    """
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return get_remote_address(request)
+    try:
+        payload = pyjwt.decode(
+            auth.removeprefix("Bearer "),
+            options={"verify_signature": False},
+        )
+        return payload.get("sub") or get_remote_address(request)
+    except Exception:
+        return get_remote_address(request)
+
+
+limiter = Limiter(key_func=_user_key)

--- a/api/main.py
+++ b/api/main.py
@@ -8,10 +8,13 @@ from collections.abc import AsyncGenerator
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
 
 logger = logging.getLogger(__name__)
 
 from dependencies import set_pool
+from limiter import limiter
 from routes import admin, calls, chat
 
 
@@ -60,6 +63,9 @@ def build_cors_origin_regex() -> str | None:
 
 
 app = FastAPI(title="EarningsFluency API", lifespan=lifespan)
+
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.add_middleware(
     CORSMiddleware,

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,3 +9,4 @@ voyageai>=0.3.0
 pgvector>=0.3.0
 modal>=0.73.0
 httpx>=0.27.0
+slowapi>=0.1.9

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -15,12 +15,16 @@ from pydantic import BaseModel, field_validator
 from db.analytics import track
 from db.repositories import AnalyticsRepository, SchemaRepository
 from dependencies import RequireAdminDep
+from settings import INGEST_RATE_LIMIT_WINDOW_SECONDS
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
 _TICKER_RE = re.compile(r"^[A-Z]{2,5}$")
+
+# Tracks the last ingest request per (user_id, ticker) for rate limiting.
+_ingest_last_request: dict[str, datetime] = {}
 
 
 class IngestRequest(BaseModel):
@@ -133,8 +137,20 @@ def analytics_ingestions(_: RequireAdminDep) -> dict:
 
 
 @router.post("/ingest", status_code=202)
-async def trigger_ingestion(body: IngestRequest, _: RequireAdminDep) -> dict:
+async def trigger_ingestion(body: IngestRequest, user_id: RequireAdminDep) -> dict:
     """Dispatch ticker to the Modal ingestion pipeline and return 202 immediately."""
+    key = f"{user_id}:{body.ticker}"
+    now = datetime.now(UTC)
+    last = _ingest_last_request.get(key)
+    if last is not None:
+        elapsed = (now - last).total_seconds()
+        if elapsed < INGEST_RATE_LIMIT_WINDOW_SECONDS:
+            remaining = int(INGEST_RATE_LIMIT_WINDOW_SECONDS - elapsed)
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit: wait {remaining}s before ingesting {body.ticker} again.",
+            )
+    _ingest_last_request[key] = now
     fn = modal.Function.lookup("earnings-ingestion", "ingest_ticker")
     fn.spawn(body.ticker)
     logger.info("Ingestion dispatched: ticker=%s at=%s", body.ticker, datetime.now(UTC).isoformat())

--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -3,11 +3,13 @@
 import os
 
 import psycopg
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from pydantic import BaseModel
 
 from db.analytics import track
 from db.repositories import AnalysisRepository, CallRepository
+from limiter import limiter
+from settings import SEARCH_QUERY_MAX_LENGTH, SEARCH_RATE_LIMIT
 
 router = APIRouter(prefix="/api/calls", tags=["calls"])
 
@@ -235,9 +237,11 @@ def get_spans(
 
 
 @router.get("/{ticker}/search", response_model=SearchResponse)
+@limiter.limit(SEARCH_RATE_LIMIT)
 def search_transcript(
+    request: Request,
     ticker: str,
-    q: str = Query(min_length=1),
+    q: str = Query(min_length=1, max_length=SEARCH_QUERY_MAX_LENGTH),
     top_k: int = Query(default=5, ge=1, le=20),
 ) -> SearchResponse:
     """Semantic search within a transcript using pgvector similarity."""

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -7,13 +7,15 @@ import time
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from db.analytics import track
 from db.repositories import CallRepository, LearningRepository
 from dependencies import CurrentUserDep
+from limiter import limiter
+from settings import CHAT_MESSAGE_MAX_LENGTH, CHAT_RATE_LIMIT, SESSION_HISTORY_MAX_TURNS
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +147,7 @@ def _sse_stream(
 # --- Request model ---
 
 class ChatRequest(BaseModel):
-    message: str
+    message: str = Field(max_length=CHAT_MESSAGE_MAX_LENGTH)
     session_id: str | None = None
     stage: int = 1  # only applied when creating a new session; 1–5
 
@@ -153,7 +155,9 @@ class ChatRequest(BaseModel):
 # --- Endpoint ---
 
 @router.post("/{ticker}/chat")
+@limiter.limit(CHAT_RATE_LIMIT)
 def chat(
+    request: Request,
     ticker: str,
     body: ChatRequest,
     user_id: CurrentUserDep,
@@ -190,6 +194,12 @@ def chat(
         topic: str = notes.get("topic", body.message)
         stage: int = notes.get("stage", 1)
         history: list[dict] = notes.get("messages", [])
+        user_turns = sum(1 for m in history if m["role"] == "user")
+        if user_turns >= SESSION_HISTORY_MAX_TURNS:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Session has reached the {SESSION_HISTORY_MAX_TURNS}-turn limit. Start a new session.",
+            )
     else:
         session_id = str(uuid.uuid4())
         topic = body.message

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,0 +1,9 @@
+"""Application-wide constants for rate limits and input bounds."""
+
+CHAT_RATE_LIMIT = "60/hour"
+SEARCH_RATE_LIMIT = "100/hour"
+INGEST_RATE_LIMIT_WINDOW_SECONDS = 600  # 10 minutes per user per ticker
+
+CHAT_MESSAGE_MAX_LENGTH = 4000
+SEARCH_QUERY_MAX_LENGTH = 500
+SESSION_HISTORY_MAX_TURNS = 50  # turn = one user message

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -83,6 +83,13 @@ def reset_modal():
     MODAL_STUB.reset_mock()
 
 
+@pytest.fixture(autouse=True)
+def reset_ingest_rate_limit():
+    """Clear the ingest TTL dict between tests to prevent rate-limit state bleed."""
+    import routes.admin as admin_mod
+    admin_mod._ingest_last_request.clear()
+
+
 def test_ingest_returns_202(client):
     mock_fn = MagicMock()
     MODAL_STUB.Function.lookup.return_value = mock_fn
@@ -305,3 +312,42 @@ def test_health_external_apis_unreachable_on_exception(client):
     body = resp.json()
     assert body["external_apis"]["voyage"]["reachable"] is False
     assert body["external_apis"]["perplexity"]["reachable"] is False
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting — POST /admin/ingest
+# ---------------------------------------------------------------------------
+
+def test_429_when_ingest_attempted_too_soon(client):
+    """Second ingest for the same user+ticker within 10 minutes returns 429."""
+    from datetime import UTC, datetime
+    import routes.admin as admin_mod
+
+    admin_mod._ingest_last_request[f"{ADMIN_UUID}:AAPL"] = datetime.now(UTC)
+
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "AAPL"},
+        headers=ADMIN_AUTH,
+    )
+    assert resp.status_code == 429
+    assert "Rate limit" in resp.json()["detail"]
+
+
+def test_different_ticker_not_rate_limited(client):
+    """Rate limit is per-ticker: a different ticker is not affected."""
+    from datetime import UTC, datetime
+    import routes.admin as admin_mod
+
+    mock_fn = MagicMock()
+    MODAL_STUB.Function.lookup.return_value = mock_fn
+
+    # AAPL is rate-limited, MSFT should proceed normally.
+    admin_mod._ingest_last_request[f"{ADMIN_UUID}:AAPL"] = datetime.now(UTC)
+
+    resp = client.post(
+        "/admin/ingest",
+        json={"ticker": "MSFT"},
+        headers=ADMIN_AUTH,
+    )
+    assert resp.status_code == 202

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -190,3 +190,19 @@ class TestSearchTranscript:
     def test_missing_query_param(self, client):
         response = client.get("/api/calls/AAPL/search")
         assert response.status_code == 422
+
+    def test_422_when_query_exceeds_max_length(self, client):
+        """Query longer than 500 chars is rejected by FastAPI before any API call."""
+        response = client.get(f"/api/calls/AAPL/search?q={'x' * 501}")
+        assert response.status_code == 422
+
+    def test_429_when_search_rate_limit_exceeded(self, client):
+        """Endpoint returns 429 when the per-user/IP rate limit is hit."""
+        from fastapi import HTTPException
+
+        def _raise_429(*args, **kwargs):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+        with patch("slowapi.Limiter._check_request_limit", side_effect=_raise_429):
+            response = client.get("/api/calls/AAPL/search?q=revenue")
+        assert response.status_code == 429

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -216,3 +216,53 @@ class TestChatStreaming:
             )
 
         mock_prompt.assert_called_once_with(3)
+
+
+# ---------------------------------------------------------------------------
+# Input bounds and rate limiting
+# ---------------------------------------------------------------------------
+
+class TestChatInputBounds:
+    def test_422_when_message_exceeds_max_length(self, client):
+        """Message longer than 4000 chars is rejected by Pydantic before any API call."""
+        response = client.post(
+            "/api/calls/AAPL/chat",
+            json={"message": "x" * 4001},
+            headers={"Authorization": AUTH_HEADER},
+        )
+        assert response.status_code == 422
+
+    def test_422_when_session_history_exceeds_turn_limit(self, client):
+        """Session with 50 prior user turns returns 422 before streaming."""
+        # 50 user + 50 assistant messages = 100 entries
+        history = []
+        for _ in range(50):
+            history.append({"role": "user", "content": "explain"})
+            history.append({"role": "assistant", "content": "..."})
+        session_notes = {"topic": "margins", "stage": 1, "messages": history}
+
+        with (
+            patch("routes.chat._ticker_exists", return_value=True),
+            patch("routes.chat._load_session", return_value=session_notes),
+        ):
+            response = client.post(
+                "/api/calls/AAPL/chat",
+                json={"message": "continue", "session_id": "long-session-id"},
+                headers={"Authorization": AUTH_HEADER},
+            )
+        assert response.status_code == 422
+
+    def test_429_when_chat_rate_limit_exceeded(self, client):
+        """Endpoint returns 429 when the per-user rate limit is hit."""
+        from fastapi import HTTPException
+
+        def _raise_429(*args, **kwargs):
+            raise HTTPException(status_code=429, detail="Rate limit exceeded")
+
+        with patch("slowapi.Limiter._check_request_limit", side_effect=_raise_429):
+            response = client.post(
+                "/api/calls/AAPL/chat",
+                json={"message": "explain revenue"},
+                headers={"Authorization": AUTH_HEADER},
+            )
+        assert response.status_code == 429


### PR DESCRIPTION
## Summary

- Installs `slowapi` and wires it into `api/main.py` as middleware with a per-user JWT key function (falls back to remote IP for unauthenticated endpoints)
- `POST /api/calls/{ticker}/chat` — 60 req/hour per user; `message` max 4000 chars; session history capped at 50 user turns before the Perplexity payload is built
- `GET /api/calls/{ticker}/search` — 100 req/hour per user/IP; `q` max 500 chars
- `POST /admin/ingest` — per-user-per-ticker TTL guard (10-minute window); ticker is in the request body so a module-level dict is used instead of the slowapi decorator
- `api/settings.py` centralises all rate-limit values and field-length bounds as named constants
- `api/limiter.py` holds the shared `Limiter` instance

## Test plan

- [ ] `pytest tests/unit/api/ -v` — 45 tests, 0 failures
- [ ] `test_422_when_message_exceeds_max_length` — 4001-char message rejected before any Perplexity call
- [ ] `test_422_when_session_history_exceeds_turn_limit` — 50-turn session returns 422
- [ ] `test_429_when_chat_rate_limit_exceeded` — patched limiter returns 429
- [ ] `test_422_when_query_exceeds_max_length` — 501-char query rejected
- [ ] `test_429_when_search_rate_limit_exceeded` — patched limiter returns 429
- [ ] `test_429_when_ingest_attempted_too_soon` — same user+ticker within 10 min returns 429
- [ ] `test_different_ticker_not_rate_limited` — different ticker not blocked by ingest TTL

Closes #225