### PR TITLE
feat: call brief + misconception reveal-cards

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -71,6 +71,31 @@ class SynthesisInfo(BaseModel):
     analyst_sentiment: str | None = None
 
 
+class TakeawayItem(BaseModel):
+    takeaway: str
+    why_it_matters: str
+
+
+class MisconceptionItem(BaseModel):
+    fact: str
+    misinterpretation: str
+    correction: str
+
+
+class CallBrief(BaseModel):
+    context_line: str
+    bigger_picture: list[str] = []
+    interpretation_questions: list[str] = []
+
+
+class SignalStrip(BaseModel):
+    overall_sentiment: str | None = None
+    executive_sentiment: str | None = None
+    analyst_sentiment: str | None = None
+    evasion_level: str | None = None
+    strategic_shift_flagged: bool = False
+
+
 class CallDetail(BaseModel):
     ticker: str
     company_name: str | None = None
@@ -83,6 +108,10 @@ class CallDetail(BaseModel):
     evasion_analyses: list[EvasionItem] = []
     strategic_shifts: list[StrategicShift] = []
     speakers: list[SpeakerInfo] = []
+    brief: CallBrief | None = None
+    takeaways: list[TakeawayItem] = []
+    misconceptions: list[MisconceptionItem] = []
+    signal_strip: SignalStrip | None = None
 
 
 class SpanItem(BaseModel):
@@ -213,6 +242,34 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
     raw_speakers = analysis_repo.get_speakers_for_ticker(ticker, conn=conn)
     speakers = [SpeakerInfo(name=r[0], role=r[1], title=r[2], firm=r[3]) for r in raw_speakers]
 
+    # Brief
+    raw_brief = analysis_repo.get_call_brief_for_ticker(ticker)
+    brief = CallBrief(**raw_brief) if raw_brief else None
+
+    # Takeaways (top 3 for the brief)
+    raw_takeaways = analysis_repo.get_takeaways_for_ticker(ticker, limit=3)
+    takeaways = [TakeawayItem(takeaway=r[0], why_it_matters=r[1]) for r in raw_takeaways]
+
+    # Misconceptions (top 3 for the brief)
+    raw_misconceptions = analysis_repo.get_misconceptions_for_ticker(ticker)
+    misconceptions = [
+        MisconceptionItem(fact=r[0], misinterpretation=r[1], correction=r[2])
+        for r in raw_misconceptions[:3]
+    ]
+
+    # Signal strip
+    evasion_level = None
+    if raw_evasion:
+        avg_score = sum(r[1] for r in raw_evasion) / len(raw_evasion)
+        evasion_level = "high" if avg_score > 6 else ("medium" if avg_score > 3 else "low")
+    signal_strip = SignalStrip(
+        overall_sentiment=raw_synthesis[0] if raw_synthesis else None,
+        executive_sentiment=raw_synthesis[1] if raw_synthesis else None,
+        analyst_sentiment=raw_synthesis[2] if raw_synthesis else None,
+        evasion_level=evasion_level,
+        strategic_shift_flagged=len(raw_shifts) > 0,
+    )
+
     response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
     return CallDetail(
         ticker=ticker,
@@ -226,6 +283,10 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         evasion_analyses=evasion_analyses,
         strategic_shifts=strategic_shifts,
         speakers=speakers,
+        brief=brief,
+        takeaways=takeaways,
+        misconceptions=misconceptions,
+        signal_strip=signal_strip,
     )
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -241,6 +241,15 @@ class TranscriptChunk(BaseModel):
 # ---------------------------------------------------------------------------
 
 @dataclass
+class CallBriefRecord:
+    """LLM-generated pre-reading brief for a call (stored in call_brief table)."""
+
+    context_line: str
+    bigger_picture: list[str]
+    interpretation_questions: list[str]
+
+
+@dataclass
 class CallAnalysis:
     """Complete structured output of the analysis pipeline for one call."""
 
@@ -251,7 +260,8 @@ class CallAnalysis:
     topics: list[TopicRecord]
     takeaways: list[SpanRecord]     # subset of spans with textrank_score set
     qa_pairs: list[QAPairRecord]
