### PR TITLE
feat: logging foundation — configure root logger, replace print(), add missing loggers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,7 @@ VOYAGE_API_KEY        # semantic embeddings
 PERPLEXITY_API_KEY    # Feynman chat
 DATABASE_URL          # optional (default: dbname=earnings_teacher)
 ANTHROPIC_API_KEY     # optional (Claude-based ingestion tiers)
+LOG_LEVEL             # optional (default: INFO); controls log verbosity
 ```
 
 ---

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import signal
+import sys
 import threading
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
@@ -12,6 +13,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+
+from settings import LOG_LEVEL_DEFAULT
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=os.environ.get("LOG_LEVEL", LOG_LEVEL_DEFAULT).upper(),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
 
 logger = logging.getLogger(__name__)
 

--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -1,6 +1,9 @@
 """Earnings calls routes — library and transcript data."""
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 import psycopg
 from fastapi import APIRouter, HTTPException, Query, Request, status
@@ -106,6 +109,7 @@ class SearchResponse(BaseModel):
 @router.get("", response_model=list[CallSummary])
 def list_calls() -> list[CallSummary]:
     """Return summary metadata for all analyzed calls."""
+    logger.info("GET /api/calls")
     with psycopg.connect(_db_url()) as conn:
         with conn.cursor() as cur:
             cur.execute(
@@ -126,6 +130,7 @@ def list_calls() -> list[CallSummary]:
 @router.get("/{ticker}", response_model=CallDetail)
 def get_call(ticker: str) -> CallDetail:
     """Return full metadata for a single analyzed call."""
+    logger.info("GET /api/calls/%s", ticker)
     if not _ticker_exists(ticker):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -197,6 +202,7 @@ def get_spans(
     page_size: int = Query(default=50, ge=1, le=200),
 ) -> SpansResponse:
     """Return paginated speaker turns for a transcript, with optional filtering."""
+    logger.info("GET /api/calls/%s/spans section=%s", ticker, section)
     if not _ticker_exists(ticker):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -245,6 +251,7 @@ def search_transcript(
     top_k: int = Query(default=5, ge=1, le=20),
 ) -> SearchResponse:
     """Semantic search within a transcript using pgvector similarity."""
+    logger.info("GET /api/calls/%s/search q=%r", ticker, q)
     if not _ticker_exists(ticker):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,5 +1,7 @@
 """Application-wide constants for rate limits and input bounds."""
 
+LOG_LEVEL_DEFAULT = "INFO"
+
 REQUIRED_ENV_VARS = [
     "DATABASE_URL",
     "SUPABASE_URL",

--- a/services/llm.py
+++ b/services/llm.py
@@ -181,8 +181,8 @@ class AgenticExtractor:
                     "output_tokens": message.usage.output_tokens,
                 },
             )
-        except Exception:
-            pass  # tracking must never block extraction
+        except Exception as exc:
+            logger.warning("analytics tracking failed for %s: %s", operation, exc)
 
     def _parse_response(self, message) -> Dict[str, Any]:
         """Parse an Anthropic message response into a result dict with usage stats."""

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -69,7 +69,7 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
             candidate_turns = turns_metadata[start_num:end_num]
             
             if candidate_turns:
-                print(f"  ↳ Deterministic Q&A detection failed. Triggering LLM fallback...")
+                logger.info("Deterministic Q&A detection failed; triggering LLM fallback")
                 result = extractor.detect_qa_transition(candidate_turns)
                 
                 t_idx = result.get("transition_index", -1)
@@ -80,7 +80,7 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
                         split_point = all_turns[abs_idx].start()
                         prepared_remarks = raw_text[:split_point]
                         qa = raw_text[split_point:]
-                        print(f"    ↳ LLM identified Q&A start at turn {abs_idx} (Confidence: {result['confidence']}).")
+                        logger.info("LLM identified Q&A start at turn %d (confidence=%.2f)", abs_idx, result['confidence'])
         except Exception as e:
             logger.warning(f"LLM Q&A detection fallback failed: {e}")
 
@@ -223,7 +223,6 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
                 for i, t in enumerate(nlp_synthesis.get("themes", []))
             ]
     except Exception as e:
-        print(f"❌ Agentic pipeline failed: {e}")
-        logger.warning(f"Agentic pipeline failed or skipped: {e}")
+        logger.warning("Agentic pipeline failed or skipped: %s", e)
 
     return analysis

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -1,5 +1,6 @@
 """Unit tests for /api/calls routes."""
 
+import logging
 import sys
 import os
 from unittest.mock import MagicMock, patch
@@ -60,6 +61,22 @@ class TestListCalls:
         assert data[1]["ticker"] == "MSFT"
         assert data[1]["call_date"] is None
 
+    def test_logs_route_entry(self, client, caplog):
+        """list_calls() emits an INFO log on entry."""
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with caplog.at_level(logging.INFO, logger="routes.calls"):
+            with patch("psycopg.connect", return_value=mock_conn):
+                client.get("/api/calls")
+
+        assert any("GET /api/calls" in r.message for r in caplog.records)
+
     def test_empty_library(self, client):
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = []
@@ -90,6 +107,14 @@ class TestGetCall:
             response = client.get("/api/calls/UNKNOWN")
 
         assert response.status_code == 404
+
+    def test_logs_route_entry(self, client, caplog):
+        """get_call() emits an INFO log with the ticker on entry."""
+        with caplog.at_level(logging.INFO, logger="routes.calls"):
+            with patch("routes.calls._ticker_exists", return_value=False):
+                client.get("/api/calls/AAPL")
+
+        assert any("AAPL" in r.message for r in caplog.records)
 
     def test_returns_call_detail(self, client):
         # _ticker_exists returns True
@@ -141,6 +166,14 @@ class TestGetSpans:
             response = client.get("/api/calls/UNKNOWN/spans")
         assert response.status_code == 404
 
+    def test_logs_route_entry(self, client, caplog):
+        """get_spans() emits an INFO log with ticker and section on entry."""
+        with caplog.at_level(logging.INFO, logger="routes.calls"):
+            with patch("routes.calls._ticker_exists", return_value=False):
+                client.get("/api/calls/AAPL/spans?section=prepared")
+
+        assert any("AAPL" in r.message and "prepared" in r.message for r in caplog.records)
+
     def test_returns_paginated_spans(self, client):
         mock_cursor = MagicMock()
         mock_cursor.fetchone.return_value = (2,)
@@ -178,6 +211,14 @@ class TestSearchTranscript:
         with patch("routes.calls._ticker_exists", return_value=False):
             response = client.get("/api/calls/UNKNOWN/search?q=revenue")
         assert response.status_code == 404
+
+    def test_logs_route_entry(self, client, caplog):
+        """search_transcript() emits an INFO log with ticker and query on entry."""
+        with caplog.at_level(logging.INFO, logger="routes.calls"):
+            with patch("routes.calls._ticker_exists", return_value=False):
+                client.get("/api/calls/AAPL/search?q=revenue")
+
+        assert any("AAPL" in r.message and "revenue" in r.message for r in caplog.records)
 
     def test_503_when_voyage_key_missing(self, client):
         with (

--- a/tests/unit/api/test_startup_logging.py
+++ b/tests/unit/api/test_startup_logging.py
@@ -1,0 +1,43 @@
+"""Tests that the root logger configuration wires api.main log output to caplog."""
+
+import logging
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+ENV = {
+    "DATABASE_URL": "postgresql://test",
+    "SUPABASE_URL": "https://test.supabase.co",
+    "VOYAGE_API_KEY": "voyage-test-key",
+    "PERPLEXITY_API_KEY": "pplx-test-key",
+    "MODAL_TOKEN_ID": "modal-test-id",
+    "ANTHROPIC_API_KEY": "anth-test-key",
+}
+
+
+def test_startup_pool_log_reaches_caplog(caplog):
+    """INFO message from the pool startup path appears in caplog after basicConfig."""
+    mock_pool = MagicMock()
+    mock_pool.close = MagicMock()
+
+    mock_psycopg_pool = MagicMock()
+    mock_psycopg_pool.ConnectionPool.return_value = mock_pool
+
+    with patch.dict(os.environ, ENV):
+        with patch.dict(sys.modules, {"psycopg_pool": mock_psycopg_pool}):
+            with patch("dependencies.set_pool"):
+                with patch("db.analytics.drain"):
+                    from fastapi.testclient import TestClient
+                    from main import app
+
+                    with caplog.at_level(logging.INFO, logger="main"):
+                        with TestClient(app):
+                            pass
+
+    assert any("connection pool started" in r.message for r in caplog.records)

--- a/tests/unit/services/test_orchestrator_logging.py
+++ b/tests/unit/services/test_orchestrator_logging.py
@@ -1,0 +1,111 @@
+"""Tests that orchestrator uses logger (not print) for Q&A detection messages."""
+
+import json
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+# Minimal transcript JSON that provides turns but no Q&A section markers,
+# so extract_transcript_sections() returns an empty QA string.
+_TRANSCRIPT_JSON = json.dumps({
+    "cik": "",
+    "date": "2026-01-01",
+    "content": "\n".join(
+        f"Speaker{i}: This is turn {i}." for i in range(20)
+    ),
+})
+
+
+def _make_mock_schema_repo():
+    """Return a SchemaRepository mock that reports a healthy schema."""
+    mock = MagicMock()
+    mock.check_health.return_value = (True, "")
+    return mock
+
+
+@pytest.fixture()
+def _patch_all_io():
+    """Patch every I/O boundary in orchestrator.analyze() so it runs in-process."""
+    with (
+        patch("services.orchestrator.SchemaRepository", return_value=_make_mock_schema_repo()),
+        patch("services.orchestrator.read_text_file", return_value=_TRANSCRIPT_JSON),
+        patch("services.orchestrator.extract_transcript_text", return_value=_TRANSCRIPT_JSON),
+        patch("services.orchestrator.fetch_company_info", return_value=("", "")),
+        patch("services.orchestrator.clean_text", return_value=""),
+        patch("services.orchestrator.tokenize", return_value=[]),
+        # Return empty Q&A so the LLM fallback branch is triggered
+        patch("services.orchestrator.extract_transcript_sections", return_value=("prepared text", "")),
+        patch("services.orchestrator.extract_spans", return_value=[]),
+        patch("services.orchestrator.enrich_speakers", return_value=[]),
+        patch("services.orchestrator.extract_qa_exchanges", return_value=[]),
+        patch("services.orchestrator.get_embeddings", return_value=[]),
+        patch("services.orchestrator.fetch_existing_embeddings", return_value={}),
+        patch("services.orchestrator.TURN_PATTERN") as mock_pattern,
+        patch("services.llm.AgenticExtractor") as MockExtractor,
+        patch("ingestion.pipeline.IngestionPipeline"),
+    ):
+        # Provide 20 fake turns so candidate_turns is non-empty
+        mock_match = MagicMock()
+        mock_match.group.side_effect = lambda k: "Speaker" if k == "speaker" else "text"
+        mock_pattern.finditer.return_value = [mock_match] * 20
+
+        extractor_instance = MockExtractor.return_value
+        extractor_instance.detect_qa_transition.return_value = {"transition_index": -1, "confidence": 0.0}
+
+        yield
+
+
+def test_qa_fallback_uses_logger_not_print(_patch_all_io, caplog):
+    """When deterministic Q&A detection fails, orchestrator logs via logger.info, not print."""
+    from services import orchestrator
+
+    with caplog.at_level(logging.INFO, logger="services.orchestrator"):
+        try:
+            orchestrator.analyze("TEST")
+        except Exception:
+            pass  # downstream errors are irrelevant; we only care about the log call
+
+    assert any(
+        "Deterministic Q&A detection failed" in r.message for r in caplog.records
+    ), "Expected logger.info call for Q&A fallback was not emitted"
+
+
+def test_agentic_pipeline_failure_uses_logger_not_print(caplog):
+    """When the agentic pipeline raises, orchestrator logs via logger.warning, not print."""
+    mock_schema = _make_mock_schema_repo()
+
+    with (
+        patch("services.orchestrator.SchemaRepository", return_value=mock_schema),
+        patch("services.orchestrator.read_text_file", return_value=_TRANSCRIPT_JSON),
+        patch("services.orchestrator.extract_transcript_text", return_value="text"),
+        patch("services.orchestrator.fetch_company_info", return_value=("", "")),
+        patch("services.orchestrator.clean_text", return_value=""),
+        patch("services.orchestrator.tokenize", return_value=[]),
+        patch("services.orchestrator.extract_transcript_sections", return_value=("prepared", "q&a")),
+        patch("services.orchestrator.extract_spans", return_value=[]),
+        patch("services.orchestrator.enrich_speakers", return_value=[]),
+        patch("services.orchestrator.extract_qa_exchanges", return_value=[]),
+        patch("services.orchestrator.get_embeddings", return_value=[]),
+        patch("services.orchestrator.fetch_existing_embeddings", return_value={}),
+        patch("ingestion.pipeline.IngestionPipeline") as MockPipeline,
+        caplog.at_level(logging.WARNING, logger="services.orchestrator"),
+    ):
+        MockPipeline.return_value.process.side_effect = RuntimeError("boom")
+
+        from services import orchestrator
+        try:
+            orchestrator.analyze("TEST")
+        except Exception:
+            pass
+
+    assert any(
+        "Agentic pipeline failed" in r.message for r in caplog.records
+    ), "Expected logger.warning call for agentic pipeline failure was not emitted"


### PR DESCRIPTION
Closes #245

## Summary

- `api/main.py` — `logging.basicConfig()` added before app build; reads `LOG_LEVEL` env var (default `INFO`), outputs to stdout with `asctime levelname name message` format. All existing `logger.*` calls that were previously silently discarded now reach stdout.
- `api/settings.py` — `LOG_LEVEL_DEFAULT = "INFO"` constant added; `LOG_LEVEL` documented in `CLAUDE.md`.
- `services/orchestrator.py` — Replaced 3 `print()` calls with `logger.info()` / `logger.warning()`; collapsed the duplicate `print` + `logger.warning` on the agentic pipeline failure path to a single `logger.warning`.
- `api/routes/calls.py` — Added `logger = logging.getLogger(__name__)` and a `logger.info()` route-entry log (with ticker/query context) on all 4 handlers.
- `services/llm.py` — Replaced `except Exception: pass` with `logger.warning("analytics tracking failed for %s: %s", operation, exc)`.

## Test plan

- [ ] `pytest` — all 127 tests pass
- [ ] `test_startup_logging.py` — verifies pool startup INFO log reaches `caplog`
- [ ] `test_orchestrator_logging.py` — verifies Q&A fallback and agentic pipeline failure emit via `logger`, not `print`
- [ ] `test_calls.py` — 4 new assertions verify each route handler emits an INFO log with the relevant context (ticker, query, section)
- [ ] Manual smoke check: `LOG_LEVEL=DEBUG uvicorn api.main:app` should show timestamped log lines on startup