### PR TITLE
feat(#226): validate all required env vars at startup

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -16,16 +16,19 @@ logger = logging.getLogger(__name__)
 from dependencies import set_pool
 from limiter import limiter
 from routes import admin, calls, chat
+from settings import REQUIRED_ENV_VARS
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown hooks."""
-    # Startup: validate required environment variables are present
-    required = ["DATABASE_URL", "SUPABASE_URL"]
-    missing = [var for var in required if not os.environ.get(var)]
+    # Startup: validate all required environment variables are present
+    missing = [var for var in REQUIRED_ENV_VARS if not os.environ.get(var)]
     if missing:
         raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+
+    # Cache validation snapshot for health endpoint reporting
+    app.state.env_var_status = {var: bool(os.environ.get(var)) for var in REQUIRED_ENV_VARS}
 
     # Start connection pool
     try:

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 import httpx
 import modal
 import psycopg
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, field_validator
 
 from db.analytics import track
@@ -40,19 +40,18 @@ class IngestRequest(BaseModel):
         return upper
 
 
-_HEALTH_ENV_VARS = ["VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID"]
 _VOYAGE_URL = "https://api.voyageai.com"
 _PERPLEXITY_URL = "https://api.perplexity.ai"
 
 
 @router.get("/health")
-async def system_health(_: RequireAdminDep) -> dict:
+async def system_health(request: Request, _: RequireAdminDep) -> dict:
     """Return system health: DB connection, env var presence, and external API reachability."""
     db_url = os.environ.get("DATABASE_URL", "")
     repo = SchemaRepository(db_url)
     version: int = await asyncio.to_thread(repo.get_current_version)
 
-    env_vars = {key: bool(os.environ.get(key)) for key in _HEALTH_ENV_VARS}
+    env_vars = request.app.state.env_var_status
 
     voyage_reachable = False
     perplexity_reachable = False

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,5 +1,14 @@
 """Application-wide constants for rate limits and input bounds."""
 
+REQUIRED_ENV_VARS = [
+    "DATABASE_URL",
+    "SUPABASE_URL",
+    "VOYAGE_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "MODAL_TOKEN_ID",
+    "ANTHROPIC_API_KEY",
+]
+
 CHAT_RATE_LIMIT = "60/hour"
 SEARCH_RATE_LIMIT = "100/hour"
 INGEST_RATE_LIMIT_WINDOW_SECONDS = 600  # 10 minutes per user per ticker

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -22,6 +22,10 @@ from main import app  # noqa: E402  (must come after sys.modules stub)
 ENV = {
     "DATABASE_URL": "postgresql://test",
     "SUPABASE_URL": "https://test.supabase.co",
+    "VOYAGE_API_KEY": "voyage-test-key",
+    "PERPLEXITY_API_KEY": "pplx-test-key",
+    "MODAL_TOKEN_ID": "modal-test-id",
+    "ANTHROPIC_API_KEY": "anth-test-key",
 }
 
 # RSA key pair used to sign and verify test JWTs.
@@ -257,9 +261,10 @@ def test_health_response_has_expected_keys(client):
     assert "external_apis" in body
     assert "connected" in body["db"]
     assert "schema_version" in body["db"]
-    assert {"VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID"} == set(
-        body["env_vars"].keys()
-    )
+    assert {
+        "DATABASE_URL", "SUPABASE_URL",
+        "VOYAGE_API_KEY", "PERPLEXITY_API_KEY", "MODAL_TOKEN_ID", "ANTHROPIC_API_KEY",
+    } == set(body["env_vars"].keys())
     assert "voyage" in body["external_apis"]
     assert "perplexity" in body["external_apis"]
 
@@ -282,14 +287,9 @@ def test_health_db_disconnected_when_version_zero(client):
     assert body["db"]["schema_version"] == 0
 
 
-def test_health_env_vars_present_when_set(client):
-    extra_env = {
-        "VOYAGE_API_KEY": "vk",
-        "PERPLEXITY_API_KEY": "pk",
-        "MODAL_TOKEN_ID": "mk",
-    }
-    with patch.dict(os.environ, extra_env), \
-         patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
+def test_health_env_vars_reflect_startup_validation(client):
+    """env_vars in health response reflects startup-validated snapshot, not request-time state."""
+    with patch("routes.admin.SchemaRepository", _make_schema_repo_mock()), \
          patch("routes.admin.httpx", _make_healthy_httpx_mock()):
         resp = client.get("/admin/health", headers=ADMIN_AUTH)
     body = resp.json()
@@ -351,3 +351,44 @@ def test_different_ticker_not_rate_limited(client):
         headers=ADMIN_AUTH,
     )
     assert resp.status_code == 202
+
+
+# ---------------------------------------------------------------------------
+# Startup env var validation
+# ---------------------------------------------------------------------------
+
+def test_startup_fails_with_missing_required_var():
+    """App raises RuntimeError at startup when a required env var is absent."""
+    from fastapi.testclient import TestClient
+
+    env_without_voyage = {k: v for k, v in ENV.items() if k != "VOYAGE_API_KEY"}
+    with patch.dict(os.environ, env_without_voyage, clear=True):
+        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
+            with TestClient(app):
+                pass
+
+
+def test_startup_error_names_all_missing_vars():
+    """RuntimeError message lists every missing variable when multiple are absent."""
+    from fastapi.testclient import TestClient
+
+    db_only = {"DATABASE_URL": "postgresql://test", "SUPABASE_URL": "https://test.supabase.co"}
+    with patch.dict(os.environ, db_only, clear=True):
+        with pytest.raises(RuntimeError) as exc_info:
+            with TestClient(app):
+                pass
+    message = str(exc_info.value)
+    assert "VOYAGE_API_KEY" in message
+    assert "PERPLEXITY_API_KEY" in message
+    assert "MODAL_TOKEN_ID" in message
+    assert "ANTHROPIC_API_KEY" in message
+
+
+def test_startup_succeeds_with_all_required_vars():
+    """App starts without error when all required env vars are set."""
+    from fastapi.testclient import TestClient
+
+    with patch.dict(os.environ, ENV):
+        with patch("psycopg.connect"):
+            with TestClient(app):
+                pass  # No exception raised

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -14,6 +14,10 @@ if API_DIR not in sys.path:
 ENV = {
     "DATABASE_URL": "postgresql://test",
     "SUPABASE_URL": "https://test.supabase.co",
+    "VOYAGE_API_KEY": "voyage-test-key",
+    "PERPLEXITY_API_KEY": "pplx-test-key",
+    "MODAL_TOKEN_ID": "modal-test-id",
+    "ANTHROPIC_API_KEY": "anth-test-key",
 }
 
 

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -23,7 +23,10 @@ if PROJECT_ROOT not in sys.path:
 ENV = {
     "DATABASE_URL": "postgresql://test",
     "SUPABASE_URL": "https://test.supabase.co",
-    "PERPLEXITY_API_KEY": "pplx-test",
+    "VOYAGE_API_KEY": "voyage-test-key",
+    "PERPLEXITY_API_KEY": "pplx-test-key",
+    "MODAL_TOKEN_ID": "modal-test-id",
+    "ANTHROPIC_API_KEY": "anth-test-key",
 }
 
 # RSA key pair used to sign and verify test JWTs.


### PR DESCRIPTION
## Summary
- Expands startup validation in `lifespan()` to include all 6 required vars: `DATABASE_URL`, `SUPABASE_URL`, `VOYAGE_API_KEY`, `PERPLEXITY_API_KEY`, `MODAL_TOKEN_ID`, `ANTHROPIC_API_KEY`
- Caches the validated snapshot in `app.state.env_var_status` so `/admin/health` reads from startup state rather than re-checking `os.environ.get` at request time
- Removes the `_HEALTH_ENV_VARS` constant in `admin.py`; adds `REQUIRED_ENV_VARS` to `settings.py` as the single source of truth

## Test plan
- [ ] `test_startup_fails_with_missing_required_var` — RuntimeError names the missing key
- [ ] `test_startup_error_names_all_missing_vars` — all 4 API keys listed when absent
- [ ] `test_startup_succeeds_with_all_required_vars` — no exception when all vars present
- [ ] `test_health_env_vars_reflect_startup_validation` — health response shows startup-captured values
- [ ] `test_health_response_has_expected_keys` — updated to check all 6 required vars appear
- [ ] All existing admin/calls/chat tests pass with updated ENV dicts

Closes #226