### PR TITLE
fix: use sonar model and surface empty-response error in evasion signals stream

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -453,10 +453,15 @@ def _signals_sse_stream(body: EvasionSignalsRequest):
         }
     ]
     try:
-        for chunk in stream_chat(messages, _SIGNALS_SYSTEM_PROMPT):
+        has_content = False
+        for chunk in stream_chat(messages, _SIGNALS_SYSTEM_PROMPT, model="sonar"):
             if isinstance(chunk, str):
+                has_content = True
                 yield f"data: {_json.dumps({'type': 'token', 'content': chunk})}\n\n"
-        yield f"data: {_json.dumps({'type': 'done'})}\n\n"
+        if has_content:
+            yield f"data: {_json.dumps({'type': 'done'})}\n\n"
+        else:
+            yield f"data: {_json.dumps({'type': 'error', 'message': 'No content received from model'})}\n\n"
     except Exception:
         logger.exception("Error streaming evasion signals")
         yield f"data: {_json.dumps({'type': 'error', 'message': 'Stream error'})}\n\n"


### PR DESCRIPTION
## Summary

- Switch `_signals_sse_stream` from `sonar-pro` (search-augmented) to `sonar` (non-search) — evasion items are specific to the transcript, not resolvable by web search, so search-augmented results come back citation-heavy or empty
- Add `has_content` guard: if the stream yields no string chunks, emit an `error` event instead of a silent `done`, so the UI displays an error rather than reverting the button silently

## Test plan

- [ ] Click "What this signals for investors" on an evasion card — should stream content and stay visible
- [ ] If stream fails, button should show an error state rather than silently reverting
- [ ] `pytest -q` passes (122 tests)

Closes #278