### PR TITLE
fix: switch evasion signals from Perplexity to Claude, fix silent revert bug

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -437,9 +437,9 @@ class EvasionSignalsRequest(BaseModel):
 
 
 def _signals_sse_stream(body: EvasionSignalsRequest):
-    """Generator that calls stream_chat and emits SSE-formatted lines for evasion signals."""
+    """Generator that streams investor-implications framing as SSE events."""
     import json as _json
-    from services.llm import stream_chat
+    from services.llm import stream_investor_signals
 
     level = _defensiveness_label(body.defensiveness_score)
     messages = [
@@ -452,12 +452,15 @@ def _signals_sse_stream(body: EvasionSignalsRequest):
             ),
         }
     ]
+    logger.debug("evasion_signals stream starting")
     try:
         has_content = False
-        for chunk in stream_chat(messages, _SIGNALS_SYSTEM_PROMPT, model="sonar"):
-            if isinstance(chunk, str):
-                has_content = True
-                yield f"data: {_json.dumps({'type': 'token', 'content': chunk})}\n\n"
+        for chunk in stream_investor_signals(messages, _SIGNALS_SYSTEM_PROMPT):
+            if not has_content:
+                logger.debug("evasion_signals first token received")
+            has_content = True
+            yield f"data: {_json.dumps({'type': 'token', 'content': chunk})}\n\n"
+        logger.debug("evasion_signals stream ended has_content=%s", has_content)
         if has_content:
             yield f"data: {_json.dumps({'type': 'done'})}\n\n"
         else:
@@ -480,13 +483,6 @@ def evasion_signals(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"No call found for ticker {ticker!r}",
-        )
-
-    api_key = os.environ.get("PERPLEXITY_API_KEY")
-    if not api_key:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Signals unavailable — PERPLEXITY_API_KEY is not configured",
         )
 
     return StreamingResponse(

--- a/services/llm.py
+++ b/services/llm.py
@@ -124,6 +124,26 @@ def stream_chat(
         raise
 
 
+def stream_investor_signals(
+    messages: list[dict],
+    system_prompt: str,
+):
+    """Stream a short investor-implications analysis using the Anthropic API.
+
+    Yields string chunks of the assistant's response as they arrive.
+    Raises on API errors.
+    """
+    client = anthropic.Anthropic()
+    with client.messages.stream(
+        model="claude-haiku-4-5-20251001",
+        max_tokens=256,
+        system=system_prompt,
+        messages=messages,
+    ) as stream:
+        for text in stream.text_stream:
+            yield text
+
+
 class RateLimiter:
     """A simple token-bucket-like rate limiter for the Anthropic API. Thread-safe."""
     def __init__(self, requests_per_minute: int = 50, requests_per_second: int = 1):

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -29,7 +29,7 @@ def client():
         with patch("psycopg.connect"):
             from fastapi.testclient import TestClient
             from main import app
-            from dependencies import get_db
+            from dependencies import get_db, get_current_user
 
             def override_get_db():
                 """Bypass the connection pool; forward to the (possibly re-patched) psycopg.connect."""
@@ -37,10 +37,16 @@ def client():
                 conn = _psycopg.connect(os.environ["DATABASE_URL"])
                 yield conn
 
+            def override_get_current_user():
+                """Return a fixed user ID for all authenticated routes."""
+                return "test-user-id"
+
             app.dependency_overrides[get_db] = override_get_db
+            app.dependency_overrides[get_current_user] = override_get_current_user
             with TestClient(app) as c:
                 yield c
             app.dependency_overrides.pop(get_db, None)
+            app.dependency_overrides.pop(get_current_user, None)
 
 
 class TestListCalls:
@@ -268,3 +274,81 @@ class TestSearchTranscript:
         with patch("slowapi.Limiter._check_request_limit", side_effect=_raise_429):
             response = client.get("/api/calls/AAPL/search?q=revenue")
         assert response.status_code == 429
+
+
+class TestEvasionSignals:
+    PAYLOAD = {
+        "analyst_concern": "Margin guidance",
+        "defensiveness_score": 7,
+        "evasion_explanation": "Executive redirected to top-line growth.",
+    }
+
+    def _parse_sse(self, text: str) -> list[dict]:
+        """Parse SSE response body into a list of event dicts."""
+        import json
+        events = []
+        for block in text.split("\n\n"):
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[len("data: "):]))
+        return events
+
+    def test_404_for_unknown_ticker(self, client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = client.post("/api/calls/UNKNOWN/evasion-signals", json=self.PAYLOAD)
+        assert response.status_code == 404
+
+    def test_happy_path_streams_tokens_and_done(self, client):
+        """When stream_investor_signals yields tokens, endpoint emits token events then done."""
+        def _fake_stream(messages, system_prompt):
+            yield "Investors "
+            yield "should note."
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_fake_stream),
+        ):
+            response = client.post("/api/calls/AAPL/evasion-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        token_events = [e for e in events if e["type"] == "token"]
+        assert len(token_events) == 2
+        assert token_events[0]["content"] == "Investors "
+        assert token_events[1]["content"] == "should note."
+        assert events[-1] == {"type": "done"}
+
+    def test_no_content_emits_error_event(self, client):
+        """When stream_investor_signals yields nothing, endpoint emits an error SSE event."""
+        def _empty_stream(messages, system_prompt):
+            return
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_empty_stream),
+        ):
+            response = client.post("/api/calls/AAPL/evasion-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+        assert "No content" in events[0]["message"]
+
+    def test_api_exception_emits_error_event(self, client):
+        """When stream_investor_signals raises, endpoint emits an error SSE event."""
+        def _failing_stream(messages, system_prompt):
+            raise RuntimeError("upstream API error")
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_failing_stream),
+        ):
+            response = client.post("/api/calls/AAPL/evasion-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"

--- a/web/lib/signals.ts
+++ b/web/lib/signals.ts
@@ -95,7 +95,7 @@ export async function streamSignals(
     }
   } finally {
     if (!terminated && !signal?.aborted) {
-      callbacks.onDone();
+      callbacks.onError("Stream closed without response");
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces Perplexity `sonar` with Claude Haiku (`stream_investor_signals` via Anthropic SDK) for the investor-implications stream — this feature requires no web search and Perplexity stopped returning content after a model/API change
- Fixes a frontend bug in `streamSignals` where an unclean stream close (no `done`/`error` event received) called `onDone()`, silently reverting the button with no error shown; now calls `onError()`
- Removes the Perplexity API key guard from the route handler (`ANTHROPIC_API_KEY` is already validated at startup)
- Adds `TestEvasionSignals` with 4 tests (404, happy path, no-content error, exception error); adds `get_current_user` override to the shared test fixture

## Test plan

- [ ] `pytest tests/unit/api/test_calls.py -v` — all 20 tests pass including 4 new `TestEvasionSignals` tests
- [ ] `pytest -q` — full suite green (154 tests)
- [ ] Manual: open a call page, click "What this signals for investors" — content streams in and persists on the card
- [ ] Manual: verify error state is visible if the API call fails (e.g. bad key)

Closes #280