### PR TITLE
feat: add warning/success/info tokens and apply across components

### DIFF
--- a/web/app/admin/health/page.tsx
+++ b/web/app/admin/health/page.tsx
@@ -48,7 +48,7 @@ async function fetchHealth(): Promise<HealthData | null> {
 function StatusDot({ ok }: { ok: boolean }) {
   return (
     <span
-      className={`inline-block h-3 w-3 flex-shrink-0 rounded-full ${ok ? "bg-green-500" : "bg-destructive"}`}
+      className={`inline-block h-3 w-3 flex-shrink-0 rounded-full ${ok ? "bg-success" : "bg-destructive"}`}
     />
   );
 }
@@ -79,7 +79,7 @@ export default async function AdminHealthPage() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       <div className="mb-6">
-        <a href="/admin/ingest" className="text-sm text-blue-600 hover:underline">
+        <a href="/admin/ingest" className="text-sm text-primary hover:underline">
           ← Admin Ingest
         </a>
       </div>

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -58,10 +58,10 @@ export default function AdminIngestPage() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       <div className="mb-6 flex gap-4 text-sm">
-        <a href="/admin" className="text-blue-600 hover:underline">
+        <a href="/admin" className="text-primary hover:underline">
           Analytics
         </a>
-        <a href="/admin/health" className="text-blue-600 hover:underline">
+        <a href="/admin/health" className="text-primary hover:underline">
           System Health
         </a>
       </div>
@@ -101,7 +101,7 @@ export default function AdminIngestPage() {
         </form>
 
         {status === "accepted" && (
-          <p className="mt-4 text-sm text-green-700">
+          <p className="mt-4 text-sm text-success">
             Accepted — ingestion dispatched successfully.
           </p>
         )}

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -173,10 +173,10 @@ export default async function AdminAnalyticsPage() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       <div className="mb-6 flex gap-4 text-sm">
-        <a href="/admin/health" className="text-blue-600 hover:underline">
+        <a href="/admin/health" className="text-primary hover:underline">
           System Health
         </a>
-        <a href="/admin/ingest" className="text-blue-600 hover:underline">
+        <a href="/admin/ingest" className="text-primary hover:underline">
           Ingest
         </a>
       </div>

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -27,6 +27,12 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-success: var(--success);
+  --color-success-foreground: var(--success-foreground);
+  --color-info: var(--info);
+  --color-info-foreground: var(--info-foreground);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -65,6 +71,12 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.769 0.188 70.08);
+  --warning-foreground: oklch(0.269 0 0);
+  --success: oklch(0.723 0.191 149.579);
+  --success-foreground: oklch(0.985 0 0);
+  --info: oklch(0.623 0.214 259.815);
+  --info-foreground: oklch(0.985 0 0);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -100,6 +112,12 @@
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --warning: oklch(0.828 0.143 70.08);
+  --warning-foreground: oklch(0.145 0 0);
+  --success: oklch(0.792 0.141 149.579);
+  --success-foreground: oklch(0.145 0 0);
+  --info: oklch(0.707 0.165 259.815);
+  --info-foreground: oklch(0.145 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);

--- a/web/components/transcript/EvasionCard.tsx
+++ b/web/components/transcript/EvasionCard.tsx
@@ -94,18 +94,18 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
 
         {/* Signals section */}
         {signals ? (
-          <div className="mt-3 rounded-md bg-amber-50 border border-amber-200 px-3 py-2 dark:bg-amber-900/20 dark:border-amber-800">
-            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 mb-1 dark:text-amber-400">
+          <div className="mt-3 rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
               📈 What this signals for investors
             </p>
             <ReactMarkdown
               remarkPlugins={[remarkGfm]}
               components={{
-                p: ({ children }) => <p className="text-sm text-amber-800 mb-1 last:mb-0 dark:text-amber-300">{children}</p>,
-                ul: ({ children }) => <ul className="list-disc list-inside text-sm text-amber-800 space-y-0.5 mb-1 dark:text-amber-300">{children}</ul>,
-                ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-amber-800 space-y-0.5 mb-1 dark:text-amber-300">{children}</ol>,
-                li: ({ children }) => <li className="text-sm text-amber-800 dark:text-amber-300">{children}</li>,
-                strong: ({ children }) => <strong className="font-semibold text-amber-900 dark:text-amber-200">{children}</strong>,
+                p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
+                ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-0.5 mb-1">{children}</ul>,
+                ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-0.5 mb-1">{children}</ol>,
+                li: ({ children }) => <li className="text-sm text-warning-foreground">{children}</li>,
+                strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
               }}
             >
               {signals}
@@ -117,7 +117,7 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
           <button
             onClick={handleSignalsClick}
             disabled={loadingSignals}
-            className="mt-3 w-full rounded-md border border-amber-300 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-100 transition-colors disabled:opacity-50 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-400 dark:hover:bg-amber-900/30"
+            className="mt-3 w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
           >
             {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
           </button>

--- a/web/components/transcript/MisconceptionCard.tsx
+++ b/web/components/transcript/MisconceptionCard.tsx
@@ -25,20 +25,20 @@ export function MisconceptionCard({ item, forceExpanded = false }: Misconception
     <Collapsible
       open={isOpen}
       onOpenChange={setRevealed}
-      className="rounded-lg border border-amber-200 bg-amber-50 overflow-hidden dark:border-amber-800 dark:bg-amber-900/20"
+      className="rounded-lg border border-warning/30 bg-warning/10 overflow-hidden"
     >
       {/* Always-visible: the misinterpretation (the "gotcha") */}
-      <CollapsibleTrigger className="w-full text-left px-4 py-3 flex items-start justify-between gap-3 hover:bg-amber-100 transition-colors dark:hover:bg-amber-900/30">
-        <p className="text-sm font-medium text-amber-900 dark:text-amber-200">{item.misinterpretation}</p>
-        <CollapsibleChevron open={isOpen} className="mt-0.5 text-amber-600 dark:text-amber-400" />
+      <CollapsibleTrigger className="w-full text-left px-4 py-3 flex items-start justify-between gap-3 hover:bg-warning/20 transition-colors">
+        <p className="text-sm font-medium text-warning-foreground">{item.misinterpretation}</p>
+        <CollapsibleChevron open={isOpen} className="mt-0.5 text-warning-foreground" />
       </CollapsibleTrigger>
 
       {/* Revealed: the correction */}
-      <CollapsibleContent className="px-4 pb-3 border-t border-amber-200 pt-2 dark:border-amber-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-amber-600 mb-1 dark:text-amber-400">
+      <CollapsibleContent className="px-4 pb-3 border-t border-warning/30 pt-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground/70 mb-1">
           Correction
         </p>
-        <p className="text-sm text-amber-800 dark:text-amber-300">{item.correction}</p>
+        <p className="text-sm text-warning-foreground">{item.correction}</p>
       </CollapsibleContent>
     </Collapsible>
   );

--- a/web/components/transcript/ThemeCard.tsx
+++ b/web/components/transcript/ThemeCard.tsx
@@ -17,7 +17,7 @@ export function ThemeCard({ label, terms }: ThemeCardProps) {
         {terms.map((term, i) => (
           <span
             key={i}
-            className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+            className="rounded-full bg-info/10 px-2.5 py-0.5 text-xs text-info-foreground"
           >
             {term}
           </span>

--- a/web/components/transcript/TranscriptBrowser.tsx
+++ b/web/components/transcript/TranscriptBrowser.tsx
@@ -239,7 +239,7 @@ function SpanBlock({ span }: { span: SpanItem }) {
     <div
       className={`rounded-lg border p-4 ${
         isAnalyst
-          ? "border-blue-100 bg-blue-50"
+          ? "border-info/20 bg-info/10"
           : "bg-card"
       }`}
     >
@@ -285,7 +285,7 @@ function SearchResultsView({
         {results.length} result{results.length !== 1 ? "s" : ""} for <em>{query}</em>
       </p>
       {results.map((r, i) => (
-        <div key={i} className="rounded-lg border border-amber-100 bg-amber-50 p-4">
+        <div key={i} className="rounded-lg border border-warning/20 bg-warning/10 p-4">
           <div className="mb-1 flex items-center justify-between gap-2">
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               {r.speaker}

--- a/web/lib/signal-colors.ts
+++ b/web/lib/signal-colors.ts
@@ -16,21 +16,21 @@ export interface SentimentStyle {
 export function getEvasionStyle(level: string): EvasionStyle {
   if (level === "high")
     return {
-      bg: "bg-red-50 dark:bg-red-900/30",
-      text: "text-red-700 dark:text-red-400",
+      bg: "bg-destructive/10",
+      text: "text-destructive",
       label: "High",
       emoji: "🔴",
     };
   if (level === "medium")
     return {
-      bg: "bg-amber-50 dark:bg-amber-900/30",
-      text: "text-amber-700 dark:text-amber-400",
+      bg: "bg-warning/10",
+      text: "text-warning-foreground",
       label: "Medium",
       emoji: "🟡",
     };
   return {
-    bg: "bg-green-50 dark:bg-green-900/30",
-    text: "text-green-700 dark:text-green-400",
+    bg: "bg-success/10",
+    text: "text-success",
     label: "Low",
     emoji: "🟢",
   };
@@ -52,8 +52,8 @@ export function getSentimentStyle(sentiment: string): SentimentStyle {
     lower.includes("optimistic")
   )
     return {
-      bg: "bg-green-50 dark:bg-green-900/30",
-      text: "text-green-700 dark:text-green-400",
+      bg: "bg-success/10",
+      text: "text-success",
     };
   if (
     lower.includes("bearish") ||
@@ -61,8 +61,8 @@ export function getSentimentStyle(sentiment: string): SentimentStyle {
     lower.includes("cautious")
   )
     return {
-      bg: "bg-red-50 dark:bg-red-900/30",
-      text: "text-red-700 dark:text-red-400",
+      bg: "bg-destructive/10",
+      text: "text-destructive",
     };
   return { bg: "bg-muted", text: "text-muted-foreground" };
 }


### PR DESCRIPTION
## Summary

Extends the OKLCH semantic theme with three new token pairs and applies them across all affected components.

**New tokens** (added to `:root`, `.dark`, and `@theme inline`):
- `--warning` / `--warning-foreground` — amber, for caution states
- `--success` / `--success-foreground` — green, for positive states
- `--info` / `--info-foreground` — blue, for informational states

**Component updates:**
- `MisconceptionCard` — full amber palette → `warning` tokens
- `EvasionCard` — signals section and button → `warning` tokens
- `ThemeCard` — term chips → `info` tokens
- `TranscriptBrowser` — analyst block → `info`, search result cards → `warning`
- `admin/health/page.tsx` — status dot → `success`/`destructive`, nav link → `text-primary`
- `admin/ingest/page.tsx` — success message → `text-success`, nav links → `text-primary`
- `admin/page.tsx` — nav links → `text-primary`
- `signal-colors.ts` — evasion high/medium/low and sentiment positive/negative fully token-aware

Closes #328

## Test plan

- [ ] Build passes (verified clean)
- [ ] Light mode spot-check: MisconceptionCard, EvasionCard (signals section), ThemeCard chips, TranscriptBrowser analyst/search blocks
- [ ] Dark mode spot-check: all warning/success/info surfaces render correctly
- [ ] Admin health page: green dot (success) and red dot (destructive) render correctly
- [ ] Admin ingest page: success confirmation message renders in success color