### PR TITLE
docs: document the prompt library

### DIFF
--- a/docs/llm_usage.md
+++ b/docs/llm_usage.md
@@ -13,6 +13,7 @@ Anthropic's Claude models power the "Agentic Ingestion Pipeline," performing dee
     *   **`claude-sonnet-4-5`**: Used for "Tier 2" tasks that require deeper reasoning, such as identifying key takeaways, analyzing executive evasion, and flagging common investor misconceptions.
 *   **Purpose:** Structured data extraction, pedagogical analysis, and strategic synthesis.
 *   **Implementation:** See `services/llm.py` (`AgenticExtractor`) and `ingestion/pipeline.py`.
+*   **Prompt architecture:** The five prompt constants driving Claude-powered ingestion (`TIER_1_SYSTEM_PROMPT`, `TIER_2_SYSTEM_PROMPT`, `TIER_3_SYNTHESIS_PROMPT`, `HAIKU_NLP_SYNTHESIS_PROMPT`, `QA_DETECTION_SYSTEM_PROMPT`) are defined in `ingestion/prompts.py`. See the module docstring there for tier responsibilities and which model runs each pass.
 
 ---
 
@@ -25,7 +26,7 @@ Perplexity AI's online models are used for interactive elements and real-time gr
     *   **Interactive Chat**: Powers the Streamlit chat interface for "General Q&A" and the "Feynman Loop" tutor.
     *   **On-Demand Definitions**: Generates concise, company-grounded definitions for financial and industry-specific jargon found in the transcript.
     *   **On-Demand Explanations**: Provides contextual explanations of terms using RAG (Retrieval Augmented Generation) based on specific transcript snippets.
-*   **Implementation:** See `services/llm.py` (`stream_chat`) and `app.py`.
+*   **Implementation:** See `services/llm.py` (`stream_chat`) and `api/routes/chat.py`.
 
 ---
 

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -1,3 +1,31 @@
+"""
+Prompt constants for the three-tier LLM ingestion pipeline.
+
+The ingestion pipeline processes transcript chunks in three tiers of increasing depth:
+
+  Tier 1 (TIER_1_SYSTEM_PROMPT): Fast extraction pass run on every chunk by claude-haiku.
+  Identifies industry-specific jargon, extracts core concepts, and scores each chunk's
+  strategic importance (1–10). Sets requires_deep_analysis=True for chunks scoring >= 6.
+
+  Tier 2 (TIER_2_SYSTEM_PROMPT): Enrichment pass run by claude-sonnet on high-importance
+  chunks only (requires_deep_analysis=True). Generates beginner-friendly takeaways,
+  analyses executive evasion and defensiveness in Q&A exchanges, and flags common
+  investor misconceptions.
+
+  Tier 3 (TIER_3_SYNTHESIS_PROMPT): Global synthesis pass run by claude-haiku after all
+  chunks are processed. Produces a narrative call summary, overall sentiment, executive
+  tone, key thematic clusters, strategic shifts, and analyst sentiment.
+
+Supporting prompts:
+  HAIKU_NLP_SYNTHESIS_PROMPT — NLP synthesis pass that ranks keywords, clusters themes,
+  and selects top takeaways from the aggregated Tier 1/2 signals.
+
+  QA_DETECTION_SYSTEM_PROMPT — Fallback for detecting the Prepared Remarks → Q&A
+  section boundary when deterministic methods fail.
+
+Consumed by: ingestion/pipeline.py
+"""
+
 import json
 
 TIER_1_SYSTEM_PROMPT = """You are an expert financial analyst assistant.

--- a/prompts/feynman/README.md
+++ b/prompts/feynman/README.md
@@ -1,0 +1,51 @@
+# Feynman Prompt Library
+
+This directory contains the system prompts for the Feynman learning loop. Each file is a self-contained prompt that shapes the tutor's behaviour for one stage of the interaction.
+
+## Stage mapping
+
+| File | Stage | Role |
+|------|-------|------|
+| `00_beginner_jargon.md` | Beginner variant | Jargon explanation tuned for novice learners |
+| `00_beginner_takeaways.md` | Beginner variant | Key takeaways framing tuned for novice learners |
+| `00_general_qa.md` | General Q&A | Free-form question answering outside the Feynman loop |
+| `01_initial_explanation.md` | Stage 1 | Tutor introduces the concept using analogies grounded in the transcript |
+| `02_gap_analysis.md` | Stage 2 | Tutor identifies gaps in the student's understanding and probes deeper |
+| `03_guided_refinement.md` | Stage 3 | Tutor provides targeted feedback to help the student refine their explanation |
+| `04_understanding_test.md` | Stage 4 | Tutor tests comprehension with knowledge checks |
+| `05_teaching_note.md` | Stage 5 | Student produces a teaching note as a summative assessment |
+| `synthesis.md` | Post-loop | Synthesises learning across all completed stages |
+
+## Loading mechanism (FastAPI path)
+
+Prompts are loaded at request time by `api/routes/chat.py`:
+
+```python
+_STAGE_PROMPTS: dict[int, str] = {
+    1: "01_initial_explanation.md",
+    2: "02_gap_analysis.md",
+    3: "03_guided_refinement.md",
+    4: "04_understanding_test.md",
+    5: "05_teaching_note.md",
+}
+
+def _load_prompt(stage: int) -> str:
+    filename = _STAGE_PROMPTS.get(stage, "01_initial_explanation.md")
+    return (_PROMPTS_DIR / filename).read_text(encoding="utf-8")
+```
+
+The `_PROMPTS_DIR` resolves to this directory (`prompts/feynman/`) relative to the repo root.
+
+**Known gap**: `00_beginner_jargon.md`, `00_beginner_takeaways.md`, `00_general_qa.md`, and `synthesis.md` exist on disk but are not wired into `_STAGE_PROMPTS`. They were used by the Streamlit-era loader and are retained for future integration.
+
+## Deprecated path
+
+The Streamlit UI (`ui/feynman.py`) had an equivalent loader (`_load_prompt_file()`, `_FEYNMAN_PROMPT_FILES`). That path is no longer active — `ui/feynman.py` is part of the deprecated Streamlit stack.
+
+## Versioning
+
+Prompt files carry no inline version markers. Changes are tracked via git history. When making a substantive change to a prompt, include a clear commit message explaining the intent.
+
+## Editing guidance
+
+Files are read from disk at request time (not cached at startup), so changes take effect immediately at the next API request without a server restart.


### PR DESCRIPTION
## Summary

- Creates `prompts/feynman/README.md` with a stage mapping table for all 9 prompt files, the live loading mechanism (`api/routes/chat.py`), a note on the unmapped `00_*`/`synthesis.md` variants, the deprecated Streamlit path, versioning approach, and editing guidance
- Adds a module-level docstring to `ingestion/prompts.py` explaining the three-tier ingestion architecture and which model runs each pass
- Updates `docs/llm_usage.md` with a prompt architecture cross-reference under the Anthropic section; fixes a stale `app.py` reference in the Perplexity section to point to `api/routes/chat.py`

## Test plan

- [ ] `ls prompts/feynman/` shows `README.md`
- [ ] `python -c "import ingestion.prompts; help(ingestion.prompts)"` prints the new docstring
- [ ] `docs/llm_usage.md` shows the prompt architecture reference under Anthropic and the corrected Perplexity implementation path

Closes #254