-    
+
     chunks: list[TranscriptChunk] = field(default_factory=list)
     synthesis: CallSynthesisRecord | None = None
     token_usage: TokenUsageSummary | None = None
+    brief: CallBriefRecord | None = None

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -482,6 +482,8 @@ class AnalysisRepository:
                 self._save_agentic_chunks(cur, result.call.id, getattr(result, "chunks", []))
                 if getattr(result, "synthesis", None):
                     self._save_call_synthesis(cur, result.call.id, result.synthesis)
+                if getattr(result, "brief", None):
+                    self._save_call_brief(cur, result.call.id, result.brief)
             conn.commit()
 
     def _save_call_synthesis(self, cur, call_id, synthesis):
@@ -736,3 +738,61 @@ class AnalysisRepository:
                     gotcha.get("correction") or "",
                 ),
             )
+
+    def _save_call_brief(self, cur, call_id, brief) -> None:
+        """Upsert the call_brief row for a given call_id (used within an open transaction)."""
+        from psycopg.types.json import Jsonb
+        cur.execute(
+            """
+            INSERT INTO call_brief (call_id, context_line, bigger_picture, interpretation_questions)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (call_id) DO UPDATE SET
+                context_line = EXCLUDED.context_line,
+                bigger_picture = EXCLUDED.bigger_picture,
+                interpretation_questions = EXCLUDED.interpretation_questions
+            """,
+            (
+                str(call_id),
+                brief.context_line,
+                Jsonb(brief.bigger_picture),
+                Jsonb(brief.interpretation_questions),
+            ),
+        )
+
+    def save_call_brief(self, call_id, brief) -> None:
+        """Upsert the call_brief row for a given call_id (opens its own connection)."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    self._save_call_brief(cur, call_id, brief)
+                conn.commit()
+        except Exception as e:
+            logger.warning(f"Could not save call_brief for {call_id}: {e}")
+
+    def get_call_brief_for_ticker(self, ticker: str) -> dict | None:
+        """Return the call_brief record for a ticker, or None if absent."""
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT cb.context_line, cb.bigger_picture, cb.interpretation_questions
+                        FROM call_brief cb
+                        JOIN calls c ON cb.call_id = c.id
+                        WHERE c.ticker = %s
+                        ORDER BY c.created_at DESC
+                        LIMIT 1
+                        """,
+                        (ticker,),
+                    )
+                    row = cur.fetchone()
+                    if not row:
+                        return None
+                    return {
+                        "context_line": row[0],
+                        "bigger_picture": row[1] or [],
+                        "interpretation_questions": row[2] or [],
+                    }
+        except Exception as e:
+            logger.warning(f"Could not fetch call_brief for {ticker}: {e}")
+        return None

--- a/ingestion/pipeline.py
+++ b/ingestion/pipeline.py
@@ -3,7 +3,7 @@ import logging
 from typing import List, Dict, Any, Optional, Tuple, Set
 import concurrent.futures
 
-from core.models import CallAnalysis, CallSynthesisRecord, TranscriptChunk, TokenUsageSummary
+from core.models import CallAnalysis, CallBriefRecord, CallSynthesisRecord, TranscriptChunk, TokenUsageSummary
 from parsing.financial_terms import scan_chunk
 from services.company_info import build_company_context
 
@@ -186,7 +186,7 @@ class IngestionPipeline:
         from services.llm import AgenticExtractor
         self.extractor = AgenticExtractor()
 
-    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord, TokenUsageSummary, dict]:
+    def process(self, analysis: CallAnalysis) -> tuple[List[TranscriptChunk], CallSynthesisRecord, TokenUsageSummary, dict, CallBriefRecord | None]:
         """Run the full ingestion pipeline on a parsed CallAnalysis."""
         logger.info(f"Starting agentic ingestion for {analysis.call.ticker}")
 
@@ -207,7 +207,7 @@ class IngestionPipeline:
             return [], CallSynthesisRecord(
                 overall_sentiment="", executive_tone="", key_themes=[],
                 strategic_shifts=[], analyst_sentiment="",
-            ), TokenUsageSummary(), {}
+            ), TokenUsageSummary(), {}, None
 
         # Phase 2: Map Phase (Concurrent Extraction)
         # Process chunks in parallel using a ThreadPoolExecutor
