### PR TITLE
docs: fix three documentation errors blocking new-stack contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,9 @@ cp web/env.example web/.env.local
 | `SUPABASE_URL` | Supabase project URL, e.g. `https://[ref].supabase.co` (Supabase → Project Settings → API) |
 | `VOYAGE_API_KEY` | Required for the `/search` endpoint; other endpoints work without it |
 | `PERPLEXITY_API_KEY` | Required for the Feynman chat endpoint |
+| `MODAL_TOKEN_ID` | Required — Modal token ID for dispatching ingestion jobs (`modal token new` to generate) |
+
+> `api/.env.example` is the canonical reference for all API env vars with inline comments.
 
 **`web/.env.local` variables:**
 
@@ -387,4 +390,6 @@ Vercel automatically creates preview deployments for every PR. To allow all prev
 | `NEXT_PUBLIC_API_URL` | Next.js frontend | FastAPI base URL (Railway domain in production, `http://localhost:8000` locally) |
 | `NEXT_PUBLIC_VERCEL_URL` | FastAPI CORS | Vercel production domain (without `https://`) — set in Railway production |
 | `CORS_ORIGIN_REGEX` | FastAPI CORS | Regex matching allowed origin patterns — covers all Vercel preview URLs without enumerating them |
+| `CORS_EXTRA_ORIGINS` | FastAPI CORS | Optional comma-separated extra allowed origins (e.g., Vercel preview URLs in staging) |
+| `MODAL_TOKEN_ID` | FastAPI (admin ingest endpoint) | Modal token ID — required at startup; generate with `modal token new` |
 | `SENTRY_DSN` | FastAPI (optional) | Sentry DSN — enables production exception alerting; service starts without it but logs a warning |

--- a/analysis_pipeline.md
+++ b/analysis_pipeline.md
@@ -1,13 +1,24 @@
 # Analysis Pipeline
 
-| #   | Analysis                     | Module         | What it produces                                                                              |
-| --- | ---------------------------- | -------------- | --------------------------------------------------------------------------------------------- |
-| 1   | **Basic Stats**              | `analysis.py`  | Token count from cleaned/tokenized text                                                       |
-| 2   | **Section Extraction**       | `sections.py`  | Splits transcript into **Prepared Remarks** and **Q&A** sections                              |
-| 3   | **Speaker Identification**   | `sections.py`  | Enriched speaker profiles with **role** (executive/analyst/operator), **title**, and **firm** |
-| 4   | **Q&A Exchanges**            | `sections.py`  | Structured question-answer threads grouped by analyst                                         |
-| 5   | **Keywords** (TF-IDF)        | `keywords.py`  | Top 20 salient **terms and bigrams** ranked by importance                                     |
-| 6   | **Themes** (NMF)             | `themes.py`    | 5 **topic clusters** of related terms representing major discussion areas                     |
-| 7   | **Key Takeaways** (TextRank) | `takeaways.py` | Top 10 most **central statements** with speaker attribution                                   |
+## Parsing layer
 
-Layers 1–4 are structural (parsing _who said what_), while 5–7 are conceptual (understanding _what matters_).
+These stages run for every transcript during ingestion, extracting structural information from the raw text.
+
+| # | Stage | Module | Output |
+|---|---|---|---|
+| 1 | **Basic stats** | `parsing/analysis.py` | Token count from cleaned/tokenized text |
+| 2 | **Section extraction** | `parsing/sections.py` | Splits transcript into **Prepared Remarks** and **Q&A** sections |
+| 3 | **Speaker identification** | `parsing/sections.py` | Speaker profiles with **role** (executive/analyst/operator), **title**, and **firm** |
+| 4 | **Q&A threading** | `parsing/sections.py` | Structured question-answer exchanges grouped by analyst |
+
+## LLM enrichment pipeline
+
+After parsing, the ingestion pipeline runs a three-tier LLM analysis defined in `ingestion/prompts.py`. Tiers use different models and run selectively to balance cost and depth.
+
+| Tier | Model | Runs on | Output |
+|---|---|---|---|
+| **Tier 1** | Claude Haiku | Every chunk | Industry jargon + definitions, core concepts (1–3 bullet points), importance score (1–10), `requires_deep_analysis` flag |
+| **Tier 2** | Claude Sonnet | High-score chunks only (`tier1_score >= 6`) | Beginner-friendly takeaways with "why it matters", analyst evasion/skepticism detection (Q&A only) |
+| **Tier 3** | Claude Sonnet | Full call (synthesis pass) | Cross-chunk themes and key takeaways summarising the entire call |
+
+See `ingestion/prompts.py` for the authoritative prompt text and JSON output schemas for each tier.

