### PR TITLE
feat: replace keyword pills with narrative summaries (#342)

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -99,6 +99,12 @@ class SignalStrip(BaseModel):
     strategic_shift_flagged: bool = False
 
 
+class TopicInfo(BaseModel):
+    label: str
+    terms: list[str] = []
+    summary: str = ""
+
+
 class CallDetail(BaseModel):
     ticker: str
     company_name: str | None = None
@@ -107,7 +113,7 @@ class CallDetail(BaseModel):
     synthesis: SynthesisInfo | None = None
     keywords: list[str] = []
     themes: list[str] = []
-    topics: list[list[str]] = []
+    topics: list[TopicInfo] = []
     evasion_analyses: list[EvasionItem] = []
     strategic_shifts: list[StrategicShift] = []
     speakers: list[SpeakerInfo] = []
@@ -296,7 +302,7 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         synthesis=synthesis,
         keywords=analysis_repo.get_keywords_for_ticker(ticker, conn=conn),
         themes=analysis_repo.get_themes_for_ticker(ticker, conn=conn),
-        topics=analysis_repo.get_topics_for_ticker(ticker, conn=conn),
+        topics=[TopicInfo(**t) for t in analysis_repo.get_topics_for_ticker(ticker, conn=conn)],
         evasion_analyses=evasion_analyses,
         strategic_shifts=strategic_shifts,
         speakers=speakers,

--- a/core/models.py
+++ b/core/models.py
@@ -150,6 +150,7 @@ class TopicRecord:
     weight: float
     rank_order: int
     name: str = ""
+    summary: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -18,7 +18,8 @@ class AnalysisRepository:
 
     def get_topics_for_ticker(
         self, ticker: str, limit: int = 5, conn: psycopg.Connection | None = None
-    ) -> list[list[str]]:
+    ) -> list[dict]:
+        """Return structured topic dicts with label, terms, and summary."""
         topics = []
         try:
             ctx = nullcontext(conn) if conn is not None else psycopg.connect(self.conn_str)
@@ -26,7 +27,7 @@ class AnalysisRepository:
                 with c.cursor() as cur:
                     cur.execute(
                         """
-                        SELECT ct.terms
+                        SELECT ct.topic_name, ct.terms, COALESCE(ct.summary, '')
                         FROM call_topics ct
                         JOIN calls c ON ct.call_id = c.id
                         WHERE c.ticker = %s
@@ -35,7 +36,10 @@ class AnalysisRepository:
                         """,
                         (ticker, limit),
                     )
-                    topics = [row[0] for row in cur.fetchall()]
+                    topics = [
+                        {"label": row[0] or row[1][0] if row[1] else "", "terms": row[1], "summary": row[2]}
+                        for row in cur.fetchall()
+                    ]
         except Exception as e:
             logger.warning(f"Could not fetch topics: {e}")
         return topics
@@ -653,10 +657,10 @@ class AnalysisRepository:
             cur.execute(
                 """
                 INSERT INTO call_topics (
-                    call_id, label, terms, weight, rank_order, topic_name
-                ) VALUES (%s, %s, %s, %s, %s, %s)
+                    call_id, label, terms, weight, rank_order, topic_name, summary
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s)
                 """,
-                (str(call_id), topic.label, topic.terms, topic.weight, topic.rank_order, getattr(topic, "name", ""))
+                (str(call_id), topic.label, topic.terms, topic.weight, topic.rank_order, getattr(topic, "name", ""), getattr(topic, "summary", ""))
             )
 
     def _save_keywords(self, cur, call_id, keywords):

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -152,7 +152,7 @@ Your job is to produce three outputs:
 
 1. **keywords** (top 20): The most important and financially significant terms from this call, ranked by importance. For each, include a brief significance note explaining why it matters for this company/sector — not a generic definition.
 
-2. **themes** (exactly 5): Labeled thematic clusters that represent the dominant strategic narratives of this call. Each theme should have a descriptive, specific name (e.g. "AI Infrastructure Investment Cycle", not "Growth") and 6–8 supporting terms drawn from the extracted signals.
+2. **themes** (exactly 5): Labeled thematic clusters that represent the dominant strategic narratives of this call. Each theme should have a descriptive, specific name (e.g. "AI Infrastructure Investment Cycle", not "Growth"), 6–8 supporting terms drawn from the extracted signals, and a one-sentence summary describing what this theme means in the context of this specific call.
 
 3. **top_takeaways** (top 10): The most important beginner-friendly takeaways across the entire call. For each, include the speaker name if available, the core takeaway text, and why it matters financially.
 
