### PR TITLE
feat: structured JSON logging across the API layer (#248)

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,5 +1,6 @@
 """Shared FastAPI dependencies: database connection, auth, admin check."""
 
+import logging
 import os
 from collections.abc import Generator
 from typing import Annotated
@@ -8,6 +9,8 @@ import jwt
 import psycopg
 from jwt import PyJWKClient
 from fastapi import Depends, Header, HTTPException, status
+
+logger = logging.getLogger(__name__)
 
 try:
     from psycopg_pool import ConnectionPool as _ConnectionPool
@@ -81,6 +84,7 @@ def get_current_user(authorization: Annotated[str | None, Header()] = None) -> s
             detail="Token has expired",
         )
     except Exception:
+        logger.warning("JWKS fetch failed", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token",

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 """FastAPI application entry point — CORS, lifespan, router registration."""
 
+import json
 import logging
 import os
 import signal
@@ -7,6 +8,7 @@ import sys
 import threading
 import time
 import uuid
+from datetime import UTC, datetime
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
@@ -22,13 +24,25 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
 
 from context import request_id_var
-from settings import LOG_LEVEL_DEFAULT, SENTRY_DSN_ENV_VAR
+from settings import LOG_FORMAT_DEFAULT, LOG_LEVEL_DEFAULT, SENTRY_DSN_ENV_VAR
 
-logging.basicConfig(
-    stream=sys.stdout,
-    level=os.environ.get("LOG_LEVEL", LOG_LEVEL_DEFAULT).upper(),
-    format="%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s",
-)
+
+class JsonFormatter(logging.Formatter):
+    """Emit each log record as a single JSON object for log aggregation tools."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Serialize the log record to a JSON string."""
+        record.message = record.getMessage()
+        entry: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.message,
+            "request_id": getattr(record, "request_id", "-"),
+        }
+        if record.exc_info:
+            entry["exception"] = self.formatException(record.exc_info)
+        return json.dumps(entry)
 
 
 class _RequestIdFilter(logging.Filter):
@@ -40,8 +54,17 @@ class _RequestIdFilter(logging.Filter):
         return True
 
 
-for _h in logging.getLogger().handlers:
-    _h.addFilter(_RequestIdFilter())
+_log_format = os.environ.get("LOG_FORMAT", LOG_FORMAT_DEFAULT).lower()
+_handler = logging.StreamHandler(sys.stdout)
+if _log_format == "json":
+    _handler.setFormatter(JsonFormatter())
+else:
+    _handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s")
+    )
+_handler.addFilter(_RequestIdFilter())
+logging.getLogger().setLevel(os.environ.get("LOG_LEVEL", LOG_LEVEL_DEFAULT).upper())
+logging.getLogger().addHandler(_handler)
 
 def _configure_sentry() -> None:
     """Initialise Sentry SDK if SENTRY_DSN is configured; warn if absent."""

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -90,8 +90,8 @@ def analytics_sessions(_: RequireAdminDep) -> list[dict]:
     """Return daily session_start counts for the last 30 days."""
     try:
         return AnalyticsRepository(_db_url()).get_daily_session_starts()
-    except psycopg.Error as e:
-        logger.error("DB error in analytics_sessions: %s", e)
+    except psycopg.Error:
+        logger.error("DB error in analytics_sessions", exc_info=True)
         raise HTTPException(status_code=503, detail="Database unavailable")
 
 
@@ -100,8 +100,8 @@ def analytics_chat(_: RequireAdminDep) -> dict:
     """Return daily chat_turn counts and average turns per session for the last 30 days."""
     try:
         return AnalyticsRepository(_db_url()).get_daily_chat_turns()
-    except psycopg.Error as e:
-        logger.error("DB error in analytics_chat: %s", e)
+    except psycopg.Error:
+        logger.error("DB error in analytics_chat", exc_info=True)
         raise HTTPException(status_code=503, detail="Database unavailable")
 
 
@@ -110,8 +110,8 @@ def analytics_costs(_: RequireAdminDep) -> dict:
     """Return token totals grouped by service for the last 30 days."""
     try:
         return AnalyticsRepository(_db_url()).get_costs_by_service()
-    except psycopg.Error as e:
-        logger.error("DB error in analytics_costs: %s", e)
+    except psycopg.Error:
+        logger.error("DB error in analytics_costs", exc_info=True)
         raise HTTPException(status_code=503, detail="Database unavailable")
 
 
@@ -120,8 +120,8 @@ def analytics_feynman(_: RequireAdminDep) -> dict:
     """Return feynman_stage_completed counts grouped by stage for the last 30 days."""
     try:
         return AnalyticsRepository(_db_url()).get_feynman_by_stage()
-    except psycopg.Error as e:
-        logger.error("DB error in analytics_feynman: %s", e)
+    except psycopg.Error:
+        logger.error("DB error in analytics_feynman", exc_info=True)
         raise HTTPException(status_code=503, detail="Database unavailable")
 
 
@@ -130,8 +130,8 @@ def analytics_ingestions(_: RequireAdminDep) -> dict:
     """Return ingestion_requested events ordered by recency."""
     try:
         return AnalyticsRepository(_db_url()).get_recent_ingestions()
