### PR TITLE
fix: don't scroll to transcript on initial page load

### DIFF
--- a/web/components/transcript/TranscriptBrowser.tsx
+++ b/web/components/transcript/TranscriptBrowser.tsx
@@ -134,6 +134,7 @@ export function TranscriptBrowser({ ticker, call }: TranscriptBrowserProps) {
   const speakerNames = call.speakers.map((s) => s.name);
 
   const topRef = useRef<HTMLDivElement>(null);
+  const hasMounted = useRef(false);
 
   // Scroll to top when entering search mode
   useEffect(() => {
@@ -142,8 +143,12 @@ export function TranscriptBrowser({ ticker, call }: TranscriptBrowserProps) {
     }
   }, [inSearchMode]);
 
-  // Scroll to top when page changes
+  // Scroll to top when page changes (skip initial mount to avoid hiding the call summary on load)
   useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      return;
+    }
     topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   }, [page]);
 


### PR DESCRIPTION
## Summary

- Transcript page was auto-scrolling past the call summary section on load
- Root cause: the `useEffect([page])` in `TranscriptBrowser` fires on initial mount as well as page changes, triggering `scrollIntoView` immediately
- Fix: added a `hasMounted` ref guard so the scroll only fires on subsequent page navigations, not on first render

## Test plan

- [ ] Load any transcript page — call summary is visible above the fold on load
- [ ] Paginate to page 2 — view scrolls to top of transcript section as expected
- [ ] Reload — page stays at top

Closes #336