### PR TITLE
feat: replace hardcoded zinc/red classes with semantic theme tokens

### DIFF
--- a/web/app/admin/health/loading.tsx
+++ b/web/app/admin/health/loading.tsx
@@ -3,18 +3,18 @@ export default function AdminHealthLoading() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       {/* Title skeleton */}
-      <div className="mb-8 h-9 w-72 animate-pulse rounded bg-zinc-200" />
+      <div className="mb-8 h-9 w-72 animate-pulse rounded bg-muted" />
 
       {/* 3-column status card skeleton */}
       <div className="grid gap-6 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-lg border border-zinc-200 bg-white p-5">
-            <div className="mb-3 h-3 w-28 animate-pulse rounded bg-zinc-200" />
+          <div key={i} className="rounded-lg border border-border bg-card p-5">
+            <div className="mb-3 h-3 w-28 animate-pulse rounded bg-muted" />
             <div className="space-y-3">
               {Array.from({ length: 3 }).map((_, j) => (
                 <div key={j} className="flex items-center gap-3">
-                  <div className="h-3 w-3 animate-pulse rounded-full bg-zinc-200" />
-                  <div className="h-4 w-40 animate-pulse rounded bg-zinc-100" />
+                  <div className="h-3 w-3 animate-pulse rounded-full bg-muted" />
+                  <div className="h-4 w-40 animate-pulse rounded bg-muted" />
                 </div>
               ))}
             </div>

