### PR TITLE
fix: resolve stuck loading state in evasion signals stream

### DIFF
--- a/web/lib/signals.ts
+++ b/web/lib/signals.ts
@@ -50,38 +50,52 @@ export async function streamSignals(
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let terminated = false;
 
   signal?.addEventListener("abort", () => { reader.cancel().catch(() => {}); });
 
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (signal?.aborted) break;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (signal?.aborted) break;
 
-    buffer += decoder.decode(value, { stream: true });
+      buffer += decoder.decode(value, { stream: true });
 
-    const events = buffer.split("\n\n");
-    buffer = events.pop() ?? "";
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
 
-    for (const event of events) {
-      const dataLine = event.split("\n").find((line) => line.startsWith("data: "));
-      if (!dataLine) continue;
+      for (const event of events) {
+        const dataLine = event.split("\n").find((line) => line.startsWith("data: "));
+        if (!dataLine) continue;
 
-      const jsonStr = dataLine.slice("data: ".length);
-      let parsed: { type: string; content?: string; message?: string };
-      try {
-        parsed = JSON.parse(jsonStr);
-      } catch {
-        continue;
+        const jsonStr = dataLine.slice("data: ".length);
+        let parsed: { type: string; content?: string; message?: string };
+        try {
+          parsed = JSON.parse(jsonStr);
+        } catch {
+          continue;
+        }
+
+        if (parsed.type === "token" && parsed.content !== undefined) {
+          callbacks.onToken(parsed.content);
+        } else if (parsed.type === "done") {
+          terminated = true;
+          callbacks.onDone();
+        } else if (parsed.type === "error") {
+          terminated = true;
+          callbacks.onError(parsed.message ?? "Unknown error");
+        }
       }
-
-      if (parsed.type === "token" && parsed.content !== undefined) {
-        callbacks.onToken(parsed.content);
-      } else if (parsed.type === "done") {
-        callbacks.onDone();
-      } else if (parsed.type === "error") {
-        callbacks.onError(parsed.message ?? "Unknown error");
-      }
+    }
+  } catch (err: unknown) {
+    if (!signal?.aborted) {
+      terminated = true;
+      callbacks.onError(err instanceof Error ? err.message : "Stream read error");
+    }
+  } finally {
+    if (!terminated && !signal?.aborted) {
+      callbacks.onDone();
     }
   }
 }


### PR DESCRIPTION
## Summary

- `streamSignals` could leave `loadingSignals = true` permanently after a successful 200 response, freezing the button in "Analysing…" state
- Two bugs caused this: a missing fallback `onDone` call and no error handling for stream read failures

## Root cause

**Bug 1 — `onDone` never called when stream ends without flushing the buffer**

The while loop broke immediately on `reader.read()` returning `{done:true}`, discarding anything still in `buffer`. If the final `\n\n` of the `done` SSE event arrived in a TCP packet merged with the stream close signal, that event was never parsed and `onDone` was never called. A `finally` block now calls `onDone()` as a fallback if the stream ended without either `onDone` or `onError` firing.

**Bug 2 — silent rejection when `reader.read()` throws**

If the network dropped after the 200 was received, `reader.read()` could throw and the promise would reject without calling `onError`. A `catch` block now surfaces this as an `onError` call.

## Test plan

- [ ] Click "What this signals for investors" on an evasion card — signals text streams in and loading state clears
- [ ] Verify no stuck "Analysing…" state under slow/interrupted network (DevTools → Network → throttle or abort mid-stream)
- [ ] Verify the button shows an error message (not stuck loading) if the API is unreachable after the button is clicked

Closes #275