@@ -322,8 +322,31 @@ class IngestionPipeline:
             logger.warning(f"NLP synthesis phase failed: {e}")
             print(f"⚠️  NLP synthesis phase failed: {e}")
 
+        # Phase 5: Brief Synthesis (Haiku — context_line, bigger_picture, interpretation_questions)
+        print(f"\n[Brief Synthesis Phase] Generating call brief...")
+        brief_record: CallBriefRecord | None = None
+        try:
+            brief_payload = self._build_brief_payload(synthesis, nlp_synthesis)
+            brief_data = self.extractor.extract_brief_synthesis(brief_payload)
+            brief_usage = brief_data.pop("_usage_stats", None)
+            if brief_usage:
+                token_usage.add(
+                    brief_usage["model"],
+                    brief_usage["prompt_tokens"],
+                    brief_usage["completion_tokens"],
+                )
+                print(f"    ↳ Brief Synthesis [Model: {brief_usage['model']} | In: {brief_usage['prompt_tokens']} | Out: {brief_usage['completion_tokens']}]")
+            brief_record = CallBriefRecord(
+                context_line=brief_data.get("context_line", ""),
+                bigger_picture=brief_data.get("bigger_picture", []),
+                interpretation_questions=brief_data.get("interpretation_questions", []),
+            )
+        except Exception as e:
+            logger.warning(f"Brief synthesis phase failed: {e}")
+            print(f"⚠️  Brief synthesis phase failed: {e}")
+
         print("✅ Agentic ingestion complete.\n")
-        return chunks, synthesis, token_usage, nlp_synthesis
+        return chunks, synthesis, token_usage, nlp_synthesis, brief_record
 
     def _build_nlp_signals_payload(self, chunks: List[TranscriptChunk]) -> str:
         """Collect map-phase signals from all chunks into a JSON payload for NLP synthesis."""
@@ -352,6 +375,25 @@ class IngestionPipeline:
         }
         return json.dumps(payload, indent=2)
         
+    def _build_brief_payload(self, synthesis: CallSynthesisRecord, nlp_synthesis: dict) -> str:
+        """Build the JSON payload for brief synthesis from call synthesis data."""
+        payload = {
+            "call_summary": synthesis.call_summary or "",
+            "overall_sentiment": synthesis.overall_sentiment,
+            "executive_tone": synthesis.executive_tone,
+            "analyst_sentiment": synthesis.analyst_sentiment,
+            "key_themes": synthesis.key_themes,
+            "strategic_shifts": synthesis.strategic_shifts,
+            "recent_news": [],
+            "competitors": [],
+        }
+        # Include NLP-derived themes if richer than synthesis themes
+        if nlp_synthesis.get("themes"):
+            nlp_theme_names = [t.get("name", "") for t in nlp_synthesis["themes"] if t.get("name")]
+            if nlp_theme_names:
+                payload["key_themes"] = nlp_theme_names
+        return json.dumps(payload, indent=2)
+
     def _process_single_chunk(self, chunk: TranscriptChunk, index: int, total_chunks: int, company_context: str = "") -> list[dict]:
         """Helper method to process a single chunk, designed to run in a thread.
 

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -20,6 +20,9 @@ Supporting prompts:
   HAIKU_NLP_SYNTHESIS_PROMPT — NLP synthesis pass that ranks keywords, clusters themes,
   and selects top takeaways from the aggregated Tier 1/2 signals.
 
+  BRIEF_SYNTHESIS_PROMPT — Brief generation pass (Phase 5) run after Tier 3 synthesis.
+  Produces the call brief: context_line, bigger_picture bullets, and interpretation_questions.
+
   QA_DETECTION_SYSTEM_PROMPT — Fallback for detecting the Prepared Remarks → Q&A
   section boundary when deterministic methods fail.
 
@@ -164,6 +167,42 @@ Respond ONLY with valid JSON matching this schema:
   "top_takeaways": [
     {"speaker": "string", "takeaway": "string", "why_it_matters": "string"}
   ]
+}
+"""
+
+BRIEF_SYNTHESIS_PROMPT = """You are an elite financial educator preparing a 60-second orientation brief \
+for a student about to read an earnings call transcript.
+
+You will receive a JSON payload containing:
+- call_summary: narrative summary of the call
+- overall_sentiment: one-sentence overall sentiment
+- executive_tone: description of executive tone
+- analyst_sentiment: prevailing analyst mood
+- key_themes: list of dominant themes
+- strategic_shifts: list of strategic shift objects
+- recent_news: list of recent headline/summary pairs about the company (may be empty)
+- competitors: list of competitor name/description pairs (may be empty)
+
+Produce exactly three fields:
+
+1. **context_line**: One precise sentence (≤25 words) that frames WHY this specific call matters right now. \
+Mention a concrete catalyst if one is present (e.g., a guidance cut, a major acquisition, a sector-wide shock). \
+Do NOT simply restate the call_summary.
+
+2. **bigger_picture**: An array of exactly 2-3 plain-text bullet strings synthesising the most important \
+external context: relevant recent news, key competitor dynamics, or macro forces a student needs to hold in mind \
+while reading. Each bullet ≤20 words. If no news or competitor data is available, derive bullets from the \
+strategic_shifts and key_themes.
+
+3. **interpretation_questions**: An array of exactly 3 open-ended questions a skilled analyst would hold in \
+mind while reading this transcript. Each question should probe something genuinely uncertain or contested — not \
+something the call_summary already answers directly.
+
+Respond ONLY with valid JSON matching this schema:
+{
+  "context_line": "string",
+  "bigger_picture": ["string", "string"],
+  "interpretation_questions": ["string", "string", "string"]
 }
 """
 

