### PR TITLE
fix: resilient startup and observable /health for missing env vars

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -25,7 +25,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup: validate all required environment variables are present
     missing = [var for var in REQUIRED_ENV_VARS if not os.environ.get(var)]
     if missing:
-        raise RuntimeError(f"Missing required environment variables: {', '.join(missing)}")
+        logger.critical("Missing required environment variables: %s", ", ".join(missing))
+        app.state.startup_ok = False
+        app.state.missing_vars = missing
+        yield
+        return
+
+    app.state.startup_ok = True
+    app.state.missing_vars = []
 
     # Cache validation snapshot for health endpoint reporting
     app.state.env_var_status = {var: bool(os.environ.get(var)) for var in REQUIRED_ENV_VARS}
@@ -92,6 +99,12 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
 
 
 @app.get("/health")
-async def health() -> dict:
-    """Return service health status."""
-    return {"status": "ok"}
+async def health(request: Request) -> JSONResponse:
+    """Return service health status. Returns 503 if startup failed."""
+    if not getattr(request.app.state, "startup_ok", False):
+        missing = getattr(request.app.state, "missing_vars", [])
+        return JSONResponse(
+            status_code=503,
+            content={"status": "unhealthy", "missing_vars": missing},
+        )
+    return JSONResponse(status_code=200, content={"status": "ok"})

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -367,31 +367,34 @@ def test_different_ticker_not_rate_limited(client):
 # Startup env var validation
 # ---------------------------------------------------------------------------
 
-def test_startup_fails_with_missing_required_var():
-    """App raises RuntimeError at startup when a required env var is absent."""
+def test_startup_marks_unhealthy_with_missing_required_var():
+    """App starts but marks itself unhealthy when a required env var is absent."""
     from fastapi.testclient import TestClient
 
     env_without_voyage = {k: v for k, v in ENV.items() if k != "VOYAGE_API_KEY"}
     with patch.dict(os.environ, env_without_voyage, clear=True):
-        with pytest.raises(RuntimeError, match="VOYAGE_API_KEY"):
-            with TestClient(app):
-                pass
+        with TestClient(app) as c:
+            resp = c.get("/health")
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert "VOYAGE_API_KEY" in body["missing_vars"]
 
 
-def test_startup_error_names_all_missing_vars():
-    """RuntimeError message lists every missing variable when multiple are absent."""
+def test_startup_names_all_missing_vars_in_health():
+    """Health endpoint lists every missing variable when multiple are absent."""
     from fastapi.testclient import TestClient
 
     db_only = {"DATABASE_URL": "postgresql://test", "SUPABASE_URL": "https://test.supabase.co"}
     with patch.dict(os.environ, db_only, clear=True):
-        with pytest.raises(RuntimeError) as exc_info:
-            with TestClient(app):
-                pass
-    message = str(exc_info.value)
-    assert "VOYAGE_API_KEY" in message
-    assert "PERPLEXITY_API_KEY" in message
-    assert "MODAL_TOKEN_ID" in message
-    assert "ANTHROPIC_API_KEY" in message
+        with TestClient(app) as c:
+            resp = c.get("/health")
+    assert resp.status_code == 503
+    missing = resp.json()["missing_vars"]
+    assert "VOYAGE_API_KEY" in missing
+    assert "PERPLEXITY_API_KEY" in missing
+    assert "MODAL_TOKEN_ID" in missing
+    assert "ANTHROPIC_API_KEY" in missing
 
 
 def test_startup_succeeds_with_all_required_vars():


### PR DESCRIPTION
## Summary

- App previously crashed on startup when any of the 6 `REQUIRED_ENV_VARS` were missing, leaving Railway with no process to health-check against (connection refused, not HTTP 503)
- Now the app starts in all cases: logs `CRITICAL` with the missing var names, sets `startup_ok = False`, and returns `503 {"status": "unhealthy", "missing_vars": [...]}` from `/health` until the configuration is corrected
- `200 {"status": "ok"}` from `/health` is now a reliable signal that startup completed cleanly
- Updated two tests that were asserting `RuntimeError` to instead assert the new observable behaviour (503 + missing_vars list)

## Test plan

- [ ] All 48 unit tests pass (`pytest tests/unit/api/`)
- [ ] Deploy to Railway with a var deliberately removed — confirm logs show `CRITICAL` and `/health` returns 503
- [ ] Add the var back — confirm `/health` returns 200 and deployment is marked healthy

Closes #237