### PR TITLE
feat: unified expand/collapse and shared color semantics

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -129,3 +129,12 @@
     @apply font-sans;
   }
 }
+
+/* Collapsible panel animation */
+[data-slot="collapsible-content"] {
+  overflow: hidden;
+  height: var(--collapsible-panel-height);
+  transition: height 200ms ease-out;
+}
+[data-slot="collapsible-content"][data-starting-style] { height: 0; }
+[data-slot="collapsible-content"][data-ending-style]   { height: 0; }

--- a/web/components/CallCard.tsx
+++ b/web/components/CallCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { getEvasionStyle, getSentimentStyle } from "@/lib/signal-colors";
 
 export interface CallSummary {
   ticker: string;
@@ -16,22 +17,6 @@ interface CallCardProps {
   call: CallSummary;
 }
 
-const EVASION_STYLES: Record<string, string> = {
-  low: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-  medium: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  high: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-};
-
-function sentimentStyle(sentiment: string): string {
-  const lower = sentiment.toLowerCase();
-  if (lower.includes("bullish") || lower.includes("positive")) {
-    return "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400";
-  }
-  if (lower.includes("bearish") || lower.includes("negative")) {
-    return "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400";
-  }
-  return "";
-}
 
 /** Card displaying summary metadata for a single earnings call. */
 export function CallCard({ call }: CallCardProps) {
@@ -63,20 +48,22 @@ export function CallCard({ call }: CallCardProps) {
         )}
         {(call.evasion_level || call.overall_sentiment) && (
           <div className="flex flex-wrap gap-1.5">
-            {call.overall_sentiment && (
-              <span
-                className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${sentimentStyle(call.overall_sentiment) || "bg-muted text-muted-foreground"}`}
-              >
-                {call.overall_sentiment}
-              </span>
-            )}
-            {call.evasion_level && (
-              <span
-                className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${EVASION_STYLES[call.evasion_level] ?? "bg-muted text-muted-foreground"}`}
-              >
-                {call.evasion_level} evasion
-              </span>
-            )}
+            {call.overall_sentiment && (() => {
+              const s = getSentimentStyle(call.overall_sentiment);
+              return (
+                <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${s.bg} ${s.text}`}>
+                  {call.overall_sentiment}
+                </span>
+              );
+            })()}
+            {call.evasion_level && (() => {
+              const s = getEvasionStyle(call.evasion_level);
+              return (
+                <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs ${s.bg} ${s.text}`}>
+                  {call.evasion_level} evasion
+                </span>
+              );
+            })()}
           </div>
         )}
         {call.top_strategic_shift && (

--- a/web/components/transcript/CallBriefPanel.tsx
+++ b/web/components/transcript/CallBriefPanel.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import type { CallBrief, TakeawayItem, MisconceptionItem, SignalStrip } from "./types";
 import { MisconceptionCard } from "./MisconceptionCard";
 import { Card, CardContent } from "@/components/ui/card";
+import { getEvasionStyle, getSentimentStyle } from "@/lib/signal-colors";
 
 interface CallBriefPanelProps {
   brief: CallBrief;
@@ -14,22 +15,6 @@ interface CallBriefPanelProps {
   signal_strip: SignalStrip | null;
 }
 
-const EVASION_STYLES: Record<string, string> = {
-  low: "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400",
-  medium: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  high: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-};
-
-function sentimentStyle(sentiment: string): string {
-  const lower = sentiment.toLowerCase();
-  if (lower.includes("bullish") || lower.includes("positive") || lower.includes("optimistic")) {
-    return "bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400";
-  }
-  if (lower.includes("bearish") || lower.includes("negative") || lower.includes("cautious")) {
-    return "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400";
-  }
-  return "bg-muted text-muted-foreground";
-}
 
 interface SignalBadgeProps {
   label: string;
@@ -38,8 +23,9 @@ interface SignalBadgeProps {
 
 function SignalBadge({ label, value }: SignalBadgeProps) {
   if (!value) return null;
+  const s = getSentimentStyle(value);
   return (
-    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${sentimentStyle(value)}`}>
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${s.bg} ${s.text}`}>
       {label}: {value}
     </span>
   );
@@ -51,9 +37,9 @@ interface EvasionBadgeProps {
 
 function EvasionBadge({ level }: EvasionBadgeProps) {
   if (!level) return null;
-  const style = EVASION_STYLES[level] ?? "bg-muted text-muted-foreground";
+  const s = getEvasionStyle(level);
   return (
-    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${style}`}>
+    <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${s.bg} ${s.text}`}>
       Evasion: {level}
     </span>
   );

--- a/web/components/transcript/EvasionCard.tsx
+++ b/web/components/transcript/EvasionCard.tsx
@@ -11,19 +11,15 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
+  CollapsibleChevron,
 } from "@/components/ui/collapsible";
+import { getEvasionStyle, evasionScoreToLevel } from "@/lib/signal-colors";
 
 interface EvasionCardProps {
   item: EvasionItem;
   ticker: string;
 }
 
-/** Maps defensiveness score (1–10) to severity badge content and colour classes. */
-function severityBadge(score: number): { emoji: string; label: string; classes: string } {
-  if (score >= 8) return { emoji: "🔴", label: "High", classes: "text-red-700 bg-red-50 dark:bg-red-900/30 dark:text-red-400" };
-  if (score >= 5) return { emoji: "🟡", label: "Medium", classes: "text-amber-700 bg-amber-50 dark:bg-amber-900/30 dark:text-amber-400" };
-  return { emoji: "🟢", label: "Low", classes: "text-green-700 bg-green-50 dark:bg-green-900/30 dark:text-green-400" };
-}
 
 export function EvasionCard({ item, ticker }: EvasionCardProps) {
   const [revealed, setRevealed] = useState(false);
@@ -32,7 +28,7 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
   const [signalsError, setSignalsError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
-  const badge = severityBadge(item.defensiveness_score);
+  const badge = getEvasionStyle(evasionScoreToLevel(item.defensiveness_score));
 
   async function handleSignalsClick() {
     if (signals) return;
@@ -79,7 +75,7 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
       {/* Always-visible header: analyst concern + severity + topic */}
       <CollapsibleTrigger className="w-full text-left px-4 py-3 flex items-start gap-3 hover:bg-muted transition-colors">
         <span
-          className={`shrink-0 mt-0.5 rounded-full px-2 py-0.5 text-xs font-semibold ${badge.classes}`}
+          className={`shrink-0 mt-0.5 rounded-full px-2 py-0.5 text-xs font-semibold ${badge.bg} ${badge.text}`}
         >
           {badge.emoji} {badge.label}
         </span>
@@ -89,9 +85,7 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
             <p className="mt-0.5 text-xs text-muted-foreground">{item.question_topic}</p>
           )}
         </div>
-        <span className="shrink-0 text-xs text-muted-foreground mt-0.5">
-          {revealed ? "▲" : "▼"}
-        </span>
+        <CollapsibleChevron open={revealed} className="mt-0.5" />
       </CollapsibleTrigger>
 
       {/* Revealed: full analysis + signals button */}

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -13,7 +13,9 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
+  CollapsibleChevron,
 } from "@/components/ui/collapsible";
+import { getEvasionStyle } from "@/lib/signal-colors";
 
 interface AnalystStepConfig {
   id: string;
@@ -93,9 +95,7 @@ export function MetadataPanel({ call }: MetadataPanelProps) {
               <span className="text-sm font-semibold text-foreground">{step.label}</span>
               <p className="text-xs text-muted-foreground mt-0.5 leading-snug">{step.question}</p>
             </div>
-            <span className="mt-0.5 shrink-0 text-muted-foreground text-xs">
-              {expanded[step.id] ? "▲" : "▼"}
-            </span>
+            <CollapsibleChevron open={expanded[step.id]} className="mt-0.5" />
           </CollapsibleTrigger>
 
           {/* Step body */}
@@ -232,12 +232,6 @@ function UnderstandTheNarrativeStep({ call }: { call: CallDetail }) {
   );
 }
 
-/** Map evasion_level string to badge styling. */
-function evasionLevelBadge(level: string): { emoji: string; classes: string } {
-  if (level === "high") return { emoji: "🔴", classes: "text-red-700 bg-red-50" };
-  if (level === "medium") return { emoji: "🟡", classes: "text-amber-700 bg-amber-50" };
-  return { emoji: "🟢", classes: "text-green-700 bg-green-50" };
-}
 
 function NoticeWhatWasAvoidedStep({ call }: { call: CallDetail }) {
   if (call.evasion_analyses.length === 0) {
@@ -252,10 +246,10 @@ function NoticeWhatWasAvoidedStep({ call }: { call: CallDetail }) {
     <div className="space-y-4">
       {/* Overall evasion index */}
       {evasionLevel && (() => {
-        const badge = evasionLevelBadge(evasionLevel);
+        const style = getEvasionStyle(evasionLevel);
         return (
-          <div className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ${badge.classes}`}>
-            {badge.emoji} Evasion index: {evasionLevel}
+          <div className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ${style.bg} ${style.text}`}>
+            {style.emoji} Evasion index: {evasionLevel}
           </div>
         );
       })()}

--- a/web/components/transcript/MisconceptionCard.tsx
+++ b/web/components/transcript/MisconceptionCard.tsx
@@ -8,6 +8,7 @@ import {
   Collapsible,
   CollapsibleTrigger,
   CollapsibleContent,
+  CollapsibleChevron,
 } from "@/components/ui/collapsible";
 
 interface MisconceptionCardProps {
@@ -29,9 +30,7 @@ export function MisconceptionCard({ item, forceExpanded = false }: Misconception
       {/* Always-visible: the misinterpretation (the "gotcha") */}
       <CollapsibleTrigger className="w-full text-left px-4 py-3 flex items-start justify-between gap-3 hover:bg-amber-100 transition-colors dark:hover:bg-amber-900/30">
         <p className="text-sm font-medium text-amber-900 dark:text-amber-200">{item.misinterpretation}</p>
-        <span className="shrink-0 text-xs text-amber-600 font-semibold mt-0.5 dark:text-amber-400">
-          {isOpen ? "Hide" : "Reveal"}
-        </span>
+        <CollapsibleChevron open={isOpen} className="mt-0.5 text-amber-600 dark:text-amber-400" />
       </CollapsibleTrigger>
 
       {/* Revealed: the correction */}

--- a/web/components/ui/collapsible.tsx
+++ b/web/components/ui/collapsible.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { cn } from "@/lib/utils"
 import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
 
 function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
@@ -18,4 +19,32 @@ function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
   )
 }
 
-export { Collapsible, CollapsibleTrigger, CollapsibleContent }
+interface CollapsibleChevronProps {
+  open: boolean;
+  className?: string;
+}
+
+/** SVG chevron that rotates 180° when open. Use inside CollapsibleTrigger. */
+function CollapsibleChevron({ open, className }: CollapsibleChevronProps) {
+  return (
+    <svg
+      className={cn(
+        "h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200",
+        open && "rotate-180",
+        className
+      )}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent, CollapsibleChevron }

--- a/web/lib/signal-colors.ts
+++ b/web/lib/signal-colors.ts
@@ -1,0 +1,68 @@
+/** Single source of truth for domain color semantics. */
+
+export interface EvasionStyle {
+  bg: string;
+  text: string;
+  label: string;
+  emoji: string;
+}
+
+export interface SentimentStyle {
+  bg: string;
+  text: string;
+}
+
+/** Maps an evasion level string to badge styling. */
+export function getEvasionStyle(level: string): EvasionStyle {
+  if (level === "high")
+    return {
+      bg: "bg-red-50 dark:bg-red-900/30",
+      text: "text-red-700 dark:text-red-400",
+      label: "High",
+      emoji: "🔴",
+    };
+  if (level === "medium")
+    return {
+      bg: "bg-amber-50 dark:bg-amber-900/30",
+      text: "text-amber-700 dark:text-amber-400",
+      label: "Medium",
+      emoji: "🟡",
+    };
+  return {
+    bg: "bg-green-50 dark:bg-green-900/30",
+    text: "text-green-700 dark:text-green-400",
+    label: "Low",
+    emoji: "🟢",
+  };
+}
+
+/** Maps a defensiveness score (1–10) to an evasion level string. */
+export function evasionScoreToLevel(score: number): "low" | "medium" | "high" {
+  if (score >= 8) return "high";
+  if (score >= 5) return "medium";
+  return "low";
+}
+
+/** Maps a sentiment string to badge styling. */
+export function getSentimentStyle(sentiment: string): SentimentStyle {
+  const lower = sentiment.toLowerCase();
+  if (
+    lower.includes("bullish") ||
+    lower.includes("positive") ||
+    lower.includes("optimistic")
+  )
+    return {
+      bg: "bg-green-50 dark:bg-green-900/30",
+      text: "text-green-700 dark:text-green-400",
+    };
+  if (
+    lower.includes("bearish") ||
+    lower.includes("negative") ||
+    lower.includes("cautious")
+  )
+    return {
+      bg: "bg-red-50 dark:bg-red-900/30",
+      text: "text-red-700 dark:text-red-400",
+    };
+  return { bg: "bg-muted", text: "text-muted-foreground" };
+}


### PR DESCRIPTION
## Summary

- Extracts evasion and sentiment color logic into `web/lib/signal-colors.ts`, eliminating 4 duplicate implementations across `CallCard`, `CallBriefPanel`, `EvasionCard`, and `MetadataPanel`
- Replaces Unicode ▲/▼ chevrons and "Reveal/Hide" text with a consistent `CollapsibleChevron` SVG component that rotates 180° on expand
- Adds smooth height animation to all collapsible panels via CSS transitions on Base UI's `--collapsible-panel-height` variable

## Test plan

- [x] `npx vitest run` — 35/35 pass
- [ ] Open a call detail page and verify chevrons rotate on expand, animation is smooth
- [ ] Confirm evasion and sentiment badge colors are unchanged across the call list and transcript pages
- [ ] Confirm MisconceptionCard shows chevron (not "Reveal/Hide" text)

Closes #317