### PR TITLE
feat: Sentry integration for production exception alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,4 @@ Vercel automatically creates preview deployments for every PR. To allow all prev
 | `NEXT_PUBLIC_API_URL` | Next.js frontend | FastAPI base URL (Railway domain in production, `http://localhost:8000` locally) |
 | `NEXT_PUBLIC_VERCEL_URL` | FastAPI CORS | Vercel production domain (without `https://`) — set in Railway production |
 | `CORS_ORIGIN_REGEX` | FastAPI CORS | Regex matching allowed origin patterns — covers all Vercel preview URLs without enumerating them |
+| `SENTRY_DSN` | FastAPI (optional) | Sentry DSN — enables production exception alerting; service starts without it but logs a warning |

--- a/api/.env.example
+++ b/api/.env.example
@@ -7,6 +7,7 @@ VOYAGE_API_KEY=
 PERPLEXITY_API_KEY=
 ANTHROPIC_API_KEY=
 API_NINJAS_KEY=
+SENTRY_DSN=                  # optional — Sentry error alerting DSN
 
 # CORS — set in Railway to allow the Vercel production domain
 # Omit in local dev (http://localhost:3000 is always allowed)

--- a/api/main.py
+++ b/api/main.py
@@ -10,16 +10,19 @@ import uuid
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
+import sentry_sdk
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from context import request_id_var
-from settings import LOG_LEVEL_DEFAULT
+from settings import LOG_LEVEL_DEFAULT, SENTRY_DSN_ENV_VAR
 
 logging.basicConfig(
     stream=sys.stdout,
@@ -39,6 +42,23 @@ class _RequestIdFilter(logging.Filter):
 
 for _h in logging.getLogger().handlers:
     _h.addFilter(_RequestIdFilter())
+
+def _configure_sentry() -> None:
+    """Initialise Sentry SDK if SENTRY_DSN is configured; warn if absent."""
+    dsn = os.environ.get(SENTRY_DSN_ENV_VAR)
+    if dsn:
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.environ.get("ENV", "production"),
+            integrations=[StarletteIntegration(), FastApiIntegration()],
+        )
+    else:
+        logging.getLogger(__name__).warning(
+            "SENTRY_DSN is not set — exception alerting disabled"
+        )
+
+
+_configure_sentry()
 
 logger = logging.getLogger(__name__)
 

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -10,3 +10,4 @@ pgvector>=0.3.0
 modal>=0.73.0
 httpx>=0.27.0
 slowapi>=0.1.9
+sentry-sdk[fastapi]>=2.56.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -31,6 +31,7 @@ certifi==2026.2.25
     #   httpx
     #   modal
     #   requests
+    #   sentry-sdk
 cffi==2.0.0
     # via cryptography
 charset-normalizer==3.4.6
@@ -45,7 +46,9 @@ cryptography==46.0.6
 deprecated==1.3.1
     # via limits
 fastapi==0.135.2
-    # via -r api/requirements.in
+    # via
+    #   -r api/requirements.in
+    #   sentry-sdk
 ffmpeg-python==0.2.0
     # via voyageai
 filelock==3.25.2
@@ -176,6 +179,8 @@ rich==14.3.3
     # via
     #   modal
     #   typer
+sentry-sdk==2.56.0
+    # via -r api/requirements.in
 shellingham==1.5.4
     # via typer
 slowapi==0.1.9
@@ -223,7 +228,9 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
 urllib3==2.6.3
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 uuid-utils==0.14.1
     # via
     #   langchain-core

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,6 +1,7 @@
 """Application-wide constants for rate limits and input bounds."""
 
 LOG_LEVEL_DEFAULT = "INFO"
+SENTRY_DSN_ENV_VAR = "SENTRY_DSN"
 LOG_SLOW_QUERY_THRESHOLD_MS = 500  # warn if any DB operation exceeds this
 
 REQUIRED_ENV_VARS = [

--- a/tests/unit/api/test_sentry.py
+++ b/tests/unit/api/test_sentry.py
@@ -1,0 +1,51 @@
+"""Tests for Sentry SDK initialisation in api/main.py."""
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+_MOCK_POOL = MagicMock()
+_MOCK_POOL.close = MagicMock()
+_MOCK_PSYCOPG_POOL = MagicMock()
+_MOCK_PSYCOPG_POOL.ConnectionPool.return_value = _MOCK_POOL
+
+# Import main once (with sentry_sdk.init patched so the module-level call is a no-op).
+with patch("sentry_sdk.init"):
+    with patch.dict(sys.modules, {"psycopg_pool": _MOCK_PSYCOPG_POOL}):
+        with patch("dependencies.set_pool"):
+            with patch("db.analytics.drain"):
+                import main  # noqa: E402
+
+
+def test_sentry_warning_logged_when_dsn_absent(caplog: pytest.LogCaptureFixture) -> None:
+    """A WARNING is emitted when SENTRY_DSN is not set."""
+    env = {"SENTRY_DSN": ""}  # absent / empty
+
+    with patch.dict(os.environ, env):
+        with patch("sentry_sdk.init") as mock_init:
+            with caplog.at_level(logging.WARNING):
+                main._configure_sentry()
+
+    mock_init.assert_not_called()
+    assert any("SENTRY_DSN" in r.message for r in caplog.records)
+
+
+def test_sentry_init_called_when_dsn_present() -> None:
+    """sentry_sdk.init is called with the correct DSN and environment when SENTRY_DSN is set."""
+    env = {"SENTRY_DSN": "https://abc@sentry.io/123", "ENV": "staging"}
+
+    with patch.dict(os.environ, env):
+        with patch("sentry_sdk.init") as mock_init:
+            main._configure_sentry()
+
+    mock_init.assert_called_once()
+    call_kwargs = mock_init.call_args.kwargs
+    assert call_kwargs["dsn"] == "https://abc@sentry.io/123"
+    assert call_kwargs["environment"] == "staging"


### PR DESCRIPTION
## Summary

- Adds `sentry-sdk[fastapi]==2.56.0` to dependencies
- Calls `sentry_sdk.init()` at startup with `FastApiIntegration` + `StarletteIntegration` — unhandled exceptions are captured automatically with full request context
- `SENTRY_DSN` is optional: service starts without it but logs a `WARNING`; no hard-required behaviour change

## Test plan

- [ ] `pytest tests/unit/api/test_sentry.py` — both paths covered (DSN absent → warning, DSN present → init called)
- [ ] Full API unit suite passes: `pytest tests/unit/api/`
- [ ] Smoke test: start app without `SENTRY_DSN` set, confirm startup warning in logs and `/health` returns 200
- [ ] Smoke test: start app with `SENTRY_DSN` set, trigger an unhandled exception, confirm it appears in Sentry dashboard

Closes #247