--- a/api/.env.example
+++ b/api/.env.example
@@ -7,6 +7,7 @@ VOYAGE_API_KEY=
 PERPLEXITY_API_KEY=
 ANTHROPIC_API_KEY=
 API_NINJAS_KEY=
+MODAL_TOKEN_ID=              # required — Modal token for dispatching ingestion jobs (modal token new)
 SENTRY_DSN=                  # optional — Sentry error alerting DSN
 
 # CORS — set in Railway to allow the Vercel production domain

--- a/web/README.md
+++ b/web/README.md
@@ -1,36 +1,52 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# web/
 
-## Getting Started
+Next.js 16 frontend for Earnings Transcript Teacher.
 
-First, run the development server:
+> **Note:** This project uses Next.js 16, which has breaking changes from older versions.
+> Read `web/AGENTS.md` before writing any frontend code.
+
+## Prerequisites
+
+- Node.js 20+
+- The FastAPI backend running locally (`./dev.sh api` from the repo root)
+
+## Environment variables
+
+Copy the template and fill in your values:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+cp env.example .env.local
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+| Variable | Description |
+|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL (Supabase → Project Settings → API) |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key (same page) |
+| `NEXT_PUBLIC_API_URL` | FastAPI base URL — use `http://localhost:8000` for local dev |
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Running
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm run dev        # http://localhost:3000
+```
 
-## Learn More
+Or start both API + frontend together from the repo root:
 
-To learn more about Next.js, take a look at the following resources:
+```bash
+./dev.sh           # starts api (8000) + web (3000)
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## How web/ connects to the backend
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+- **Auth:** Supabase client (`lib/supabase.ts`) handles login/session; JWT is forwarded to FastAPI on every request.
+- **API calls:** `NEXT_PUBLIC_API_URL` points to the FastAPI backend. All data fetching goes through FastAPI — Supabase is auth-only on the frontend.
+- **Proxy:** `proxy.ts` provides a local dev proxy to avoid CORS issues when testing against a non-local API.
 
-## Deploy on Vercel
+## Key files
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Path | Purpose |
+|---|---|
+| `app/` | Next.js App Router pages and layouts |
+| `components/` | Shared UI components |
+| `lib/` | Supabase client, API helpers |
+| `AGENTS.md` | Critical notes for AI coding agents — read before editing |


### PR DESCRIPTION
## Summary

- Adds `MODAL_TOKEN_ID` to `api/.env.example` and both README env tables — it was in `REQUIRED_ENV_VARS` (causing HTTP 503 on all routes if absent) but completely undocumented
- Adds `CORS_EXTRA_ORIGINS` to the README env table (existed in `.env.example` only)
- Adds a note pointing to `api/.env.example` as the canonical API env var reference
- Replaces `web/README.md` default `create-next-app` boilerplate with project-specific setup guide (prereqs, env vars, how to run, how frontend connects to backend, pointer to `web/AGENTS.md`)
- Rewrites `analysis_pipeline.md`: preserves accurate parsing stages 1–4, replaces stages 5–7 (which referenced deleted `keywords.py`/`themes.py`/`takeaways.py`) with a description of the actual three-tier LLM ingestion pipeline in `ingestion/prompts.py`
- `docs/disaster-recovery.md` — no change needed; confirmed no Firebase references

## Test plan

- [ ] Verify `api/.env.example` now contains `MODAL_TOKEN_ID`
- [ ] Verify README env table contains both `MODAL_TOKEN_ID` and `CORS_EXTRA_ORIGINS`
- [ ] Verify `web/README.md` contains project-specific content and links to `web/AGENTS.md`
- [ ] Verify `analysis_pipeline.md` references only modules that exist (`parsing/analysis.py`, `parsing/sections.py`, `ingestion/prompts.py`)
- [ ] Grep for `keywords.py`, `themes.py`, `takeaways.py` in `analysis_pipeline.md` — should return nothing

Closes #250