### PR TITLE
docs: add implementation status to architecture specs

### DIFF
--- a/docs/architecture-review/specs/[001] project-restructure.spec.md
+++ b/docs/architecture-review/specs/[001] project-restructure.spec.md
@@ -6,6 +6,22 @@
 
 ---
 
+## Implementation status
+
+**Status:** Not implemented as specified
+
+**What happened instead:** The FastAPI backend (`api/`) was built directly against the existing top-level module structure. The `nlp/`, `parsing/`, `services/`, `ingestion/`, and `db/` directories were never moved under `core/`. The `core/` package exists but contains only `models.py`.
+
+**Remaining (deferred):**
+- Move `nlp/`, `parsing/`, `services/`, `ingestion/` under `core/`
+- Move `db/` under `core/db/`
+- Rewrite all consumer imports across `api/`, `app.py`, `ui/`, `cli/`, `tests/`
+- Delete original top-level module directories
+
+**Note:** The practical goal of this spec — keeping `api/` thin and delegating to business logic modules — was achieved without the physical restructure. The move may still be worth doing for long-term maintainability, but it is not blocking any current work.
+
+---
+
 ## Goal
 
 Move all framework-independent business logic into a `core/` package so that both the existing Streamlit app and the new FastAPI backend can import from the same place. At the end of this spec, the Streamlit app and CLI work exactly as before — the only change is where imports come from.

--- a/docs/architecture-review/specs/[002] data-layer.spec.md
+++ b/docs/architecture-review/specs/[002] data-layer.spec.md
@@ -6,6 +6,26 @@
 
 ---
 
