### PR TITLE
feat: surface signal data on call cards

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -41,6 +41,9 @@ class CallSummary(BaseModel):
     company_name: str | None = None
     call_date: str | None = None
     industry: str | None = None
+    evasion_level: str | None = None
+    overall_sentiment: str | None = None
+    top_strategic_shift: str | None = None
 
 
 class SpeakerInfo(BaseModel):
@@ -117,15 +120,43 @@ def list_calls() -> list[CallSummary]:
     with psycopg.connect(_db_url()) as conn:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT ticker, company_name, call_date, industry FROM calls ORDER BY created_at DESC"
+                """
+                SELECT
+                    c.ticker,
+                    c.company_name,
+                    c.call_date::text,
+                    c.industry,
+                    cs.overall_sentiment,
+                    CASE
+                        WHEN COUNT(ea.id) = 0 THEN NULL
+                        WHEN AVG(ea.defensiveness_score) <= 3 THEN 'low'
+                        WHEN AVG(ea.defensiveness_score) <= 6 THEN 'medium'
+                        ELSE 'high'
+                    END AS evasion_level,
+                    CASE
+                        WHEN cs.strategic_shifts IS NOT NULL
+                             AND array_length(cs.strategic_shifts, 1) > 0
+                        THEN cs.strategic_shifts[1]->>'current_position'
+                        ELSE NULL
+                    END AS top_strategic_shift
+                FROM calls c
+                LEFT JOIN call_synthesis cs ON cs.call_id = c.id
+                LEFT JOIN evasion_analysis ea ON ea.call_id = c.id
+                GROUP BY c.ticker, c.company_name, c.call_date, c.industry, c.created_at,
+                         cs.overall_sentiment, cs.strategic_shifts
+                ORDER BY c.created_at DESC
+                """
             )
             rows = cur.fetchall()
     return [
         CallSummary(
             ticker=r[0],
             company_name=r[1],
-            call_date=str(r[2]) if r[2] else None,
+            call_date=r[2],
             industry=r[3],
+            overall_sentiment=r[4],
+            evasion_level=r[5],
+            top_strategic_shift=r[6],
         )
         for r in rows
     ]

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -46,8 +46,8 @@ def client():
 class TestListCalls:
     def test_returns_call_list(self, client):
         mock_rows = [
-            ("AAPL", "Apple Inc.", "2025-01-30", "Technology"),
-            ("MSFT", "Microsoft Corp.", None, None),
+            ("AAPL", "Apple Inc.", "2025-01-30", "Technology", "bullish", "low", "Expanding into AI hardware"),
+            ("MSFT", "Microsoft Corp.", None, None, None, None, None),
         ]
         mock_cursor = MagicMock()
         mock_cursor.fetchall.return_value = mock_rows
@@ -67,8 +67,13 @@ class TestListCalls:
         assert data[0]["company_name"] == "Apple Inc."
         assert data[0]["call_date"] == "2025-01-30"
         assert data[0]["industry"] == "Technology"
+        assert data[0]["overall_sentiment"] == "bullish"
+        assert data[0]["evasion_level"] == "low"
+        assert data[0]["top_strategic_shift"] == "Expanding into AI hardware"
         assert data[1]["ticker"] == "MSFT"
         assert data[1]["call_date"] is None
+        assert data[1]["evasion_level"] is None
+        assert data[1]["top_strategic_shift"] is None
 
     def test_logs_route_entry(self, client, caplog):
         """list_calls() emits an INFO log on entry."""

--- a/web/components/CallCard.tsx
+++ b/web/components/CallCard.tsx
@@ -5,10 +5,30 @@ export interface CallSummary {
   company_name: string | null;
   call_date: string | null;
   industry: string | null;
+  evasion_level: "low" | "medium" | "high" | null;
+  overall_sentiment: string | null;
+  top_strategic_shift: string | null;
 }
 
 interface CallCardProps {
   call: CallSummary;
+}
+
+const EVASION_STYLES: Record<string, string> = {
+  low: "bg-green-50 text-green-700",
+  medium: "bg-amber-50 text-amber-700",
+  high: "bg-red-50 text-red-700",
+};
+
+function sentimentStyle(sentiment: string): string {
+  const lower = sentiment.toLowerCase();
+  if (lower.includes("bullish") || lower.includes("positive")) {
+    return "bg-green-50 text-green-700";
+  }
+  if (lower.includes("bearish") || lower.includes("negative")) {
+    return "bg-red-50 text-red-700";
+  }
+  return "bg-zinc-100 text-zinc-600";
 }
 
 /** Card displaying summary metadata for a single earnings call. */
@@ -35,6 +55,29 @@ export function CallCard({ call }: CallCardProps) {
         <span className="mt-3 inline-block rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs text-zinc-600">
           {call.industry}
         </span>
+      )}
+      {(call.evasion_level || call.overall_sentiment) && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {call.overall_sentiment && (
+            <span
+              className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${sentimentStyle(call.overall_sentiment)}`}
+            >
+              {call.overall_sentiment}
+            </span>
+          )}
+          {call.evasion_level && (
+            <span
+              className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${EVASION_STYLES[call.evasion_level] ?? "bg-zinc-100 text-zinc-600"}`}
+            >
+              {call.evasion_level} evasion
+            </span>
+          )}
+        </div>
+      )}
+      {call.top_strategic_shift && (
+        <p className="mt-2 truncate text-xs text-zinc-400">
+          {call.top_strategic_shift}
+        </p>
       )}
     </Link>
   );


### PR DESCRIPTION
## Summary

- Extends `/api/calls` list endpoint to return `evasion_level`, `overall_sentiment`, and `top_strategic_shift` via a single JOIN query (no extra round trips)
- Evasion level is computed in SQL from avg `defensiveness_score`: ≤3 → low, ≤6 → medium, >6 → high
- `CallCard` renders evasion and sentiment as small colored badges; top strategic shift appears as a truncated muted line; cards with no signal data show no empty fields

## Test plan

- [ ] `pytest tests/unit/api/test_calls.py` — 16 tests pass
- [ ] `GET /api/calls` returns `evasion_level`, `overall_sentiment`, `top_strategic_shift` fields in JSON
- [ ] Library page shows signal badges on cards that have analysis data
- [ ] Cards without analysis data render cleanly with no empty fields

Closes #204