### PR TITLE
fix: operator precedence bug in topic label resolution

### DIFF
--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -37,7 +37,7 @@ class AnalysisRepository:
                         (ticker, limit),
                     )
                     topics = [
-                        {"label": row[0] or row[1][0] if row[1] else "", "terms": row[1], "summary": row[2]}
+                        {"label": row[0] or (row[1][0] if row[1] else ""), "terms": row[1], "summary": row[2]}
                         for row in cur.fetchall()
                     ]
         except Exception as e:

--- a/tests/integration/db/test_analysis_repository.py
+++ b/tests/integration/db/test_analysis_repository.py
@@ -22,6 +22,21 @@ def test_get_topics_for_ticker(mock_psycopg_connect):
     assert "Azure" in topics[0]["summary"]
 
 
+def test_get_topics_uses_topic_name_when_terms_empty(mock_psycopg_connect):
+    """topic_name must be used as label even when terms is empty."""
+    m_connect, m_cursor = mock_psycopg_connect
+
+    m_cursor.fetchall.return_value = [
+        ("AI Infrastructure Investment Cycle", [], "AI spending is accelerating."),
+    ]
+
+    repo = AnalysisRepository("fake_connection_string")
+    topics = repo.get_topics_for_ticker("MSFT")
+
+    assert len(topics) == 1
+    assert topics[0]["label"] == "AI Infrastructure Investment Cycle"
+
+
 def test_get_synthesis_for_ticker(mock_psycopg_connect):
     m_connect, m_cursor = mock_psycopg_connect
 


### PR DESCRIPTION
## Summary
- Fixes a Python operator precedence bug where `topic_name` was silently discarded when `terms` was an empty list
- `row[0] or row[1][0] if row[1] else ""` parses as `(row[0] or row[1][0]) if row[1] else ""`, returning `""` even when `topic_name` is populated — fixed with explicit parentheses
- Adds regression test for the empty-terms case

## Root cause
The NLP synthesis (Haiku) sometimes produces themes with a `name` and `summary` but an empty `terms` array. The ternary `if row[1]` gates the entire expression, so a falsy `terms` list causes the label to be `""` regardless of `topic_name`. The frontend fallback then shows "Topic 1", "Topic 2", etc.

## Test plan
- [ ] Reingest a transcript and confirm ThemeCards show actual theme names, not "Topic N"
- [ ] `pytest -q` passes (176 tests)

Closes #342