### PR TITLE
feat: CI migration enforcement and graceful shutdown (#230)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,6 +2,8 @@
 
 import logging
 import os
+import signal
+import threading
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
@@ -13,15 +15,25 @@ from slowapi.errors import RateLimitExceeded
 
 logger = logging.getLogger(__name__)
 
+from db.analytics import drain as drain_analytics
 from dependencies import set_pool
 from limiter import limiter
 from routes import admin, calls, chat
 from settings import REQUIRED_ENV_VARS
+from shutdown import shutdown_event
+
+
+def _handle_sigterm(signum: int, frame: object) -> None:
+    """Set the shutdown flag so active SSE generators can emit a terminal event."""
+    shutdown_event.set()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan: startup and shutdown hooks."""
+    if threading.current_thread() is threading.main_thread():
+        signal.signal(signal.SIGTERM, _handle_sigterm)
+
     # Startup: validate all required environment variables are present
     missing = [var for var in REQUIRED_ENV_VARS if not os.environ.get(var)]
     if missing:
@@ -49,7 +61,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
-    # Shutdown: close pool if it was started
+    # Shutdown: drain in-flight analytics inserts, then close the connection pool
+    drain_analytics(timeout=5.0)
     if pool is not None:
         pool.close()
         logger.info("Database connection pool closed")

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -16,6 +16,7 @@ from db.repositories import CallRepository, LearningRepository
 from dependencies import CurrentUserDep
 from limiter import limiter
 from settings import CHAT_MESSAGE_MAX_LENGTH, CHAT_RATE_LIMIT, SESSION_HISTORY_MAX_TURNS
+from shutdown import shutdown_event
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +101,9 @@ def _sse_stream(
     start = time.monotonic()
     try:
         for chunk in stream_chat(messages, system_prompt):
+            if shutdown_event.is_set():
+                yield f"data: {json.dumps({'type': 'error', 'message': 'Server restarting, please retry'})}\n\n"
+                return
             if isinstance(chunk, str):
                 accumulated.append(chunk)
                 yield f"data: {json.dumps({'type': 'token', 'content': chunk})}\n\n"

--- a/api/shutdown.py
+++ b/api/shutdown.py
@@ -1,0 +1,5 @@
+"""Shutdown coordination — shared event set on SIGTERM."""
+
+import threading
+
+shutdown_event = threading.Event()

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -3,11 +3,15 @@
 import logging
 import os
 import threading
+import time
 from typing import Any
 
 import psycopg
 
 logger = logging.getLogger(__name__)
+
+_active_threads: list[threading.Thread] = []
+_threads_lock = threading.Lock()
 
 
 def _insert_event(event_name: str, session_id: str | None, properties: dict[str, Any] | None) -> None:
@@ -28,6 +32,18 @@ def _insert_event(event_name: str, session_id: str | None, properties: dict[str,
         logger.warning("analytics.track failed for event=%r: %s", event_name, exc)
 
 
+def _run_and_untrack(event_name: str, session_id: str | None, properties: dict[str, Any] | None) -> None:
+    """Run the DB insert and remove this thread from the active registry when done."""
+    try:
+        _insert_event(event_name, session_id, properties)
+    finally:
+        with _threads_lock:
+            try:
+                _active_threads.remove(threading.current_thread())
+            except ValueError:
+                pass
+
+
 def track(
     event_name: str,
     session_id: str | None = None,
@@ -35,8 +51,34 @@ def track(
 ) -> None:
     """Record an analytics event without blocking the caller.
 
-    Spawns a daemon thread to perform the DB insert. Logs a warning on failure
+    Spawns a non-daemon thread to perform the DB insert. Logs a warning on failure
     and never raises — safe to call on any code path.
     """
-    t = threading.Thread(target=_insert_event, args=(event_name, session_id, properties), daemon=True)
+    t = threading.Thread(target=_run_and_untrack, args=(event_name, session_id, properties), daemon=False)
+    with _threads_lock:
+        _active_threads.append(t)
     t.start()
+
+
+def drain(timeout: float = 5.0) -> None:
+    """Join all in-flight analytics threads up to the given timeout.
+
+    Called from the lifespan shutdown path. Logs a warning if any threads
+    do not finish within the allotted time.
+    """
+    with _threads_lock:
+        threads = list(_active_threads)
+    deadline = time.monotonic() + timeout
+    for t in threads:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        t.join(timeout=remaining)
+    with _threads_lock:
+        still_running = len(_active_threads)
+    if still_running:
+        logger.warning(
+            "analytics.drain: %d thread(s) did not finish within %.1fs timeout",
+            still_running,
+            timeout,
+        )

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -228,6 +228,38 @@ class TestChatStreaming:
 
         mock_prompt.assert_called_once_with(3)
 
+    def test_shutdown_flag_emits_error_event(self, client):
+        """When shutdown_event is set, SSE generator emits error event and stops streaming."""
+        mock_chunks = ["Hello", " world"]
+
+        mock_event = MagicMock()
+        # First chunk passes, second chunk triggers shutdown
+        mock_event.is_set.side_effect = [False, True]
+
+        with (
+            patch("routes.chat._ticker_exists", return_value=True),
+            patch("routes.chat._load_prompt", return_value="You are a Feynman tutor."),
+            patch("routes.chat._upsert_session"),
+            patch("services.llm.stream_chat", return_value=iter(mock_chunks)),
+            patch("routes.chat.shutdown_event", mock_event),
+        ):
+            response = client.post(
+                "/api/calls/AAPL/chat",
+                json={"message": "explain revenue"},
+                headers={"Authorization": AUTH_HEADER},
+            )
+
+        assert response.status_code == 200
+        lines = [ln for ln in response.text.strip().split("\n\n") if ln]
+        events = [json.loads(ln.removeprefix("data: ")) for ln in lines if ln.startswith("data: ")]
+
+        error_events = [e for e in events if e["type"] == "error"]
+        done_events = [e for e in events if e["type"] == "done"]
+
+        assert len(error_events) == 1
+        assert "restarting" in error_events[0]["message"]
+        assert len(done_events) == 0
+
 
 # ---------------------------------------------------------------------------
 # Input bounds and rate limiting

--- a/tests/unit/db/test_analytics.py
+++ b/tests/unit/db/test_analytics.py
@@ -1,0 +1,88 @@
+"""Unit tests for db/analytics — thread tracking and drain behaviour."""
+
+import sys
+import os
+import threading
+import time
+
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from db import analytics
+
+
+@pytest.fixture(autouse=True)
+def reset_thread_registry():
+    """Clear the analytics thread registry before and after each test."""
+    with analytics._threads_lock:
+        analytics._active_threads.clear()
+    yield
+    with analytics._threads_lock:
+        analytics._active_threads.clear()
+
+
+class TestDrain:
+    def test_drain_joins_threads_within_timeout(self):
+        """drain() waits for in-flight threads and returns with an empty registry."""
+        started = threading.Event()
+        proceed = threading.Event()
+
+        def slow_insert(event_name, session_id, properties):
+            started.set()
+            proceed.wait(timeout=2)
+
+        t = threading.Thread(target=analytics._run_and_untrack, args=("test_event", None, {}), daemon=False)
+        # Patch _insert_event for the duration of this thread's execution
+        original = analytics._insert_event
+        analytics._insert_event = slow_insert
+        try:
+            with analytics._threads_lock:
+                analytics._active_threads.append(t)
+            t.start()
+            started.wait(timeout=1)
+            proceed.set()  # unblock the thread before draining
+            analytics.drain(timeout=2.0)
+        finally:
+            analytics._insert_event = original
+
+        with analytics._threads_lock:
+            assert len(analytics._active_threads) == 0
+
+    def test_drain_logs_warning_when_thread_does_not_finish(self, caplog):
+        """drain() logs a warning when a thread is still running after the timeout."""
+        blocker = threading.Event()
+
+        def stuck_insert(event_name, session_id, properties):
+            blocker.wait(timeout=10)  # will not be unblocked during the test
+
+        original = analytics._insert_event
+        analytics._insert_event = stuck_insert
+        t = threading.Thread(target=analytics._run_and_untrack, args=("test_event", None, {}), daemon=True)
+        try:
+            with analytics._threads_lock:
+                analytics._active_threads.append(t)
+            t.start()
+
+            import logging
+            with caplog.at_level(logging.WARNING, logger="db.analytics"):
+                analytics.drain(timeout=0.05)
+
+            assert any("did not finish" in record.message for record in caplog.records)
+        finally:
+            analytics._insert_event = original
+            blocker.set()
+
+    def test_track_registers_non_daemon_thread(self):
+        """track() spawns a non-daemon thread tracked in the active registry."""
+        from unittest.mock import patch
+
+        with patch("db.analytics._insert_event"):
+            analytics.track("test_event", session_id=None, properties={})
+
+        # Thread was registered (may have already finished and been removed — that is fine)
+        # The key assertion is that it was non-daemon, verified by checking it was started
+        # We assert drain() completes without error (thread finishes naturally)
+        analytics.drain(timeout=1.0)


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions CI workflow that blocks merges when pending Supabase migrations are detected, removing the stale `db/schema.sql` in favour of migration-tracked schema
- Implements graceful shutdown for SSE streams and analytics threads so Railway deploys no longer drop in-flight analytics events or leave clients with a silent connection close

## Changes

### CI migration enforcement
- `.github/workflows/ci.yml` — new workflow; blocks PRs that include unapplied migrations
- `db/schema.sql` — removed (superseded by Supabase migration files)
- `docs/database.md`, `docs/runbooks/migration-rollback.md` — new runbook and updated DB docs

### Graceful shutdown (#230)
- `api/shutdown.py` (new) — shared `threading.Event` set on SIGTERM; isolated to avoid circular imports
- `api/main.py` — registers `_handle_sigterm` in lifespan (main-thread guarded); calls `drain_analytics(5s)` before closing the connection pool
- `db/analytics.py` — analytics threads converted from `daemon=True` to `daemon=False`; thread registry + `drain(timeout)` with warning on timeout
- `api/routes/chat.py` — `_sse_stream` checks `shutdown_event` each iteration; emits `{type: error, message: "Server restarting, please retry"}` and returns on shutdown

## Test plan

- [ ] All existing tests pass: `pytest`
- [ ] New shutdown flag test: `TestChatStreaming::test_shutdown_flag_emits_error_event`
- [ ] New analytics drain tests: `TestDrain::test_drain_joins_threads_within_timeout`, `test_drain_logs_warning_when_thread_does_not_finish`
- [ ] CI workflow runs on push and blocks on unapplied migrations
- [ ] Manual: start server, open SSE stream, send SIGTERM — client receives `{type: error, message: "Server restarting, please retry"}`

Closes #230