+## Implementation status
+
+**Status:** Partially implemented
+
+**Implemented via:** #214
+
+**What was built:**
+- Repository pattern implemented as `db/repositories/` (split into `calls.py`, `analysis.py`, `learning.py`, `progress.py`, `embeddings.py`, `competitors.py`, `analytics.py`, `schema.py`)
+- Supabase JWT provides user identity — `user_id` is extracted from the auth token and passed through to repository calls
+- Schema has evolved to v12 (migrations 000–012 in `db/migrations/`)
+
+**Remaining / diverged:**
+- Abstract interfaces (`core/db/interfaces.py` with `abc.ABC` + `@abstractmethod`) were never created — concrete repository classes exist with no formal interface layer
+- Connection pooling: the spec called for `psycopg_pool.ConnectionPool`; current repositories accept a connection string and open connections per-call — pooling may still be needed for production load
+- Auth provider changed from Firebase UID to Supabase UID — the scoping model is the same but the token format and verification path differ
+- Some raw SQL remains in route files rather than going through repository classes (tracked in #195, #198)
+- Typed return dataclasses (replacing raw tuples) were partially adopted; some methods still return raw tuples or dicts
+
+---
+
 ## Goal
 
 Extract abstract repository interfaces from the current concrete PostgreSQL implementations. Add user_id scoping to support multi-tenancy. Introduce connection pooling for production readiness. At the end of this spec, the data layer has clean interfaces that a future non-Postgres backend could implement, and all user-scoped data is isolated by Firebase UID.

--- a/docs/architecture-review/specs/[003] backend-api.spec.md
+++ b/docs/architecture-review/specs/[003] backend-api.spec.md
@@ -6,6 +6,33 @@
 
 ---
 
+## Implementation status
+
+**Status:** Implemented (with significant divergence from spec)
+
+**Implemented via:** Multiple PRs. Auth bypass fixed in #212.
+
+**What was built:**
+- FastAPI application at `api/` (not `backend/` as spec'd)
+- Auth middleware uses Supabase JWT verification (not Firebase Admin SDK) — `api/dependencies.py` provides `CurrentUserDep` and `RequireAdminDep`
+- Routes at `api/routes/`: `calls.py` (call library + all analysis endpoints), `chat.py` (Feynman SSE streaming), `admin.py` (health check + ingestion trigger)
+- Dependency injection via `api/dependencies.py` (`DbDep`, `CurrentUserDep`, `RequireAdminDep`)
+- Pydantic response models on all endpoints
+- Rate limiting via `slowapi` (was out of scope in spec; delivered anyway)
+- JSON structured logging, Sentry integration, graceful shutdown
+- Ingestion dispatched to Modal (not an inline long-running FastAPI endpoint)
+- `api/Dockerfile` present
+
+**Remaining / diverged:**
+- `backend/` directory structure from spec was not used — everything lives in `api/`
+- Firebase Admin SDK replaced by Supabase JWT — local dev bypass pattern differs from spec
+- Separate `analysis.py` route file from spec was not created; analysis endpoints live in `calls.py`
+- `learning.py` and `progress.py` route files were not created as separate files; learning/progress endpoints may be absent or consolidated
+- `GET /api/calls/{ticker}/news` and `/competitors` endpoints: verify current state
+- OpenAPI docs available at `/docs` (FastAPI default)
+
+---
+
 ## Goal
 
 Stand up a FastAPI application that exposes the full API surface defined in the target architecture, with Firebase Auth middleware protecting all endpoints. At the end of this spec, a developer can run the backend locally and exercise every endpoint via curl or an API client — no frontend required.

--- a/docs/architecture-review/specs/[004] deployment.spec.md
+++ b/docs/architecture-review/specs/[004] deployment.spec.md
@@ -6,6 +6,27 @@
 
 ---
 
+## Implementation status
+
+**Status:** Partially implemented
+
+**Implemented via:** #229 (CI pipeline)
+
+**What was built:**
+- GitHub Actions CI at `.github/workflows/ci.yml`: runs pytest + migration checks on push to `main` and on pull requests
+- `api/Dockerfile` present (multi-stage build for the FastAPI backend)
+
+**Remaining / diverged:**
+- Infrastructure stack changed from the spec: GCP (Cloud Run + Cloud SQL + Firebase Hosting + Secret Manager) was replaced by Supabase (database + auth), Modal (ingestion pipeline), and a separate frontend host
+- Firebase projects (`ett-dev`, `ett-prod`) were never created; `firebase.json` and `.firebaserc` do not exist
+- Cloud Run deployment automation not implemented — no `gcloud` scripts or Terraform
+- `docker-compose.yml` for local containerised dev: verify whether this was added
+- GitHub Actions prod deploy with manual approval gate: not implemented
+- Secret management via GCP Secret Manager: replaced by Modal secrets (`earnings-secrets`) for the ingestion pipeline and environment variables for the API
+- CI currently runs tests and migration checks; it does not build a Docker image or deploy anywhere
+
+---
+
 ## Goal
 
 Define the infrastructure and CI/CD pipeline to deploy the FastAPI backend to Cloud Run and (later) the React frontend to Firebase Hosting. At the end of this spec, pushing to `main` triggers an automated deploy to the dev environment, and production deploys are gated by manual approval.

--- a/docs/architecture-review/specs/[005] frontend.spec.md
+++ b/docs/architecture-review/specs/[005] frontend.spec.md
@@ -6,6 +6,32 @@
 
 ---
 
+## Implementation status
+
+**Status:** Partially implemented
+
+**What was built:**
+- Next.js application at `web/` (not Vite + React as spec'd) — see `web/AGENTS.md` for Next.js-specific conventions
+- Auth via Supabase (not Firebase JS SDK)
+- App Router with server and client components; no React Router
+- Pages: home (`/`), call library, ticker detail (`/calls/[ticker]`), Feynman learning (`/calls/[ticker]/learn`), admin dashboard + health + ingest
+- API client layer at `web/lib/api.ts` with Supabase auth token injection
+- SSE streaming client at `web/lib/chat.ts`
+- Supabase server/client helpers at `web/lib/supabase/`
+
+**Remaining / diverged:**
+- Build tool changed: Vite + React SPA → Next.js (App Router, server components)
+- Auth provider changed: Firebase JS SDK → Supabase Auth
+- Data fetching: TanStack Query was not adopted; server components fetch directly via `createSupabaseServerClient()` or the backend API
+- Component library and styling choices from spec (Shadcn/ui or Headless UI, Tailwind) may differ from what was implemented — verify `web/package.json`
+- Learning Path steps 3–6 (Language, Strategic Shifts, Evasion, Test Understanding): verify current implementation state
+- Step progress tracking UI: verify whether `web/lib/` hooks for progress exist
+- Transcript Browser page: verify current state
+- E2E tests (Playwright): verify whether any exist in `web/`
+- Deployment target: Firebase Hosting was replaced; verify actual hosting setup (likely Vercel given `web/vercel.json`)
+
+---
+
 ## Goal
 
 Build a React SPA that achieves feature parity with the current Streamlit UI. The frontend consumes the FastAPI backend (003), authenticates via Firebase Auth, and deploys to Firebase Hosting (004). At the end of this spec, the Streamlit app can be retired.


### PR DESCRIPTION
## Summary

- Each of the five `docs/architecture-review/specs/` files now has an **Implementation status** block immediately after the title, covering: current status, implementing PRs, and what diverged from the original spec

## Per-spec findings

| Spec | Status | Key divergence |
|------|--------|----------------|
| 001 Project Restructure | Not implemented | `core/` extraction never done; FastAPI built directly against top-level modules |
| 002 Data Layer | Partially implemented | Repository pattern exists (`db/repositories/`); no abstract interface layer; Firebase → Supabase auth |
| 003 FastAPI Backend | Implemented (diverged) | Lives in `api/` not `backend/`; Firebase Admin → Supabase JWT; rate limiting added; Modal handles ingestion |
| 004 Deployment Pipeline | Partially implemented | CI live (#229); GCP/Firebase Hosting/Cloud Run replaced by Supabase + Modal + separate frontend host |
| 005 React Frontend | Partially implemented | Next.js not Vite+React; Supabase not Firebase; server components not React Query |

## Test plan

- [ ] Read each of the five spec files — status block appears at the top, before the existing content
- [ ] No existing spec content was modified

Closes #255