### PR TITLE
feat: add correlation middleware, request timing, and latency logging

### DIFF
--- a/api/context.py
+++ b/api/context.py
@@ -1,0 +1,5 @@
+"""Request-scoped context variables for correlation ID propagation."""
+
+import contextvars
+
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="-")

--- a/api/main.py
+++ b/api/main.py
@@ -5,6 +5,8 @@ import os
 import signal
 import sys
 import threading
+import time
+import uuid
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
@@ -13,14 +15,30 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response
 
+from context import request_id_var
 from settings import LOG_LEVEL_DEFAULT
 
 logging.basicConfig(
     stream=sys.stdout,
     level=os.environ.get("LOG_LEVEL", LOG_LEVEL_DEFAULT).upper(),
-    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    format="%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s",
 )
+
+
+class _RequestIdFilter(logging.Filter):
+    """Inject request_id from ContextVar into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Add request_id attribute so the log format can reference it."""
+        record.request_id = request_id_var.get("-")
+        return True
+
+
+for _h in logging.getLogger().handlers:
+    _h.addFilter(_RequestIdFilter())
 
 logger = logging.getLogger(__name__)
 
@@ -94,10 +112,38 @@ def build_cors_origin_regex() -> str | None:
     return os.environ.get("CORS_ORIGIN_REGEX") or None
 
 
+class CorrelationTimingMiddleware(BaseHTTPMiddleware):
+    """Read or generate X-Request-ID; log request duration; propagate ID to response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        """Set request ID ContextVar, time the request, log on completion."""
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+        token = request_id_var.set(request_id)
+        start = time.monotonic()
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+            elapsed_ms = (time.monotonic() - start) * 1000
+            logger.info(
+                "completed %s %s in %.0fms [request_id=%s]",
+                request.method,
+                request.url.path,
+                elapsed_ms,
+                request_id,
+            )
+        response.headers["X-Request-ID"] = request_id
+        return response
+
+
 app = FastAPI(title="EarningsFluency API", lifespan=lifespan)
 
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+# CorrelationTimingMiddleware is added first (becomes inner); CORSMiddleware added
+# last (becomes outermost) so CORS handles OPTIONS preflight before our middleware.
+app.add_middleware(CorrelationTimingMiddleware)
 
 app.add_middleware(
     CORSMiddleware,

--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +270,9 @@ def search_transcript(
     from pgvector.psycopg import register_vector
 
     client = voyageai.Client(api_key=api_key)
+    _t0 = time.monotonic()
     embed_result = client.embed([q], model="voyage-finance-2")
+    logger.debug("voyage embed completed in %.0fms", (time.monotonic() - _t0) * 1000)
     query_vector = embed_result.embeddings[0]
     track(
         "api_call_completed",

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,6 +1,7 @@
 """Application-wide constants for rate limits and input bounds."""
 
 LOG_LEVEL_DEFAULT = "INFO"
+LOG_SLOW_QUERY_THRESHOLD_MS = 500  # warn if any DB operation exceeds this
 
 REQUIRED_ENV_VARS = [
     "DATABASE_URL",

--- a/db/analytics.py
+++ b/db/analytics.py
@@ -1,12 +1,20 @@
 """Analytics event tracking — fire-and-forget inserts into analytics_events."""
 
+import contextvars
 import logging
 import os
+import sys
 import threading
 import time
 from typing import Any
 
 import psycopg
+
+# Import slow-query threshold from settings (api/ is on sys.path at runtime).
+try:
+    from settings import LOG_SLOW_QUERY_THRESHOLD_MS
+except ImportError:
+    LOG_SLOW_QUERY_THRESHOLD_MS = 500
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +26,7 @@ def _insert_event(event_name: str, session_id: str | None, properties: dict[str,
     """Execute the DB insert; run in a background thread."""
     try:
         db_url = os.environ.get("DATABASE_URL", "dbname=earnings_teacher")
+        start = time.monotonic()
         with psycopg.connect(db_url) as conn:
             with conn.cursor() as cur:
                 cur.execute(
@@ -28,6 +37,13 @@ def _insert_event(event_name: str, session_id: str | None, properties: dict[str,
                     (event_name, session_id, psycopg.types.json.Jsonb(properties or {})),
                 )
             conn.commit()
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if elapsed_ms > LOG_SLOW_QUERY_THRESHOLD_MS:
+            logger.warning(
+                "slow query: analytics_events insert took %.0fms (threshold=%dms)",
+                elapsed_ms,
+                LOG_SLOW_QUERY_THRESHOLD_MS,
+            )
     except Exception as exc:
         logger.warning("analytics.track failed for event=%r: %s", event_name, exc)
 
@@ -51,10 +67,16 @@ def track(
 ) -> None:
     """Record an analytics event without blocking the caller.
 
