### PR TITLE
docs: staging environment setup and CI preview fixes

### DIFF
--- a/.claude/skills/learned/vercel-ci-preview-env-vars.md
+++ b/.claude/skills/learned/vercel-ci-preview-env-vars.md
@@ -1,0 +1,51 @@
+---
+name: vercel-ci-preview-env-vars
+description: "Inject staging env vars into Vercel preview deploys via -b/-e flags; avoid vercel pull with rootDirectory"
+user-invocable: false
+origin: auto-extracted
+---
+
+# Vercel CI Preview Deploy with Staging Env Vars
+
+**Extracted:** 2026-04-04
+**Context:** GitHub Actions deploying Vercel previews for a Next.js app that needs different env vars (staging) than production
+
+## Problem
+
+When a Vercel project has `rootDirectory` configured (e.g. `"web"`), running `vercel pull` in CI downloads project settings that include this `rootDirectory`. Subsequent `vercel build` or `vercel deploy` then double the path (`web/web/package.json` not found). Every workaround (running from subdirectory, copying `.vercel/` to root, etc.) fails because the CLI compounds the paths.
+
+Separately, `NEXT_PUBLIC_*` variables must be present at both **build time** (inlined by Next.js compiler) and **runtime** (used during SSR). Build-only injection causes "Supabase URL and Key required" errors when the preview serves requests.
+
+## Solution
+
+Skip `vercel pull` entirely. Use `vercel deploy` with `-b` (build-env) and `-e` (runtime env) flags:
+
+```yaml
+- name: Deploy preview
+  id: deploy
+  run: |
+    url=$(vercel deploy --token=${{ secrets.VERCEL_TOKEN }} --yes \
+      -b NEXT_PUBLIC_SUPABASE_URL=${{ secrets.STAGING_SUPABASE_URL }} \
+      -b NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.STAGING_SUPABASE_ANON_KEY }} \
+      -b NEXT_PUBLIC_API_URL=${{ secrets.STAGING_API_URL }} \
+      -e NEXT_PUBLIC_SUPABASE_URL=${{ secrets.STAGING_SUPABASE_URL }} \
+      -e NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.STAGING_SUPABASE_ANON_KEY }} \
+      -e NEXT_PUBLIC_API_URL=${{ secrets.STAGING_API_URL }})
+    echo "url=$url" >> $GITHUB_OUTPUT
+  env:
+    VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+    VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+```
+
+Key details:
+- `-b KEY=VAL` injects at build time (Next.js inlines `NEXT_PUBLIC_*`)
+- `-e KEY=VAL` injects at runtime (SSR/server components can read them)
+- Both are required for `NEXT_PUBLIC_*` vars used in SSR code
+- `STAGING_API_URL` must NOT have a trailing slash (causes `//api/calls` double-slash → CORS failures)
+- `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` as env vars let the CLI find the project without `vercel pull`
+
+## When to Use
+
+- Deploying Vercel previews from GitHub Actions with env var overrides
+- Any Vercel project with `rootDirectory` set in dashboard settings
+- When preview deployments need to point at a different backend (staging API, staging DB)

--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ git commit -m "chore: update <package> to x.y.z"
 
 Vercel automatically creates preview deployments for every PR. To allow all preview URLs through Railway's CORS, set `CORS_ORIGIN_REGEX` in Railway to a regex matching your app's preview URL pattern (e.g. `https://myapp(-[a-z0-9-]+)?\.vercel\.app`).
 
+### Staging / Preview environment
+
+The project includes a staging environment for testing PRs end-to-end before merging.
+
+| Layer | Production | Staging |
+|---|---|---|
+| Frontend | Vercel production deploy | Vercel preview (per PR, auto-deployed by CI) |
+| API | Railway production environment | Railway `staging` environment |
+| Database | Supabase production project | Supabase staging project |
+
+Preview deployments are wired to staging automatically via CI — Vercel previews point at the staging API and staging database. See [`docs/disaster-recovery.md`](docs/disaster-recovery.md) for full setup/rebuild instructions.
+
 ---
 
 ## Environment variable reference
@@ -262,3 +274,18 @@ Vercel automatically creates preview deployments for every PR. To allow all prev
 | `CORS_EXTRA_ORIGINS` | FastAPI CORS | Optional comma-separated extra allowed origins (e.g., Vercel preview URLs in staging) |
 | `MODAL_TOKEN_ID` | FastAPI (admin ingest endpoint) | Modal token ID — required at startup; generate with `modal token new` |
 | `SENTRY_DSN` | FastAPI (optional) | Sentry DSN — enables production exception alerting; service starts without it but logs a warning |
+
+### GitHub Actions secrets
+
+These secrets must be configured in the repo's Settings → Secrets and variables → Actions:
+
+| Secret | Purpose |
+|---|---|
+| `SUPABASE_ACCESS_TOKEN` | Supabase CLI auth (both prod and staging migration deploys) |
+| `SUPABASE_STAGING_PROJECT_REF` | Staging Supabase project ref (for `deploy-migrations-staging` CI job) |
+| `STAGING_SUPABASE_URL` | Staging Supabase project URL (injected into Vercel preview deploys) |
+| `STAGING_SUPABASE_ANON_KEY` | Staging Supabase anon key (injected into Vercel preview deploys) |
+| `STAGING_API_URL` | Railway staging API URL, no trailing slash (injected into Vercel preview deploys) |
+| `VERCEL_TOKEN` | Vercel API token (for preview and production deploys) |
+| `VERCEL_ORG_ID` | Vercel org ID |
+| `VERCEL_PROJECT_ID` | Vercel project ID |

