### PR TITLE
fix: guard against undefined news_items/competitors on expand

### DIFF
--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -336,8 +336,10 @@ interface SituateInContextStepProps {
 }
 
 function SituateInContextStep({ call }: SituateInContextStepProps) {
-  const hasNews = call.news_items.length > 0;
-  const hasCompetitors = call.competitors.length > 0;
+  const newsItems = call.news_items ?? [];
+  const competitors = call.competitors ?? [];
+  const hasNews = newsItems.length > 0;
+  const hasCompetitors = competitors.length > 0;
 
   return (
     <div className="space-y-5">
@@ -347,7 +349,7 @@ function SituateInContextStep({ call }: SituateInContextStepProps) {
         </h3>
         {hasNews ? (
           <div className="space-y-2">
-            {call.news_items.map((item) => (
+            {newsItems.map((item) => (
               <NewsCard key={item.headline} item={item} ticker={call.ticker} />
             ))}
           </div>
@@ -361,7 +363,7 @@ function SituateInContextStep({ call }: SituateInContextStepProps) {
           Competitors
         </h3>
         {hasCompetitors ? (
-          <CompetitorList competitors={call.competitors} />
+          <CompetitorList competitors={competitors} />
         ) : (
           <EmptyState title="No competitor data found." />
         )}


### PR DESCRIPTION
## Summary

- Adds `?? []` defaults in `SituateInContextStep` to prevent a TypeError crash when expanding the "Situate in Context" collapsible

**Root cause:** `@base-ui/react` Collapsible.Panel defaults to `keepMounted: false`, so this component is only first mounted when the user clicks to expand. If the Next.js ISR cache serves a `CallDetail` response from before the backend deployed the new `news_items`/`competitors` fields, those properties are `undefined` at runtime. `undefined.length` throws a TypeError, crashing the React tree.

## Test plan

- [ ] Expand "Situate in Context" — renders empty states instead of crashing
- [ ] After ISR cache refreshes with new API response — renders real data