-    except psycopg.Error as e:
-        logger.error("DB error in analytics_ingestions: %s", e)
+    except psycopg.Error:
+        logger.error("DB error in analytics_ingestions", exc_info=True)
         raise HTTPException(status_code=503, detail="Database unavailable")
 
 

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,6 +1,7 @@
 """Application-wide constants for rate limits and input bounds."""
 
 LOG_LEVEL_DEFAULT = "INFO"
+LOG_FORMAT_DEFAULT = "text"  # "json" in production, "text" for local development
 SENTRY_DSN_ENV_VAR = "SENTRY_DSN"
 LOG_SLOW_QUERY_THRESHOLD_MS = 500  # warn if any DB operation exceeds this
 

--- a/tests/unit/api/test_json_logging.py
+++ b/tests/unit/api/test_json_logging.py
@@ -1,0 +1,110 @@
+"""Tests for JsonFormatter and the LOG_FORMAT-driven handler configuration."""
+
+import json
+import logging
+import os
+import sys
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+from main import JsonFormatter, _RequestIdFilter
+
+
+def _make_record(
+    message: str = "test message",
+    level: int = logging.INFO,
+    name: str = "test.logger",
+    exc_info=None,
+) -> logging.LogRecord:
+    """Return a LogRecord pre-populated with a request_id for formatter tests."""
+    record = logging.LogRecord(
+        name=name,
+        level=level,
+        pathname="",
+        lineno=0,
+        msg=message,
+        args=(),
+        exc_info=exc_info,
+    )
+    record.request_id = "req-abc-123"
+    return record
+
+
+def test_json_formatter_output_is_valid_json():
+    """JsonFormatter must produce a parseable JSON string."""
+    formatter = JsonFormatter()
+    record = _make_record()
+    output = formatter.format(record)
+    parsed = json.loads(output)  # raises if not valid JSON
+    assert isinstance(parsed, dict)
+
+
+def test_json_formatter_includes_required_fields():
+    """JSON output must include timestamp, level, logger, message, and request_id."""
+    formatter = JsonFormatter()
+    record = _make_record(message="hello world", name="my.module")
+    output = json.loads(formatter.format(record))
+
+    assert output["level"] == "INFO"
+    assert output["logger"] == "my.module"
+    assert output["message"] == "hello world"
+    assert output["request_id"] == "req-abc-123"
+    assert "timestamp" in output
+    # timestamp must be a valid ISO-8601 string
+    from datetime import datetime
+    datetime.fromisoformat(output["timestamp"])
+
+
+def test_json_formatter_includes_exception_when_exc_info_present():
+    """JSON output must include an 'exception' key when the record carries exc_info."""
+    formatter = JsonFormatter()
+    try:
+        raise ValueError("something went wrong")
+    except ValueError:
+        exc_info = sys.exc_info()
+
+    record = _make_record(exc_info=exc_info)
+    output = json.loads(formatter.format(record))
+
+    assert "exception" in output
+    assert "ValueError" in output["exception"]
+    assert "something went wrong" in output["exception"]
+
+
+def test_json_formatter_no_exception_key_without_exc_info():
+    """JSON output must not include 'exception' key when no exception is attached."""
+    formatter = JsonFormatter()
+    record = _make_record()
+    output = json.loads(formatter.format(record))
+    assert "exception" not in output
+
+
+def test_request_id_filter_injects_dash_when_no_context(monkeypatch):
+    """_RequestIdFilter sets request_id to '-' when no ContextVar value is set."""
+    # Ensure the ContextVar has no value by resetting any existing state
+    import context as ctx
+    token = ctx.request_id_var.set("-")
+    try:
+        filt = _RequestIdFilter()
+        record = logging.LogRecord("x", logging.INFO, "", 0, "msg", (), None)
+        filt.filter(record)
+        assert record.request_id == "-"
+    finally:
+        ctx.request_id_var.reset(token)
+
+
+def test_request_id_filter_injects_contextvar_value():
+    """_RequestIdFilter propagates the active ContextVar value into the record."""
+    import context as ctx
+    token = ctx.request_id_var.set("req-xyz-789")
+    try:
+        filt = _RequestIdFilter()
+        record = logging.LogRecord("x", logging.INFO, "", 0, "msg", (), None)
+        filt.filter(record)
+        assert record.request_id == "req-xyz-789"
+    finally:
+        ctx.request_id_var.reset(token)


### PR DESCRIPTION
## Summary

- Adds `JsonFormatter` — emits `timestamp`, `level`, `logger`, `message`, `request_id`, and optional `exception` as a single JSON object per line
- `LOG_FORMAT=json` enables JSON output in production; `LOG_FORMAT=text` (default) keeps human-readable format for local dev
- Request ID from the correlation middleware ContextVar flows into every log entry automatically via `_RequestIdFilter`
- Five admin route DB error logs switched from `%s` string interpolation to `exc_info=True` so tracebacks go through the logging framework
- JWKS fetch failures now emit `logger.warning("JWKS fetch failed", exc_info=True)` before raising 401

## Test plan

- [ ] `pytest tests/unit/api/test_json_logging.py -v` — 6 new tests: valid JSON, required fields, exception serialisation, no spurious exception key, filter injects `-` default, filter injects ContextVar value
- [ ] `pytest tests/unit/ -q` — full unit suite (119 tests) should pass with no regressions
- [ ] Manual smoke: `LOG_FORMAT=json python -c "import main; import logging; logging.getLogger('smoke').info('hello')"` from `api/` — confirm single-line valid JSON output

Closes #248