### PR TITLE
feat: loading, empty, and error state consistency (#314)

### DIFF
--- a/web/__tests__/components/LearnPage.test.tsx
+++ b/web/__tests__/components/LearnPage.test.tsx
@@ -103,6 +103,30 @@ describe("LearnPage", () => {
     );
   });
 
+  it("shows a dismissible error banner when streamChat calls onError", async () => {
+    mockStreamChat.mockImplementation(
+      (_ticker: unknown, _message: unknown, _sessionId: unknown, callbacks: { onError: (msg: string) => void }) => {
+        callbacks.onError("Something went wrong.");
+        return Promise.resolve();
+      }
+    );
+
+    renderLearnPage("aapl");
+    const textarea = screen.getByRole("textbox");
+    await userEvent.type(textarea, "Tell me about revenue");
+    await userEvent.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /dismiss error/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Something went wrong.")).not.toBeInTheDocument();
+    });
+  });
+
   it("clears messages and resets state when New session is clicked", async () => {
     // Make streamChat call onDone to add an assistant message
     mockStreamChat.mockImplementation(

--- a/web/app/admin/health/loading.tsx
+++ b/web/app/admin/health/loading.tsx
@@ -1,0 +1,26 @@
+/** Skeleton shown while admin health data loads. */
+export default function AdminHealthLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      {/* Title skeleton */}
+      <div className="mb-8 h-9 w-72 animate-pulse rounded bg-zinc-200" />
+
+      {/* 3-column status card skeleton */}
+      <div className="grid gap-6 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-zinc-200 bg-white p-5">
+            <div className="mb-3 h-3 w-28 animate-pulse rounded bg-zinc-200" />
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, j) => (
+                <div key={j} className="flex items-center gap-3">
+                  <div className="h-3 w-3 animate-pulse rounded-full bg-zinc-200" />
+                  <div className="h-4 w-40 animate-pulse rounded bg-zinc-100" />
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -2,7 +2,7 @@
 
 /** Admin page for triggering transcript ingestion. Client component (form state). */
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type Status = "idle" | "submitting" | "accepted" | "error";
 
@@ -10,6 +10,13 @@ export default function AdminIngestPage() {
   const [ticker, setTicker] = useState("");
   const [status, setStatus] = useState<Status>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+    };
+  }, []);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -28,6 +35,7 @@ export default function AdminIngestPage() {
       if (resp.status === 202) {
         setStatus("accepted");
         setTicker("");
+        dismissTimerRef.current = setTimeout(() => setStatus("idle"), 4000);
         return;
       }
 
@@ -76,10 +84,7 @@ export default function AdminIngestPage() {
               id="ticker"
               type="text"
               value={ticker}
-              onChange={(e) => {
-                setTicker(e.target.value);
-                if (status !== "submitting") setStatus("idle");
-              }}
+              onChange={(e) => setTicker(e.target.value)}
               placeholder="e.g. AAPL"
               disabled={status === "submitting"}
               className="w-full rounded-md border border-zinc-300 px-3 py-2 font-mono text-sm uppercase text-zinc-900 placeholder:normal-case placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-zinc-50 disabled:text-zinc-400"

--- a/web/app/admin/loading.tsx
+++ b/web/app/admin/loading.tsx
@@ -1,0 +1,36 @@
+/** Skeleton shown while admin analytics data loads. */
+export default function AdminLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      {/* Title skeleton */}
+      <div className="mb-8 h-9 w-64 animate-pulse rounded bg-zinc-200" />
+
+      {/* Stat card row skeleton */}
+      <div className="mb-8 grid gap-6 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="rounded-lg border border-zinc-200 bg-white p-5">
+            <div className="mb-3 h-3 w-24 animate-pulse rounded bg-zinc-200" />
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, j) => (
+                <div key={j} className="h-4 w-full animate-pulse rounded bg-zinc-100" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Table-like skeleton */}
+      <div className="rounded-lg border border-zinc-200 bg-white p-5">
+        <div className="mb-3 h-3 w-32 animate-pulse rounded bg-zinc-200" />
+        <div className="space-y-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-4">
+              <div className="h-4 w-24 animate-pulse rounded bg-zinc-200" />
+              <div className="h-4 flex-1 animate-pulse rounded bg-zinc-100" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/app/auth/sign-in/page.tsx
+++ b/web/app/auth/sign-in/page.tsx
@@ -63,9 +63,17 @@ function SignInContent() {
   );
 }
 
+function SignInSpinner() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-zinc-50">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+    </div>
+  );
+}
+
 export default function SignInPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<SignInSpinner />}>
       <SignInContent />
     </Suspense>
   );