-    Spawns a non-daemon thread to perform the DB insert. Logs a warning on failure
-    and never raises — safe to call on any code path.
+    Spawns a non-daemon thread to perform the DB insert. The current contextvars
+    context (including the request_id ContextVar) is copied into the thread so
+    background log entries remain linkable to the originating request. Logs a
+    warning on failure and never raises — safe to call on any code path.
     """
-    t = threading.Thread(target=_run_and_untrack, args=(event_name, session_id, properties), daemon=False)
+    ctx = contextvars.copy_context()
+    t = threading.Thread(
+        target=lambda: ctx.run(_run_and_untrack, event_name, session_id, properties),
+        daemon=False,
+    )
     with _threads_lock:
         _active_threads.append(t)
     t.start()

--- a/services/llm.py
+++ b/services/llm.py
@@ -64,6 +64,7 @@ def stream_chat(
     }
     
     try:
+        _t0 = time.time()
         with requests.post(
             "https://api.perplexity.ai/chat/completions",
             headers=headers,
@@ -115,6 +116,8 @@ def stream_chat(
             # Flush any remaining buffered text (a partial citation that never closed)
             if citation_buffer:
                 yield citation_buffer
+
+        logger.debug("perplexity stream_chat completed in %.0fms", (time.time() - _t0) * 1000)
 
     except Exception as e:
         logger.error("Error connecting to Perplexity API: %s", e)

--- a/tests/unit/api/test_correlation.py
+++ b/tests/unit/api/test_correlation.py
@@ -1,0 +1,102 @@
+"""Tests for correlation ID middleware and slow-query threshold."""
+
+import logging
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+DB_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if DB_DIR not in sys.path:
+    sys.path.insert(0, DB_DIR)
+
+ENV = {
+    "DATABASE_URL": "postgresql://test",
+    "SUPABASE_URL": "https://test.supabase.co",
+    "VOYAGE_API_KEY": "voyage-test-key",
+    "PERPLEXITY_API_KEY": "pplx-test-key",
+    "MODAL_TOKEN_ID": "modal-test-id",
+    "ANTHROPIC_API_KEY": "anth-test-key",
+}
+
+
+@pytest.fixture()
+def client():
+    """TestClient with env vars set and connection pool mocked.
+
+    Uses sys.modules.setdefault to inject the psycopg_pool mock without
+    patch.dict(sys.modules) — that would remove all modules imported during
+    the fixture on teardown, breaking subsequent test setups.
+    """
+    mock_pool = MagicMock()
+    mock_pool.close = MagicMock()
+    mock_psycopg_pool = MagicMock()
+    mock_psycopg_pool.ConnectionPool.return_value = mock_pool
+    sys.modules.setdefault("psycopg_pool", mock_psycopg_pool)
+
+    with patch.dict(os.environ, ENV):
+        with patch("dependencies.set_pool"):
+            with patch("db.analytics.drain"):
+                from fastapi.testclient import TestClient
+                import main
+
+                with TestClient(main.app) as c:
+                    yield c
+
+
+def test_request_id_in_log_output(client, caplog):
+    """The timing middleware INFO line must appear in caplog with a UUID request_id."""
+    with caplog.at_level(logging.INFO, logger="main"):
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    timing_records = [r for r in caplog.records if "completed" in r.message and "/health" in r.message]
+    assert timing_records, "Expected timing log line from CorrelationTimingMiddleware"
+    # request_id is embedded in the message as [request_id=<uuid>]
+    assert any("request_id=" in r.message for r in timing_records)
+
+
+def test_custom_request_id_forwarded(client, caplog):
+    """A custom X-Request-ID header is echoed in the response and appears in logs."""
+    custom_id = "test-abc-123"
+    with caplog.at_level(logging.INFO, logger="main"):
+        response = client.get("/health", headers={"X-Request-ID": custom_id})
+
+    assert response.status_code == 200
+    assert response.headers.get("X-Request-ID") == custom_id
+    timing_records = [r for r in caplog.records if "completed" in r.message and "/health" in r.message]
+    assert timing_records, "Expected timing log line"
+    assert any(custom_id in r.message for r in timing_records)
+
+
+def test_slow_query_threshold_triggers_warning(caplog):
+    """_insert_event logs a WARNING when the DB insert exceeds LOG_SLOW_QUERY_THRESHOLD_MS."""
+    with patch.dict(os.environ, ENV):
+        import importlib
+        import db.analytics as analytics_mod
+
+        # Reload to pick up any module-level imports freshly
+        importlib.reload(analytics_mod)
+
+        # Patch LOG_SLOW_QUERY_THRESHOLD_MS to a very low value so the mock insert triggers it
+        with patch.object(analytics_mod, "LOG_SLOW_QUERY_THRESHOLD_MS", 0):
+            # Mock psycopg.connect so the "insert" completes but takes non-zero time
+            mock_cur = MagicMock()
+            mock_conn = MagicMock()
+            mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+            mock_conn.__exit__ = MagicMock(return_value=False)
+            mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+            mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+            with patch("psycopg.connect", return_value=mock_conn):
+                with caplog.at_level(logging.WARNING, logger="db.analytics"):
+                    analytics_mod._insert_event("test_event", None, {})
+
+    warning_records = [r for r in caplog.records if "slow query" in r.message]
+    assert warning_records, "Expected slow query WARNING from _insert_event"


### PR DESCRIPTION
## Summary

- Adds `CorrelationTimingMiddleware` to `api/main.py`: reads `X-Request-ID` from incoming requests or generates a UUID, stores it in a `contextvars.ContextVar`, and echoes it back in the response header
- Adds a `_RequestIdFilter` logging filter so every log record (across all loggers) includes the request ID in the formatted output — no per-call `extra=` required
- Logs `completed {METHOD} {path} in {ms}ms [request_id=...]` at INFO after each request
- `db/analytics.py`: uses `contextvars.copy_context()` when spawning background threads so the request ID propagates into daemon thread log entries; adds slow-query warning in `_insert_event` when insert exceeds `LOG_SLOW_QUERY_THRESHOLD_MS`
- `services/llm.py`: logs Perplexity `stream_chat` wall-clock duration at DEBUG
- `api/routes/calls.py`: logs Voyage embed duration at DEBUG in `search_transcript`
- `api/settings.py`: adds `LOG_SLOW_QUERY_THRESHOLD_MS = 500`
- New file `api/context.py` — isolated ContextVar to avoid circular imports
- 3 new tests: request ID in log output, custom header forwarding, slow query warning

## Test plan

- [ ] `pytest tests/unit/api/test_correlation.py -v` — all 3 new tests pass
- [ ] `pytest tests/unit/ -v` — 111/111 pass, no regressions
- [ ] Manual: `curl -v http://localhost:8000/health` shows `X-Request-ID` response header; log line `completed GET /health in Xms [request_id=...]` on stdout

Closes #246