--- a/web/app/admin/health/page.tsx
+++ b/web/app/admin/health/page.tsx
@@ -48,7 +48,7 @@ async function fetchHealth(): Promise<HealthData | null> {
 function StatusDot({ ok }: { ok: boolean }) {
   return (
     <span
-      className={`inline-block h-3 w-3 flex-shrink-0 rounded-full ${ok ? "bg-green-500" : "bg-red-500"}`}
+      className={`inline-block h-3 w-3 flex-shrink-0 rounded-full ${ok ? "bg-green-500" : "bg-destructive"}`}
     />
   );
 }
@@ -57,15 +57,15 @@ function StatusRow({ label, ok }: { label: string; ok: boolean }) {
   return (
     <div className="flex items-center gap-3 py-1.5">
       <StatusDot ok={ok} />
-      <span className="text-sm text-zinc-700">{label}</span>
+      <span className="text-sm text-foreground">{label}</span>
     </div>
   );
 }
 
 function StatusCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-5">
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+    <div className="rounded-lg border border-border bg-card p-5">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {title}
       </h2>
       {children}
@@ -83,10 +83,10 @@ export default async function AdminHealthPage() {
           ← Admin Ingest
         </a>
       </div>
-      <h1 className="mb-8 text-3xl font-semibold text-zinc-900">Admin — System Health</h1>
+      <h1 className="mb-8 text-3xl font-semibold text-foreground">Admin — System Health</h1>
 
       {health === null ? (
-        <p className="text-red-500">Unable to fetch health data. Check server configuration.</p>
+        <p className="text-destructive">Unable to fetch health data. Check server configuration.</p>
       ) : (
         <div className="grid gap-6 sm:grid-cols-3">
           <StatusCard title="Database">

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -65,18 +65,18 @@ export default function AdminIngestPage() {
           System Health
         </a>
       </div>
-      <h1 className="mb-2 text-3xl font-semibold text-zinc-900">Admin — Ingest</h1>
-      <p className="mb-8 text-zinc-500">
+      <h1 className="mb-2 text-3xl font-semibold text-foreground">Admin — Ingest</h1>
+      <p className="mb-8 text-muted-foreground">
         Dispatch a ticker to the ingestion pipeline. Returns immediately — processing runs
         asynchronously.
       </p>
 
-      <div className="max-w-sm rounded-lg border border-zinc-200 bg-white p-6">
+      <div className="max-w-sm rounded-lg border border-border bg-card p-6">
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>
             <label
               htmlFor="ticker"
-              className="mb-1.5 block text-sm font-medium text-zinc-700"
+              className="mb-1.5 block text-sm font-medium text-foreground"
             >
               Ticker symbol
             </label>
@@ -87,14 +87,14 @@ export default function AdminIngestPage() {
               onChange={(e) => setTicker(e.target.value)}
               placeholder="e.g. AAPL"
               disabled={status === "submitting"}
-              className="w-full rounded-md border border-zinc-300 px-3 py-2 font-mono text-sm uppercase text-zinc-900 placeholder:normal-case placeholder:text-zinc-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-zinc-50 disabled:text-zinc-400"
+              className="w-full rounded-md border border-input px-3 py-2 font-mono text-sm uppercase text-foreground placeholder:normal-case placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:bg-muted disabled:text-muted-foreground"
             />
           </div>
 
           <button
             type="submit"
             disabled={status === "submitting" || !ticker.trim()}
-            className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700 disabled:cursor-not-allowed disabled:bg-zinc-300"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted"
           >
             {status === "submitting" ? "Submitting…" : "Ingest transcript"}
           </button>
@@ -106,7 +106,7 @@ export default function AdminIngestPage() {
           </p>
         )}
         {status === "error" && errorMessage && (
-          <p className="mt-4 text-sm text-red-600">{errorMessage}</p>
+          <p className="mt-4 text-sm text-destructive">{errorMessage}</p>
         )}
       </div>
     </div>

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -149,8 +149,8 @@ async function fetchChat(): Promise<ChatData | null> {
 
 function AnalyticsCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-lg border border-zinc-200 bg-white p-5">
-      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-zinc-500">
+    <div className="rounded-lg border border-border bg-card p-5">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
         {title}
       </h2>
       {children}
@@ -180,27 +180,27 @@ export default async function AdminAnalyticsPage() {
           Ingest
         </a>
       </div>
-      <h1 className="mb-8 text-3xl font-semibold text-zinc-900">Admin — Analytics</h1>
+      <h1 className="mb-8 text-3xl font-semibold text-foreground">Admin — Analytics</h1>
 
       <div className="grid gap-6 lg:grid-cols-2">
         <AnalyticsCard title={`Session Activity — last 30 days (${totalSessions} total)`}>
           {sessions === null ? (
-            <p className="text-sm text-red-500">Unable to load session data.</p>
+            <p className="text-sm text-destructive">Unable to load session data.</p>
           ) : sessions.length === 0 ? (
-            <p className="text-sm text-zinc-500">No sessions recorded yet.</p>
+            <p className="text-sm text-muted-foreground">No sessions recorded yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-100">
-                  <th className="py-1.5 text-left font-medium text-zinc-500">Date</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Sessions</th>
+                <tr className="border-b border-border">
+                  <th className="py-1.5 text-left font-medium text-muted-foreground">Date</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Sessions</th>
                 </tr>
               </thead>
               <tbody>
                 {sessions.map((row) => (
-                  <tr key={row.date} className="border-b border-zinc-50">
-                    <td className="py-1.5 text-zinc-700">{row.date}</td>
-                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  <tr key={row.date} className="border-b border-border">
+                    <td className="py-1.5 text-foreground">{row.date}</td>
+                    <td className="py-1.5 text-right tabular-nums text-foreground">{row.count}</td>
                   </tr>
                 ))}
               </tbody>
@@ -210,26 +210,26 @@ export default async function AdminAnalyticsPage() {
 
         <AnalyticsCard title="API Cost — last 30 days (tokens by service)">
           {costs === null ? (
-            <p className="text-sm text-red-500">Unable to load cost data.</p>
+            <p className="text-sm text-destructive">Unable to load cost data.</p>
           ) : Object.keys(costs.by_service).length === 0 ? (
-            <p className="text-sm text-zinc-500">No API calls recorded yet.</p>
+            <p className="text-sm text-muted-foreground">No API calls recorded yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-100">
-                  <th className="py-1.5 text-left font-medium text-zinc-500">Service</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Input</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Output</th>
+                <tr className="border-b border-border">
+                  <th className="py-1.5 text-left font-medium text-muted-foreground">Service</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Input</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Output</th>
                 </tr>
               </thead>
               <tbody>
                 {Object.entries(costs.by_service).map(([service, tokens]) => (
-                  <tr key={service} className="border-b border-zinc-50">
-                    <td className="py-1.5 capitalize text-zinc-700">{service}</td>
-                    <td className="py-1.5 text-right tabular-nums text-zinc-900">
+                  <tr key={service} className="border-b border-border">
+                    <td className="py-1.5 capitalize text-foreground">{service}</td>
+                    <td className="py-1.5 text-right tabular-nums text-foreground">
                       {tokens.input_tokens.toLocaleString()}
                     </td>
-                    <td className="py-1.5 text-right tabular-nums text-zinc-900">
+                    <td className="py-1.5 text-right tabular-nums text-foreground">
                       {tokens.output_tokens.toLocaleString()}
                     </td>
                   </tr>
@@ -243,22 +243,22 @@ export default async function AdminAnalyticsPage() {
           title={`Chat Activity — last 30 days (${totalTurns} turns, avg ${chat?.avg_turns_per_session ?? 0} per session)`}
         >
           {chat === null ? (
-            <p className="text-sm text-red-500">Unable to load chat data.</p>
+            <p className="text-sm text-destructive">Unable to load chat data.</p>
           ) : chat.daily.length === 0 ? (
-            <p className="text-sm text-zinc-500">No chat turns recorded yet.</p>
+            <p className="text-sm text-muted-foreground">No chat turns recorded yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-100">
-                  <th className="py-1.5 text-left font-medium text-zinc-500">Date</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Turns</th>
+                <tr className="border-b border-border">
+                  <th className="py-1.5 text-left font-medium text-muted-foreground">Date</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Turns</th>
                 </tr>
               </thead>
               <tbody>
                 {chat.daily.map((row) => (
-                  <tr key={row.date} className="border-b border-zinc-50">
-                    <td className="py-1.5 text-zinc-700">{row.date}</td>
-                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.turns}</td>
+                  <tr key={row.date} className="border-b border-border">
+                    <td className="py-1.5 text-foreground">{row.date}</td>
+                    <td className="py-1.5 text-right tabular-nums text-foreground">{row.turns}</td>
                   </tr>
                 ))}
               </tbody>
@@ -268,22 +268,22 @@ export default async function AdminAnalyticsPage() {
 
         <AnalyticsCard title="Feynman Engagement — stage funnel, last 30 days">
           {feynman === null ? (
-            <p className="text-sm text-red-500">Unable to load Feynman data.</p>
+            <p className="text-sm text-destructive">Unable to load Feynman data.</p>
           ) : feynman.by_stage.length === 0 ? (
-            <p className="text-sm text-zinc-500">No Feynman sessions recorded yet.</p>
+            <p className="text-sm text-muted-foreground">No Feynman sessions recorded yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-100">
-                  <th className="py-1.5 text-left font-medium text-zinc-500">Stage</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Sessions</th>
+                <tr className="border-b border-border">
+                  <th className="py-1.5 text-left font-medium text-muted-foreground">Stage</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Sessions</th>
                 </tr>
               </thead>
               <tbody>
                 {feynman.by_stage.map((row) => (
-                  <tr key={row.stage} className="border-b border-zinc-50">
-                    <td className="py-1.5 text-zinc-700">Stage {row.stage}</td>
-                    <td className="py-1.5 text-right tabular-nums text-zinc-900">{row.count}</td>
+                  <tr key={row.stage} className="border-b border-border">
+                    <td className="py-1.5 text-foreground">Stage {row.stage}</td>
+                    <td className="py-1.5 text-right tabular-nums text-foreground">{row.count}</td>
                   </tr>
                 ))}
               </tbody>
@@ -292,22 +292,22 @@ export default async function AdminAnalyticsPage() {
         </AnalyticsCard>
         <AnalyticsCard title="Ingestion History — most recent 100 requests">
           {ingestions === null ? (
-            <p className="text-sm text-red-500">Unable to load ingestion data.</p>
+            <p className="text-sm text-destructive">Unable to load ingestion data.</p>
           ) : ingestions.ingestions.length === 0 ? (
-            <p className="text-sm text-zinc-500">No ingestions recorded yet.</p>
+            <p className="text-sm text-muted-foreground">No ingestions recorded yet.</p>
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-100">
-                  <th className="py-1.5 text-left font-medium text-zinc-500">Ticker</th>
-                  <th className="py-1.5 text-right font-medium text-zinc-500">Requested At</th>
+                <tr className="border-b border-border">
+                  <th className="py-1.5 text-left font-medium text-muted-foreground">Ticker</th>
+                  <th className="py-1.5 text-right font-medium text-muted-foreground">Requested At</th>
                 </tr>
               </thead>
               <tbody>
                 {ingestions.ingestions.map((row, i) => (
-                  <tr key={i} className="border-b border-zinc-50">
-                    <td className="py-1.5 font-mono text-zinc-900">{row.ticker}</td>
-                    <td className="py-1.5 text-right text-zinc-700">
+                  <tr key={i} className="border-b border-border">
+                    <td className="py-1.5 font-mono text-foreground">{row.ticker}</td>
+                    <td className="py-1.5 text-right text-foreground">
                       {new Date(row.requested_at).toLocaleString()}
                     </td>
                   </tr>

--- a/web/app/auth/sign-in/page.tsx
+++ b/web/app/auth/sign-in/page.tsx
@@ -19,24 +19,24 @@ function SignInContent() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-50">
-      <div className="w-full max-w-sm rounded-xl border border-zinc-200 bg-white p-8 shadow-sm">
-        <h1 className="mb-2 text-2xl font-semibold text-zinc-900">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background">
+      <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 shadow-sm">
+        <h1 className="mb-2 text-2xl font-semibold text-foreground">
           EarningsFluency
         </h1>
-        <p className="mb-8 text-sm text-zinc-500">
+        <p className="mb-8 text-sm text-muted-foreground">
           Sign in to access your earnings transcript library.
         </p>
 
         {error && (
-          <p className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+          <p className="mb-4 rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
             {decodeURIComponent(error)}
           </p>
         )}
 
         <button
           onClick={signInWithGoogle}
-          className="flex w-full items-center justify-center gap-3 rounded-lg border border-zinc-200 bg-white px-4 py-3 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 focus:outline-none focus:ring-2 focus:ring-zinc-500 focus:ring-offset-2"
+          className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium text-card-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         >
           <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
             <path
@@ -65,8 +65,8 @@ function SignInContent() {
 
 function SignInSpinner() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50">
-      <div className="h-6 w-6 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-700" />
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-border border-t-foreground" />
     </div>
   );
 }

--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -128,12 +128,12 @@ export default function LearnPage({
 
       {/* Error banner */}
       {error && (
-        <div className="mb-4 flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="mb-4 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
           <span className="flex-1">{error}</span>
           <button
             onClick={() => setError(null)}
             aria-label="Dismiss error"
-            className="shrink-0 text-red-400 hover:text-red-600"
+            className="shrink-0 text-destructive/60 hover:text-destructive"
           >
             ✕
           </button>

--- a/web/app/calls/[ticker]/loading.tsx
+++ b/web/app/calls/[ticker]/loading.tsx
@@ -4,8 +4,8 @@ export default function TranscriptPageLoading() {
     <div className="mx-auto w-full max-w-7xl px-6 py-8">
       {/* Header skeleton */}
       <div className="mb-6 flex items-baseline gap-3">
-        <div className="h-9 w-24 animate-pulse rounded bg-zinc-200" />
-        <div className="h-6 w-40 animate-pulse rounded bg-zinc-100" />
+        <div className="h-9 w-24 animate-pulse rounded bg-muted" />
+        <div className="h-6 w-40 animate-pulse rounded bg-muted" />
       </div>
 
       {/* Two-column layout skeleton */}
@@ -14,18 +14,18 @@ export default function TranscriptPageLoading() {
         <div className="space-y-3">
           {Array.from({ length: 8 }).map((_, i) => (
             <div key={i} className="space-y-1">
-              <div className="h-3 w-24 animate-pulse rounded bg-zinc-200" />
-              <div className="h-4 w-full animate-pulse rounded bg-zinc-100" />
-              <div className="h-4 w-5/6 animate-pulse rounded bg-zinc-100" />
+              <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+              <div className="h-4 w-full animate-pulse rounded bg-muted" />
+              <div className="h-4 w-5/6 animate-pulse rounded bg-muted" />
             </div>
           ))}
         </div>
 
         {/* Right: metadata skeleton */}
         <div className="space-y-3">
-          <div className="h-8 w-full animate-pulse rounded bg-zinc-200" />
+          <div className="h-8 w-full animate-pulse rounded bg-muted" />
           {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="h-5 w-3/4 animate-pulse rounded bg-zinc-100" />
+            <div key={i} className="h-5 w-3/4 animate-pulse rounded bg-muted" />
           ))}
         </div>
       </div>

--- a/web/components/CallList.tsx
+++ b/web/components/CallList.tsx
@@ -46,7 +46,7 @@ export function CallList() {
 
   if (error) {
     return (
-      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">
+      <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
         {error}
       </div>
     );

--- a/web/components/transcript/EvasionCard.tsx
+++ b/web/components/transcript/EvasionCard.tsx
@@ -112,7 +112,7 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
             </ReactMarkdown>
           </div>
         ) : signalsError ? (
-          <p className="mt-3 text-xs text-red-500">{signalsError}</p>
+          <p className="mt-3 text-xs text-destructive">{signalsError}</p>
         ) : (
           <button
             onClick={handleSignalsClick}

--- a/web/components/transcript/TranscriptBrowser.tsx
+++ b/web/components/transcript/TranscriptBrowser.tsx
@@ -212,7 +212,7 @@ function SpanListView({
 
   if (error) {
     return (
-      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
     );
   }
 
@@ -265,7 +265,7 @@ function SearchResultsView({
 }) {
   if (error) {
     return (
-      <div className="rounded-lg bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      <div className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
     );
   }
 


### PR DESCRIPTION
## Summary

- Replaced all `zinc-*` / `bg-white` hardcoded Tailwind palette classes with semantic tokens (`bg-background`, `bg-card`, `bg-muted`, `text-foreground`, `text-muted-foreground`, `border-border`, `border-input`, `bg-primary`, `text-primary-foreground`)
- Replaced all `red-*` error state classes with `destructive` token equivalents (`bg-destructive/10`, `text-destructive`, `border-destructive/30`)
- Replaced `focus:ring-blue-500` / `focus:border-blue-500` with `focus:ring-ring` / `focus:border-ring`

Intentional exceptions left untouched:
- Google OAuth SVG fills (`#4285F4`, `#34A853`, `#FBBC05`, `#EA4335`) — brand colors
- `text-blue-600` nav links, `bg-green-500` status dot, `text-green-700` success message, amber signals — deferred to follow-up issue (needs `--info`, `--success`, `--warning` token decisions)

Closes #327

## Files changed

`web/app/auth/sign-in/page.tsx`, `web/app/calls/[ticker]/loading.tsx`, `web/app/calls/[ticker]/learn/page.tsx`, `web/app/admin/health/page.tsx`, `web/app/admin/health/loading.tsx`, `web/app/admin/ingest/page.tsx`, `web/app/admin/page.tsx`, `web/components/CallList.tsx`, `web/components/transcript/TranscriptBrowser.tsx`, `web/components/transcript/EvasionCard.tsx`

## Test plan

- [ ] Build passes (`npm run build` in `web/` — verified clean)
- [ ] Visual spot-check in light mode: sign-in page, admin pages, learn page, transcript browser
- [ ] Dark mode toggle: confirm all updated components render correctly