--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -122,8 +122,15 @@ export default function LearnPage({
 
       {/* Error banner */}
       {error && (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
+        <div className="mb-4 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <span className="flex-1">{error}</span>
+          <button
+            onClick={() => setError(null)}
+            aria-label="Dismiss error"
+            className="shrink-0 text-red-400 hover:text-red-600"
+          >
+            ✕
+          </button>
         </div>
       )}
 

--- a/web/components/EmptyState.tsx
+++ b/web/components/EmptyState.tsx
@@ -1,0 +1,15 @@
+interface EmptyStateProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+}
+
+/** Reusable empty state with dashed border, centered title and optional subtitle. */
+export function EmptyState({ title, subtitle, className }: EmptyStateProps) {
+  return (
+    <div className={`rounded-xl border border-dashed px-8 py-12 text-center bg-card ${className ?? ""}`}>
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      {subtitle && <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>}
+    </div>
+  );
+}

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -8,6 +8,7 @@ import { ThemeCard } from "./ThemeCard";
 import { EvasionCard } from "./EvasionCard";
 import { StrategicShiftCard } from "./StrategicShiftCard";
 import { Card } from "@/components/ui/card";
+import { EmptyState } from "@/components/EmptyState";
 import {
   Collapsible,
   CollapsibleTrigger,
@@ -151,7 +152,7 @@ function OrientStep({ call }: { call: CallDetail }) {
   const sentiment = call.synthesis?.overall_sentiment;
 
   if (!sentiment) {
-    return <p className="text-sm text-muted-foreground">No orientation data available.</p>;
+    return <EmptyState title="No orientation data available." />;
   }
 
   return (
@@ -209,7 +210,7 @@ function ReadTheRoomStep({ call }: { call: CallDetail }) {
       )}
 
       {!hasSentiment && speakers.length === 0 && (
-        <p className="text-sm text-muted-foreground">No room dynamics data available.</p>
+        <EmptyState title="No room dynamics data available." />
       )}
     </div>
   );
@@ -219,7 +220,7 @@ function UnderstandTheNarrativeStep({ call }: { call: CallDetail }) {
   const source = call.topics.length > 0 ? call.topics : call.themes.map((t) => [t]);
 
   if (source.length === 0) {
-    return <p className="text-sm text-muted-foreground">No themes extracted.</p>;
+    return <EmptyState title="No themes extracted." />;
   }
 
   return (
@@ -240,7 +241,7 @@ function evasionLevelBadge(level: string): { emoji: string; classes: string } {
 
 function NoticeWhatWasAvoidedStep({ call }: { call: CallDetail }) {
   if (call.evasion_analyses.length === 0) {
-    return <p className="text-sm text-muted-foreground">No evasion patterns detected.</p>;
+    return <EmptyState title="No evasion patterns detected." />;
   }
 
   const evasionLevel = call.signal_strip?.evasion_level ?? null;
@@ -292,7 +293,7 @@ function NoticeWhatWasAvoidedStep({ call }: { call: CallDetail }) {
 
 function TrackWhatChangedStep({ call }: { call: CallDetail }) {
   if (call.strategic_shifts.length === 0) {
-    return <p className="text-sm text-muted-foreground">No strategic shifts identified.</p>;
+    return <EmptyState title="No strategic shifts identified." />;
   }
 
   return (
@@ -305,5 +306,5 @@ function TrackWhatChangedStep({ call }: { call: CallDetail }) {
 }
 
 function SituateInContextStep() {
-  return <p className="text-sm text-muted-foreground">Context data coming soon.</p>;
+  return <EmptyState title="Context data coming soon." />;
 }


### PR DESCRIPTION
## Summary

- Add `loading.tsx` skeletons for `/admin` and `/admin/health` — both were blank screens during server-side data fetch
- Add a Suspense fallback spinner to the sign-in page — `<Suspense>` had no `fallback`, causing a blank flash during auth check
- Add a dismiss (✕) button to the learn page error banner — errors previously persisted until the next successful message
- Auto-dismiss the ingest success banner after 4 seconds; error banners now persist until the next submission (previously cleared on any input change)
- Extract a reusable `<EmptyState>` component and apply it to all 6 inline plain-text empty states in `MetadataPanel` — standardizes the inconsistent presentation

## Test plan

- [x] All 33 existing tests pass
- [x] New test: dismiss button hides the error banner in `LearnPage`
- [ ] Visit `/admin` and verify skeleton appears during load
- [ ] Visit `/admin/health` and verify skeleton appears during load
- [ ] Visit `/auth/sign-in` and verify spinner shows briefly
- [ ] Visit `/calls/AAPL/learn`, trigger an error (e.g. kill API), confirm dismiss button works
- [ ] Visit `/admin/ingest`, submit a ticker, confirm success banner auto-dismisses after ~4s
- [ ] After an error on `/admin/ingest`, type in the field and confirm the error stays

Closes #314