@@ -162,7 +162,7 @@ Respond ONLY with valid JSON matching this schema:
     {"term": "string", "significance": "string"}
   ],
   "themes": [
-    {"name": "string", "terms": ["string"]}
+    {"name": "string", "terms": ["string"], "summary": "string"}
   ],
   "top_takeaways": [
     {"speaker": "string", "takeaway": "string", "why_it_matters": "string"}

--- a/services/orchestrator.py
+++ b/services/orchestrator.py
@@ -220,6 +220,7 @@ def analyze(ticker: str = "MSFT") -> CallAnalysis:
                     terms=t.get("terms", []),
                     weight=1.0,
                     rank_order=i + 1,
+                    summary=t.get("summary", ""),
                 )
                 for i, t in enumerate(nlp_synthesis.get("themes", []))
             ]

--- a/supabase/migrations/20260403000000_call_topics_summary.sql
+++ b/supabase/migrations/20260403000000_call_topics_summary.sql
@@ -1,0 +1,2 @@
+-- Add narrative summary field to call_topics for #342.
+ALTER TABLE call_topics ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT '';

--- a/tests/integration/db/test_analysis_repository.py
+++ b/tests/integration/db/test_analysis_repository.py
@@ -9,15 +9,17 @@ def test_get_topics_for_ticker(mock_psycopg_connect):
     m_connect, m_cursor = mock_psycopg_connect
 
     m_cursor.fetchall.return_value = [
-        (["cloud", "azure", "growth"],),
-        (["ai", "copilot", "chat"],),
+        ("Cloud & Azure Growth", ["cloud", "azure", "growth"], "Management highlighted accelerating Azure adoption as the primary growth driver."),
+        ("AI & Copilot Momentum", ["ai", "copilot", "chat"], "Copilot integrations are driving seat expansion across enterprise accounts."),
     ]
 
     repo = AnalysisRepository("fake_connection_string")
     topics = repo.get_topics_for_ticker("MSFT")
 
     assert len(topics) == 2
-    assert topics[0] == ["cloud", "azure", "growth"]
+    assert topics[0]["label"] == "Cloud & Azure Growth"
+    assert topics[0]["terms"] == ["cloud", "azure", "growth"]
+    assert "Azure" in topics[0]["summary"]
 
 
 def test_get_synthesis_for_ticker(mock_psycopg_connect):

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -110,7 +110,10 @@ class TestGetCall:
             analysis_repo.get_synthesis_for_ticker.return_value = ("bullish", "confident", "neutral")
             analysis_repo.get_keywords_for_ticker.return_value = ["AI", "cloud"]
             analysis_repo.get_themes_for_ticker.return_value = ["Growth", "Margins"]