--- a/scripts/backfill_briefs.py
+++ b/scripts/backfill_briefs.py
@@ -1,0 +1,168 @@
+"""Backfill call briefs for existing calls that have synthesis data but no brief yet.
+
+Usage:
+    python scripts/backfill_briefs.py                  # process all missing briefs
+    python scripts/backfill_briefs.py --dry-run        # show which calls would be processed
+    python scripts/backfill_briefs.py --ticker MSFT    # process a single ticker
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+# Allow running from project root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv("api/.env")
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def find_tickers_missing_briefs(conn_str: str, ticker_filter: str | None = None) -> list[tuple[str, str]]:
+    """Return [(ticker, call_id)] for calls with synthesis data but no brief."""
+    import psycopg
+
+    query = """
+        SELECT c.ticker, c.id::text
+        FROM calls c
+        JOIN call_synthesis cs ON cs.call_id = c.id
+        LEFT JOIN call_brief cb ON cb.call_id = c.id
+        WHERE cb.call_id IS NULL
+    """
+    params: list = []
+    if ticker_filter:
+        query += " AND c.ticker = %s"
+        params.append(ticker_filter.upper())
+    query += " ORDER BY c.created_at DESC"
+
+    with psycopg.connect(conn_str) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, params)
+            return cur.fetchall()
+
+
+def fetch_synthesis_for_call(conn_str: str, call_id: str) -> dict | None:
+    """Return synthesis data for a call_id."""
+    import psycopg
+
+    with psycopg.connect(conn_str) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT overall_sentiment, executive_tone, analyst_sentiment,
+                       key_themes, strategic_shifts, call_summary
+                FROM call_synthesis
+                WHERE call_id = %s
+                """,
+                (call_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            return {
+                "overall_sentiment": row[0] or "",
+                "executive_tone": row[1] or "",
+                "analyst_sentiment": row[2] or "",
+                "key_themes": row[3] or [],
+                "strategic_shifts": row[4] or [],
+                "call_summary": row[5] or "",
+            }
+
+
+def generate_brief(synthesis: dict) -> dict:
+    """Call the brief synthesis LLM step and return the result dict."""
+    from services.llm import AgenticExtractor
+
+    extractor = AgenticExtractor()
+    payload = {
+        "call_summary": synthesis["call_summary"],
+        "overall_sentiment": synthesis["overall_sentiment"],
+        "executive_tone": synthesis["executive_tone"],
+        "analyst_sentiment": synthesis["analyst_sentiment"],
+        "key_themes": synthesis["key_themes"],
+        "strategic_shifts": synthesis["strategic_shifts"],
+        "recent_news": [],
+        "competitors": [],
+    }
+    result = extractor.extract_brief_synthesis(json.dumps(payload, indent=2))
+    result.pop("_usage_stats", None)
+    return result
+
+
+def save_brief(conn_str: str, call_id: str, brief_data: dict) -> None:
+    """Upsert the call_brief row for a call_id."""
+    import psycopg
+    from psycopg.types.json import Jsonb
+
+    with psycopg.connect(conn_str) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO call_brief (call_id, context_line, bigger_picture, interpretation_questions)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (call_id) DO UPDATE SET
+                    context_line = EXCLUDED.context_line,
+                    bigger_picture = EXCLUDED.bigger_picture,
+                    interpretation_questions = EXCLUDED.interpretation_questions
+                """,
+                (
+                    call_id,
+                    brief_data.get("context_line", ""),
+                    Jsonb(brief_data.get("bigger_picture", [])),
+                    Jsonb(brief_data.get("interpretation_questions", [])),
+                ),
+            )
+        conn.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill call briefs for existing calls.")
+    parser.add_argument("--dry-run", action="store_true", help="Show affected calls without making changes.")
+    parser.add_argument("--ticker", metavar="TICKER", help="Process a single ticker only.")
+    args = parser.parse_args()
+
+    conn_str = os.environ.get("DATABASE_URL")
+    if not conn_str:
+        logger.error("DATABASE_URL environment variable is not set.")
+        sys.exit(1)
+
+    missing = find_tickers_missing_briefs(conn_str, ticker_filter=args.ticker)
+
+    if not missing:
+        logger.info("No calls missing a brief. Nothing to do.")
+        return
+
+    logger.info("Found %d call(s) missing a brief: %s", len(missing), [t for t, _ in missing])
+
+    if args.dry_run:
+        logger.info("Dry run — no changes made.")
+        return
+
+    success = 0
+    failed = 0
+    for ticker, call_id in missing:
+        logger.info("Processing %s (call_id=%s)...", ticker, call_id)
+        try:
+            synthesis = fetch_synthesis_for_call(conn_str, call_id)
+            if not synthesis:
+                logger.warning("No synthesis found for %s — skipping.", ticker)
+                failed += 1
+                continue
+            brief_data = generate_brief(synthesis)
+            save_brief(conn_str, call_id, brief_data)
+            logger.info("  ✓ Brief saved for %s", ticker)
+            success += 1
+        except Exception as e:
+            logger.error("  ✗ Failed for %s: %s", ticker, e)
+            failed += 1
+
+    logger.info("Done. %d succeeded, %d failed.", success, failed)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/llm.py
+++ b/services/llm.py
@@ -12,7 +12,7 @@ from tenacity import retry, wait_exponential_jitter, stop_after_attempt, retry_i
 _CITATION_PATTERN = re.compile(r'\[(?:\d+|[a-z_]+)\]')
 
 import anthropic
-from ingestion.prompts import TIER_1_SYSTEM_PROMPT, TIER_2_SYSTEM_PROMPT, TIER_3_SYNTHESIS_PROMPT, QA_DETECTION_SYSTEM_PROMPT, HAIKU_NLP_SYNTHESIS_PROMPT
+from ingestion.prompts import TIER_1_SYSTEM_PROMPT, TIER_2_SYSTEM_PROMPT, TIER_3_SYNTHESIS_PROMPT, QA_DETECTION_SYSTEM_PROMPT, HAIKU_NLP_SYNTHESIS_PROMPT, BRIEF_SYNTHESIS_PROMPT
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +288,25 @@ class AgenticExtractor:
             messages=[{"role": "user", "content": user_prompt}]
         )
         self._track_usage(message, "nlp_synthesis")
+        return self._parse_response(message)
+
+    @retry(
+        wait=wait_exponential_jitter(initial=2, max=60),
+        stop=stop_after_attempt(5),
+        retry=retry_if_exception(_should_retry_error),
+        reraise=True
+    )
+    def extract_brief_synthesis(self, payload: str) -> Dict[str, Any]:
+        """Run Phase 5 brief synthesis: produce context_line, bigger_picture, and interpretation_questions."""
+        user_prompt = f"### Call Brief Payload:\n{payload}\n\nProduce the call brief JSON."
+        self.rate_limiter.wait()
+        message = self.client.messages.create(
+            model=self.tier3_model,
+            max_tokens=1024,
+            system=BRIEF_SYNTHESIS_PROMPT,
+            messages=[{"role": "user", "content": user_prompt}]
+        )
+        self._track_usage(message, "brief_synthesis")
         return self._parse_response(message)
 
     @retry(

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -200,10 +200,11 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
     try:
         from ingestion.pipeline import IngestionPipeline
         pipeline = IngestionPipeline()
-        chunks, synthesis, token_usage, nlp_synthesis = pipeline.process(analysis)
+        chunks, synthesis, token_usage, nlp_synthesis, brief = pipeline.process(analysis)
         analysis.chunks = chunks
         analysis.synthesis = synthesis
         analysis.token_usage = token_usage
+        analysis.brief = brief
 
         if nlp_synthesis:
             raw_keywords = nlp_synthesis.get("keywords", [])

--- a/supabase/migrations/20260330000000_call_brief.sql
+++ b/supabase/migrations/20260330000000_call_brief.sql
@@ -1,0 +1,13 @@
+-- Migration: add call_brief table for LLM-generated pre-reading brief
+-- Generated as part of issue #206 (call brief + misconception cards)
+
+CREATE TABLE IF NOT EXISTS call_brief (
+    id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    call_id                  UUID NOT NULL REFERENCES calls(id) ON DELETE CASCADE UNIQUE,
+    context_line             TEXT NOT NULL,
+    bigger_picture           JSONB NOT NULL DEFAULT '[]',
+    interpretation_questions JSONB NOT NULL DEFAULT '[]',
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_call_brief_call ON call_brief(call_id);

--- a/web/app/calls/[ticker]/page.tsx
+++ b/web/app/calls/[ticker]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { TranscriptBrowser } from "@/components/transcript/TranscriptBrowser";
 import { MetadataPanel } from "@/components/transcript/MetadataPanel";
+import { CallBriefPanel } from "@/components/transcript/CallBriefPanel";
 import type { CallDetail } from "@/components/transcript/types";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -58,6 +59,16 @@ export default async function TranscriptPage({
           <span className="ml-auto text-sm text-zinc-400">{call.call_date}</span>
         )}
       </div>
+
+      {/* Call brief — shown only when available */}
+      {call.brief && (
+        <CallBriefPanel
+          brief={call.brief}
+          takeaways={call.takeaways}
+          misconceptions={call.misconceptions}
+          signal_strip={call.signal_strip ?? null}
+        />
+      )}
 
       {/* Two-column layout */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">

--- a/web/components/transcript/CallBriefPanel.tsx
+++ b/web/components/transcript/CallBriefPanel.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+/** Pre-reading brief panel shown at the top of the call page. */
+
+import { useState } from "react";
+import type { CallBrief, TakeawayItem, MisconceptionItem, SignalStrip } from "./types";
+import { MisconceptionCard } from "./MisconceptionCard";
+
+interface CallBriefPanelProps {
+  brief: CallBrief;
+  takeaways: TakeawayItem[];
+  misconceptions: MisconceptionItem[];
+  signal_strip: SignalStrip | null;
+}
+
+const EVASION_STYLES: Record<string, string> = {
+  low: "bg-green-50 text-green-700",
+  medium: "bg-amber-50 text-amber-700",
+  high: "bg-red-50 text-red-700",
+};
+
+function sentimentStyle(sentiment: string): string {
+  const lower = sentiment.toLowerCase();
+  if (lower.includes("bullish") || lower.includes("positive") || lower.includes("optimistic")) {
+    return "bg-green-50 text-green-700";
+  }
+  if (lower.includes("bearish") || lower.includes("negative") || lower.includes("cautious")) {
+    return "bg-red-50 text-red-700";
+  }
+  return "bg-zinc-100 text-zinc-600";
+}
+
+interface SignalBadgeProps {
+  label: string;
+  value: string | null;
+}
+
+function SignalBadge({ label, value }: SignalBadgeProps) {
+  if (!value) return null;
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${sentimentStyle(value)}`}>
+      {label}: {value}
+    </span>
+  );
+}
+
+interface EvasionBadgeProps {
+  level: string | null;
+}
+
+function EvasionBadge({ level }: EvasionBadgeProps) {
+  if (!level) return null;
+  const style = EVASION_STYLES[level] ?? "bg-zinc-100 text-zinc-600";
+  return (
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${style}`}>
+      Evasion: {level}
+    </span>
+  );
+}
+
+export function CallBriefPanel({ brief, takeaways, misconceptions, signal_strip }: CallBriefPanelProps) {
+  const [allExpanded, setAllExpanded] = useState(false);
+
+  return (
+    <div className="rounded-xl border border-zinc-200 bg-white p-5 space-y-5 mb-6">
+      {/* Context line */}
+      <p className="text-sm font-medium text-zinc-700 leading-relaxed italic">
+        {brief.context_line}
+      </p>
+
+      {/* Bigger Picture bullets */}
+      {brief.bigger_picture.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400 mb-2">
+            Bigger Picture
+          </p>
+          <ul className="space-y-1">
+            {brief.bigger_picture.map((bullet, i) => (
+              <li key={i} className="text-sm text-zinc-600 flex gap-2">
+                <span className="text-zinc-300 select-none">•</span>
+                {bullet}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Key takeaways */}
+      {takeaways.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400 mb-2">
+            Key Takeaways
+          </p>
+          <ol className="space-y-2 list-decimal list-inside">
+            {takeaways.map((t, i) => (
+              <li key={i} className="text-sm">
+                <span className="font-medium text-zinc-800">{t.takeaway}</span>
+                {t.why_it_matters && (
+                  <span className="text-zinc-500"> — {t.why_it_matters}</span>
+                )}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {/* Interpretation questions */}
+      {brief.interpretation_questions.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400 mb-2">
+            Hold These in Mind
+          </p>
+          <ol className="space-y-1.5 list-decimal list-inside">
+            {brief.interpretation_questions.map((q, i) => (
+              <li key={i} className="text-sm text-zinc-600">{q}</li>
+            ))}
+          </ol>
+        </div>
+      )}
+
+      {/* Signal strip */}
+      {signal_strip && (
+        <div className="flex flex-wrap gap-2 border-t border-zinc-100 pt-4">
+          <SignalBadge label="Exec tone" value={signal_strip.executive_sentiment} />
+          <SignalBadge label="Analyst mood" value={signal_strip.analyst_sentiment} />
+          <EvasionBadge level={signal_strip.evasion_level} />
+          {signal_strip.strategic_shift_flagged && (
+            <span className="rounded-full px-2.5 py-0.5 text-xs font-medium bg-violet-50 text-violet-700">
+              Strategic shift flagged
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Misconception reveal-cards */}
+      {misconceptions.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">
+              Common Misreadings
+            </p>
+            {misconceptions.length >= 2 && (
+              <button
+                onClick={() => setAllExpanded((prev) => !prev)}
+                className="text-xs text-zinc-500 hover:text-zinc-700 underline-offset-2 hover:underline"
+              >
+                {allExpanded ? "Collapse all" : "Expand all"}
+              </button>
+            )}
+          </div>
+          <div className="space-y-2">
+            {misconceptions.map((m, i) => (
+              <MisconceptionCard key={i} item={m} forceExpanded={allExpanded} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/transcript/MisconceptionCard.tsx
+++ b/web/components/transcript/MisconceptionCard.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+/** Reveal-card for a single misconception item. Judgment-first pattern. */
+
+import { useState } from "react";
+import type { MisconceptionItem } from "./types";
+
+interface MisconceptionCardProps {
+  item: MisconceptionItem;
+  /** When true, overrides local state and forces the card open. */
+  forceExpanded?: boolean;
+}
+
+export function MisconceptionCard({ item, forceExpanded = false }: MisconceptionCardProps) {
+  const [revealed, setRevealed] = useState(false);
+  const isOpen = forceExpanded || revealed;
+
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 overflow-hidden">
+      {/* Always-visible: the misinterpretation (the "gotcha") */}
+      <button
+        onClick={() => setRevealed((prev) => !prev)}
+        className="w-full text-left px-4 py-3 flex items-start justify-between gap-3 hover:bg-amber-100 transition-colors"
+      >
+        <p className="text-sm font-medium text-amber-900">{item.misinterpretation}</p>
+        <span className="shrink-0 text-xs text-amber-600 font-semibold mt-0.5">
+          {isOpen ? "Hide" : "Reveal"}
+        </span>
+      </button>
+
+      {/* Revealed: the correction */}
+      {isOpen && (
+        <div className="px-4 pb-3 border-t border-amber-200 pt-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-600 mb-1">
+            Correction
+          </p>
+          <p className="text-sm text-amber-800">{item.correction}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/transcript/types.ts
+++ b/web/components/transcript/types.ts
@@ -25,6 +25,31 @@ export interface SpeakerInfo {
   firm: string | null;
 }
 
+export interface TakeawayItem {
+  takeaway: string;
+  why_it_matters: string;
+}
+
+export interface MisconceptionItem {
+  fact: string;
+  misinterpretation: string;
+  correction: string;
+}
+
+export interface CallBrief {
+  context_line: string;
+  bigger_picture: string[];
+  interpretation_questions: string[];
+}
+
+export interface SignalStrip {
+  overall_sentiment: string | null;
+  executive_sentiment: string | null;
+  analyst_sentiment: string | null;
+  evasion_level: string | null;
+  strategic_shift_flagged: boolean;
+}
+
 export interface CallDetail {
   ticker: string;
   company_name: string | null;
@@ -37,6 +62,10 @@ export interface CallDetail {
   evasion_analyses: EvasionItem[];
   strategic_shifts: StrategicShift[];
   speakers: SpeakerInfo[];
+  brief: CallBrief | null;
+  takeaways: TakeawayItem[];
+  misconceptions: MisconceptionItem[];
+  signal_strip: SignalStrip | null;
 }
 
 export interface SpanItem {


### PR DESCRIPTION
## Summary

- Adds a 60–90 second pre-reading **Call Brief** panel above the analyst steps on every call page
- Brief contains: context line, bigger-picture bullets, key takeaways, interpretation questions, signal strip (sentiment/evasion/strategic shift), and 2–3 misconception reveal-cards
- Misconception cards use a **judgment-first reveal** pattern — misinterpretation shown by default, correction revealed on click; "Expand all" toggle when 2+ cards are present
- Brief is generated at ingest time (Phase 5 of ingestion pipeline, Haiku model)
- New `call_brief` DB table; existing calls can be backfilled via `scripts/backfill_briefs.py`

## What changed

**DB:** `supabase/migrations/20260330000000_call_brief.sql` — new `call_brief` table

**Ingestion:** `BRIEF_SYNTHESIS_PROMPT` + `extract_brief_synthesis()` + Phase 5 in `pipeline.py`; `CallBriefRecord` dataclass in `core/models.py`

**Backend:** `get_call_brief_for_ticker()` + `save_call_brief()` in `AnalysisRepository`; `CallBrief`, `SignalStrip`, `TakeawayItem`, `MisconceptionItem` Pydantic models; `CallDetail` extended; `GET /api/calls/{ticker}` now returns brief + signal strip

**Frontend:** `types.ts` extended; new `MisconceptionCard.tsx` + `CallBriefPanel.tsx`; `page.tsx` renders `CallBriefPanel` above the two-column layout (degrades gracefully when brief is absent)

**Backfill:** `scripts/backfill_briefs.py` (supports `--dry-run`, `--ticker`)

## Test plan

- [ ] Apply migration in Supabase SQL Editor: `supabase/migrations/20260330000000_call_brief.sql`
- [ ] Run ingestion on a test ticker: confirm `call_brief` row appears in DB
- [ ] `curl /api/calls/{ticker}` — confirm `brief`, `takeaways`, `misconceptions`, `signal_strip` in response
- [ ] Load `/calls/{ticker}` — brief panel renders above analyst steps
- [ ] Click a misconception card → correction revealed; click "Expand all" → all cards open
- [ ] Load a call with no brief row → page renders without brief panel, no errors
- [ ] `python scripts/backfill_briefs.py --dry-run` → shows affected tickers; run without flag → rows created

Closes #206