### PR TITLE
feat: Feynman chat UX polish (#315)

### DIFF
--- a/web/__tests__/components/chat/ChatInput.test.tsx
+++ b/web/__tests__/components/chat/ChatInput.test.tsx
@@ -24,10 +24,19 @@ describe("ChatInput", () => {
     expect(textarea).toHaveValue("Line one\n");
   });
 
-  it("disables textarea and Send button when isStreaming is true", () => {
+  it("shows an enabled Stop button and disabled textarea when isStreaming is true", () => {
     render(<ChatInput onSend={vi.fn()} isStreaming={true} />);
     expect(screen.getByRole("textbox")).toBeDisabled();
-    expect(screen.getByRole("button", { name: /…/ })).toBeDisabled();
+    const stopButton = screen.getByRole("button", { name: /stop/i });
+    expect(stopButton).toBeInTheDocument();
+    expect(stopButton).not.toBeDisabled();
+  });
+
+  it("calls onAbort when the Stop button is clicked during streaming", async () => {
+    const onAbort = vi.fn();
+    render(<ChatInput onSend={vi.fn()} onAbort={onAbort} isStreaming={true} />);
+    await userEvent.click(screen.getByRole("button", { name: /stop/i }));
+    expect(onAbort).toHaveBeenCalledTimes(1);
   });
 
   it("does not call onSend when input is blank", async () => {

--- a/web/__tests__/components/chat/ChatThread.test.tsx
+++ b/web/__tests__/components/chat/ChatThread.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import { ChatThread } from "@/components/chat/ChatThread";
@@ -44,7 +44,8 @@ describe("ChatThread", () => {
     expect(screen.getByText("What is the evasion level?")).toBeInTheDocument();
   });
 
-  it("calls onSuggestionClick with the suggestion text when clicked", async () => {
+  it("calls onSuggestionClick with the suggestion text after fade-out delay", () => {
+    vi.useFakeTimers();
     const onSuggestionClick = vi.fn();
     render(
       <ChatThread
@@ -55,8 +56,11 @@ describe("ChatThread", () => {
         onSuggestionClick={onSuggestionClick}
       />
     );
-    await userEvent.click(screen.getByText("Tell me about services"));
+    fireEvent.click(screen.getByText("Tell me about services"));
+    expect(onSuggestionClick).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(200);
     expect(onSuggestionClick).toHaveBeenCalledWith("Tell me about services");
+    vi.useRealTimers();
   });
 
   it("renders user and assistant message bubbles", () => {
@@ -65,6 +69,17 @@ describe("ChatThread", () => {
     expect(
       screen.getByText("Services revenue was the primary driver.")
     ).toBeInTheDocument();
+  });
+
+  it("renders assistant messages as markdown (bold, not raw **)", () => {
+    const mdMessages: ChatMessage[] = [
+      { role: "assistant", content: "This is **important** text." },
+    ];
+    render(<ChatThread messages={mdMessages} streamingContent="" />);
+    const strong = document.querySelector("strong");
+    expect(strong).toBeInTheDocument();
+    expect(strong?.textContent).toBe("important");
+    expect(screen.queryByText(/\*\*important\*\*/)).not.toBeInTheDocument();
   });
 
   it("renders streaming content with a cursor indicator", () => {

--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -46,6 +46,12 @@ export default function LearnPage({
       .finally(() => setLoadingSuggestions(false));
   }, [ticker]);
 
+  function handleAbort() {
+    abortControllerRef.current?.abort();
+    setStreamingContent("");
+    setIsStreaming(false);
+  }
+
   async function handleSend(message: string) {
     abortControllerRef.current?.abort();
     const controller = new AbortController();
@@ -89,7 +95,7 @@ export default function LearnPage({
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col px-6 py-8" style={{ height: "calc(100vh - 64px)" }}>
+    <div className="mx-auto flex w-full max-w-3xl flex-1 min-h-0 flex-col px-6 py-8">
       {/* Header */}
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-baseline gap-3">
@@ -145,7 +151,7 @@ export default function LearnPage({
 
       {/* Input */}
       <div className="mt-4">
-        <ChatInput onSend={handleSend} isStreaming={isStreaming} initialValue={topic ?? ""} />
+        <ChatInput onSend={handleSend} onAbort={handleAbort} isStreaming={isStreaming} initialValue={topic ?? ""} />
       </div>
     </div>
   );

--- a/web/components/chat/ChatInput.tsx
+++ b/web/components/chat/ChatInput.tsx
@@ -6,12 +6,13 @@ import { Button } from "@/components/ui/button";
 
 interface ChatInputProps {
   onSend: (message: string) => void;
+  onAbort?: () => void;
   isStreaming: boolean;
   initialValue?: string;
 }
 
-/** Textarea with send button. Submits on Enter; Shift+Enter inserts a newline. */
-export function ChatInput({ onSend, isStreaming, initialValue = "" }: ChatInputProps) {
+/** Textarea with send/stop button. Submits on Enter; Shift+Enter inserts a newline. */
+export function ChatInput({ onSend, onAbort, isStreaming, initialValue = "" }: ChatInputProps) {
   const [value, setValue] = useState(initialValue);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -42,13 +43,23 @@ export function ChatInput({ onSend, isStreaming, initialValue = "" }: ChatInputP
         placeholder="Ask a question… (Enter to send, Shift+Enter for newline)"
         className="flex-1 resize-none"
       />
-      <Button
-        onClick={handleSubmit}
-        disabled={isStreaming || !value.trim()}
-        className="mb-0.5"
-      >
-        {isStreaming ? "…" : "Send"}
-      </Button>
+      {isStreaming ? (
+        <Button
+          onClick={onAbort}
+          variant="secondary"
+          className="mb-0.5"
+        >
+          Stop
+        </Button>
+      ) : (
+        <Button
+          onClick={handleSubmit}
+          disabled={!value.trim()}
+          className="mb-0.5"
+        >
+          Send
+        </Button>
+      )}
     </div>
   );
 }

--- a/web/components/chat/ChatThread.tsx
+++ b/web/components/chat/ChatThread.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type { ChatMessage } from "@/lib/chat";
 import { Button } from "@/components/ui/button";
 
@@ -15,10 +17,36 @@ interface ChatThreadProps {
 /** Renders the full conversation history plus any in-progress streamed assistant response. */
 export function ChatThread({ messages, streamingContent, suggestions, loadingSuggestions, onSuggestionClick }: ChatThreadProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isNearBottomRef = useRef(true);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const [fadingOut, setFadingOut] = useState<string | null>(null);
+
+  function handleScroll() {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const near = distanceFromBottom < 100;
+    isNearBottomRef.current = near;
+    setIsNearBottom(near);
+  }
+
+  function scrollToBottom() {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    isNearBottomRef.current = true;
+    setIsNearBottom(true);
+  }
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (isNearBottomRef.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
   }, [messages, streamingContent]);
+
+  function handleSuggestionClick(suggestion: string) {
+    setFadingOut(suggestion);
+    setTimeout(() => onSuggestionClick?.(suggestion), 200);
+  }
 
   if (messages.length === 0 && !streamingContent) {
     return (
@@ -38,8 +66,10 @@ export function ChatThread({ messages, streamingContent, suggestions, loadingSug
               <Button
                 key={suggestion}
                 variant="outline"
-                onClick={() => onSuggestionClick?.(suggestion)}
-                className="rounded-full"
+                onClick={() => handleSuggestionClick(suggestion)}
+                className={`rounded-full active:scale-95 transition-all duration-200 ${
+                  fadingOut === suggestion ? "opacity-0 scale-95" : ""
+                }`}
               >
                 {suggestion}
               </Button>
@@ -51,14 +81,28 @@ export function ChatThread({ messages, streamingContent, suggestions, loadingSug
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-1 py-2">
-      {messages.map((msg, i) => (
-        <MessageBubble key={i} role={msg.role} content={msg.content} />
-      ))}
-      {streamingContent && (
-        <MessageBubble role="assistant" content={streamingContent} streaming />
+    <div className="relative flex flex-1 flex-col min-h-0">
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="flex flex-1 flex-col gap-4 overflow-y-auto px-1 py-2"
+      >
+        {messages.map((msg, i) => (
+          <MessageBubble key={i} role={msg.role} content={msg.content} />
+        ))}
+        {streamingContent && (
+          <MessageBubble role="assistant" content={streamingContent} streaming />
+        )}
+        <div ref={bottomRef} />
+      </div>
+      {streamingContent && !isNearBottom && (
+        <button
+          onClick={scrollToBottom}
+          className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs text-primary-foreground shadow-md hover:bg-primary/90 transition-colors"
+        >
+          ↓ New messages
+        </button>
       )}
-      <div ref={bottomRef} />
     </div>
   );
 }
@@ -75,13 +119,31 @@ function MessageBubble({ role, content, streaming = false }: MessageBubbleProps)
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed whitespace-pre-wrap ${
+        className={`max-w-[90%] sm:max-w-[80%] rounded-2xl px-4 py-3 text-sm leading-relaxed ${
           isUser
-            ? "bg-primary text-primary-foreground"
+            ? "bg-primary text-primary-foreground whitespace-pre-wrap"
             : "bg-muted text-foreground"
         }`}
       >
-        {content}
+        {isUser ? (
+          content
+        ) : (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+              ul: ({ children }) => <ul className="mb-2 list-disc list-inside space-y-0.5 last:mb-0">{children}</ul>,
+              ol: ({ children }) => <ol className="mb-2 list-decimal list-inside space-y-0.5 last:mb-0">{children}</ol>,
+              li: ({ children }) => <li>{children}</li>,
+              strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+              em: ({ children }) => <em className="italic">{children}</em>,
+              code: ({ children }) => <code className="rounded bg-background/50 px-1 py-0.5 font-mono text-xs">{children}</code>,
+              pre: ({ children }) => <pre className="mb-2 overflow-x-auto rounded bg-background/50 p-2 font-mono text-xs last:mb-0">{children}</pre>,
+            }}
+          >
+            {content}
+          </ReactMarkdown>
+        )}
         {streaming && (
           <span className="ml-1 inline-block h-3 w-0.5 animate-pulse bg-current" />
         )}


### PR DESCRIPTION
## Summary

- **Markdown rendering**: Assistant messages now render with `react-markdown` + `remark-gfm` — bold, lists, code blocks, and links display correctly instead of raw `**text**`
- **Abort streaming**: Stop button replaces Send during streaming; wired to `AbortController.abort()` with immediate UI cleanup via `handleAbort`
- **Smart scroll**: Auto-scroll only fires when user is within 100px of the bottom; a "↓ New messages" pill appears when streaming while scrolled up, clicking it returns to bottom
- **Mobile bubble width**: `max-w-[90%] sm:max-w-[80%]` gives more screen real estate on small viewports
- **Suggestion feedback**: Click triggers `active:scale-95` press + 200ms fade-out before callback fires
- **Flex height**: Removed hardcoded `calc(100vh - 64px)`; outer div now uses `flex-1 min-h-0` so it adapts to actual header/breadcrumb height

## Test plan

- [ ] All 35 existing tests pass (`pnpm test`)
- [ ] New ChatInput tests: Stop button is enabled during streaming, calls `onAbort` on click
- [ ] New ChatThread tests: markdown renders `<strong>` not `**bold**`; suggestion delay fires after 200ms

Closes #315