-            analysis_repo.get_topics_for_ticker.return_value = [["ai", "cloud"], ["revenue"]]
+            analysis_repo.get_topics_for_ticker.return_value = [
+                {"label": "AI & Cloud", "terms": ["ai", "cloud"], "summary": "AI and cloud adoption dominated the discussion."},
+                {"label": "Revenue Growth", "terms": ["revenue"], "summary": ""},
+            ]
             analysis_repo.get_evasion_for_ticker.return_value = [
                 ("margin compression", 3, "Deflected with guidance", "margin guidance", "John Smith")
             ]

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -239,16 +239,24 @@ function ReadTheRoomStep({ call }: { call: CallDetail }) {
 }
 
 function UnderstandTheNarrativeStep({ call }: { call: CallDetail }) {
-  const source = call.topics.length > 0 ? call.topics : call.themes.map((t) => [t]);
-
-  if (source.length === 0) {
+  if (call.topics.length === 0 && call.themes.length === 0) {
     return <EmptyState title="No themes extracted." />;
+  }
+
+  if (call.topics.length > 0) {
+    return (
+      <div className="space-y-3">
+        {call.topics.map((topic, i) => (
+          <ThemeCard key={i} label={topic.label || `Topic ${i + 1}`} summary={topic.summary} />
+        ))}
+      </div>
+    );
   }
 
   return (
     <div className="space-y-3">
-      {source.map((terms, i) => (
-        <ThemeCard key={i} label={terms[0] ?? `Topic ${i + 1}`} terms={terms} />
+      {call.themes.map((theme, i) => (
+        <ThemeCard key={i} label={theme} summary="" />
       ))}
     </div>
   );

--- a/web/components/transcript/ThemeCard.tsx
+++ b/web/components/transcript/ThemeCard.tsx
@@ -1,28 +1,21 @@
-/** Renders a topic cluster as a card with a label and term chips. */
+/** Renders a topic cluster as a card with a label and narrative summary. */
 
 import { Card } from "@/components/ui/card";
 
 interface ThemeCardProps {
-  /** The leading term used as the card label. */
+  /** The theme label (topic name). */
   label: string;
-  /** All terms in the topic cluster. */
-  terms: string[];
+  /** One-sentence narrative summary for this theme. */
+  summary: string;
 }
 
-export function ThemeCard({ label, terms }: ThemeCardProps) {
+export function ThemeCard({ label, summary }: ThemeCardProps) {
   return (
     <Card className="p-4 gap-2">
       <p className="text-sm font-semibold text-foreground">{label}</p>
-      <div className="flex flex-wrap gap-1.5">
-        {terms.map((term, i) => (
-          <span
-            key={i}
-            className="rounded-full bg-info/10 px-2.5 py-0.5 text-xs text-info-foreground"
-          >
-            {term}
-          </span>
-        ))}
-      </div>
+      {summary && (
+        <p className="text-sm text-muted-foreground leading-snug">{summary}</p>
+      )}
     </Card>
   );
 }

--- a/web/components/transcript/types.ts
+++ b/web/components/transcript/types.ts
@@ -52,6 +52,12 @@ export interface SignalStrip {
   strategic_shift_flagged: boolean;
 }
 
+export interface TopicInfo {
+  label: string;
+  terms: string[];
+  summary: string;
+}
+
 export interface CallDetail {
   ticker: string;
   company_name: string | null;
@@ -60,7 +66,7 @@ export interface CallDetail {
   synthesis: SynthesisInfo | null;
   keywords: string[];
   themes: string[];
-  topics: string[][];
+  topics: TopicInfo[];
   evasion_analyses: EvasionItem[];
   strategic_shifts: StrategicShift[];
   speakers: SpeakerInfo[];


### PR DESCRIPTION
## Summary
- Replaces keyword pill chips in the **Understand the Narrative** section with a one-sentence narrative summary per theme
- Adds `summary` field end-to-end: DB migration → `TopicRecord` → NLP prompt → repository → API → TypeScript types → UI
- Existing calls without summaries degrade gracefully (card shows label only)

## Changes
- `supabase/migrations/20260403000000_call_topics_summary.sql` — `ALTER TABLE call_topics ADD COLUMN summary TEXT DEFAULT ''`
- `core/models.py` — `TopicRecord.summary: str = ""`
- `ingestion/prompts.py` — `HAIKU_NLP_SYNTHESIS_PROMPT` now requests a `summary` per theme
- `services/orchestrator.py` — passes `summary` into `TopicRecord`
- `db/repositories/analysis.py` — `get_topics_for_ticker` returns `list[dict]` with label/terms/summary; `_save_topics` persists summary
- `api/routes/calls.py` — new `TopicInfo` Pydantic model; `CallDetail.topics: list[TopicInfo]`
- `web/components/transcript/types.ts` — new `TopicInfo` interface; `CallDetail.topics: TopicInfo[]`
- `web/components/transcript/ThemeCard.tsx` — renders label + summary sentence, no pills
- `web/components/transcript/MetadataPanel.tsx` — `UnderstandTheNarrativeStep` uses `TopicInfo` with fallback to `themes`

## Test plan
- [ ] Run a new ingestion and confirm `summary` is generated in the LLM response and stored in `call_topics.summary`
- [ ] Open a call detail page — ThemeCards show label + narrative sentence, no pill chips
- [ ] Existing calls without summaries show label only (empty summary renders nothing)
- [ ] `pytest -q` passes (175 tests)

Closes #342