--- a/docs/database.md
+++ b/docs/database.md
@@ -12,6 +12,17 @@ supabase db push
 
 This is idempotent — already-applied migrations are tracked by Supabase and skipped.
 
+By default this targets the linked project (production). To push to staging instead:
+
+```bash
+supabase link --project-ref <staging-project-ref>
+supabase db push
+```
+
+Re-link to production afterward: `supabase link --project-ref qxdexukkmzidalnrzfqf`
+
+CI handles this automatically — the `deploy-migrations-staging` job pushes to staging on PRs that change migration files.
+
 ## Adding a migration
 
 1. Create a new file: `supabase/migrations/YYYYMMDDHHMMSS_description.sql`

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -250,6 +250,28 @@ curl https://[railway-domain]/admin/health \
 
 ---
 
+## 5. GitHub Actions
+
+CI/CD workflows (`.github/workflows/ci.yml`) require these repository secrets. Configure them in the repo's Settings → Secrets and variables → Actions.
+
+| Secret | Where to find the value |
+|---|---|
+| `SUPABASE_ACCESS_TOKEN` | Supabase dashboard → Account → Access tokens → Generate new token |
+| `SUPABASE_STAGING_PROJECT_REF` | Supabase dashboard → staging project → Settings → General → Reference ID |
+| `STAGING_SUPABASE_URL` | Supabase dashboard → staging project → Settings → API → Project URL |
+| `STAGING_SUPABASE_ANON_KEY` | Supabase dashboard → staging project → Settings → API → `anon` `public` key |
+| `STAGING_API_URL` | Railway dashboard → staging environment → public domain (e.g. `https://...-staging.up.railway.app`). **No trailing slash.** |
+| `VERCEL_TOKEN` | Vercel dashboard → Account Settings → Tokens → Create |
+| `VERCEL_ORG_ID` | Vercel dashboard → Settings → General → Team ID (or run `vercel whoami`) |
+| `VERCEL_PROJECT_ID` | Vercel dashboard → Project Settings → General → Project ID |
+
+These secrets power three CI jobs:
+- **`deploy-migrations-staging`** — pushes migrations to the staging Supabase project on PRs that change `supabase/migrations/**`
+- **`deploy-web-preview`** — deploys Vercel previews with staging env vars injected via `vercel deploy -b/-e` flags
+- **`deploy-migrations`** / **`deploy-web`** — production deploys on merge to main
+
+---
+
 ## Environment variable summary
 
 Complete reference of all env vars, grouped by where they're set:
@@ -292,7 +314,7 @@ If starting from zero:
 
 - [ ] Create Supabase production project
 - [ ] Enable pgvector extension on production
-- [ ] Run migrations on production (`python migrate.py`)
+- [ ] Run migrations on production (`supabase db push`)
 - [ ] Backfill profiles table and promote admin user on production (see §1.3a)
 - [ ] Configure Google OAuth on production (redirect URLs)
 - [ ] Create Supabase staging project
@@ -309,4 +331,5 @@ If starting from zero:
 - [ ] Set preview-scoped env vars in Vercel (staging Supabase + Railway staging)
 - [ ] Create Modal `earnings-secrets` secret group
 - [ ] Deploy Modal app (`modal deploy pipeline/ingest.py`)
+- [ ] Configure GitHub Actions secrets (see §5)
 - [ ] Smoke-test each service (Supabase auth, Railway `/health`, Vercel preview, Modal ingest)

--- a/ideation/staging-environments.plan.md
+++ b/ideation/staging-environments.plan.md
@@ -1,3 +1,5 @@
+> **Status: Implemented** — see PR #355 and [`docs/disaster-recovery.md`](../docs/disaster-recovery.md) for the current setup.
+
 # Staging Environments — Supabase + Railway + Vercel
 
 GitHub Issue: [#156](https://github.com/ed-mays/earnings-transcript-teacher/issues/156)


### PR DESCRIPTION
## Summary
- Fix Vercel preview deploy CI job to inject staging env vars via `vercel deploy -b/-e` flags (replaces broken `vercel pull` approach that caused `web/web` path doubling)
- Document staging environment architecture in README (environment table + GitHub Actions secrets reference)
- Add GitHub Actions secrets section to disaster-recovery.md with "where to find each value" guide
- Add staging migration workflow note to database.md
- Mark ideation/staging-environments.plan.md as implemented
- Add cloud stack vendor analysis document (issue #221)

Closes #221

## Test plan
- [ ] Verify Vercel preview deploy succeeds with staging env vars
- [ ] Verify preview app authenticates against staging Supabase
- [ ] Verify preview app calls staging Railway API (check Railway staging logs)
- [ ] Review README staging section and secrets table for accuracy
- [ ] Review disaster-recovery.md CI secrets section