### PR TITLE
feat: add on-demand endpoints for call detail sections

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -131,17 +131,33 @@ class CallDetail(BaseModel):
     industry: str | None = None
     synthesis: SynthesisInfo | None = None
     keywords: list[str] = []
-    themes: list[str] = []
-    topics: list[TopicInfo] = []
-    evasion_analyses: list[EvasionItem] = []
-    strategic_shifts: list[StrategicShift] = []
     speakers: list[SpeakerInfo] = []
     brief: CallBrief | None = None
     takeaways: list[TakeawayItem] = []
     misconceptions: list[MisconceptionItem] = []
     signal_strip: SignalStrip | None = None
-    news_items: list[NewsItemInfo] = []
+
+
+class TopicsResponse(BaseModel):
+    topics: list[TopicInfo] = []
+    themes: list[str] = []
+
+
+class EvasionResponse(BaseModel):
+    evasion_analyses: list[EvasionItem] = []
+    evasion_level: str | None = None
+
+
+class StrategicShiftsResponse(BaseModel):
+    strategic_shifts: list[StrategicShift] = []
+
+
+class CompetitorsResponse(BaseModel):
     competitors: list[CompetitorInfo] = []
+
+
+class NewsResponse(BaseModel):
+    news_items: list[NewsItemInfo] = []
 
 
 class AdjacentCallInfo(BaseModel):
@@ -261,28 +277,6 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         else None
     )
 
-    raw_shifts = analysis_repo.get_strategic_shifts_for_ticker(ticker, conn=conn) or []
-    strategic_shifts = [
-        StrategicShift(
-            prior_position=s.get("prior_position", ""),
-            current_position=s.get("current_position", ""),
-            investor_significance=s.get("investor_significance", ""),
-        )
-        for s in raw_shifts
-    ]
-
-    raw_evasion = analysis_repo.get_evasion_for_ticker(ticker, conn=conn)
-    evasion_analyses = [
-        EvasionItem(
-            analyst_concern=r[0],
-            defensiveness_score=r[1],
-            evasion_explanation=r[2],
-            question_topic=r[3],
-            analyst_name=r[4],
-        )
-        for r in raw_evasion
-    ]
-
     raw_speakers = analysis_repo.get_speakers_for_ticker(ticker, conn=conn)
     speakers = [SpeakerInfo(name=r[0], role=r[1], title=r[2], firm=r[3]) for r in raw_speakers]
 
@@ -301,23 +295,118 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         for r in raw_misconceptions[:3]
     ]
 
-    # Signal strip
-    evasion_level = None
-    if raw_evasion:
-        avg_score = sum(r[1] for r in raw_evasion) / len(raw_evasion)
-        evasion_level = "high" if avg_score > 6 else ("medium" if avg_score > 3 else "low")
+    # Signal strip — lightweight flags query, no full evasion/shift data load
+    evasion_level, strategic_shift_flagged = analysis_repo.get_signal_strip_flags_for_ticker(
+        ticker, conn=conn
+    )
     signal_strip = SignalStrip(
         overall_sentiment=raw_synthesis[0] if raw_synthesis else None,
         executive_sentiment=raw_synthesis[1] if raw_synthesis else None,
         analyst_sentiment=raw_synthesis[2] if raw_synthesis else None,
         evasion_level=evasion_level,
-        strategic_shift_flagged=len(raw_shifts) > 0,
+        strategic_shift_flagged=strategic_shift_flagged,
     )
 
-    # --- Competitors (lazy hydration) ---
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return CallDetail(
+        ticker=ticker,
+        company_name=company_name or None,
+        call_date=str(call_date) if call_date else None,
+        industry=industry or None,
+        synthesis=synthesis,
+        keywords=analysis_repo.get_keywords_for_ticker(ticker, conn=conn),
+        speakers=speakers,
+        brief=brief,
+        takeaways=takeaways,
+        misconceptions=misconceptions,
+        signal_strip=signal_strip,
+    )
+
+
+@router.get("/{ticker}/topics", response_model=TopicsResponse)
+def get_call_topics(ticker: str, conn: DbDep, response: Response) -> TopicsResponse:
+    """Return topics and themes for a call (Understand the Narrative section)."""
+    logger.info("GET /api/calls/%s/topics", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    analysis_repo = AnalysisRepository(_db_url())
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return TopicsResponse(
+        topics=[TopicInfo(**t) for t in analysis_repo.get_topics_for_ticker(ticker, conn=conn)],
+        themes=analysis_repo.get_themes_for_ticker(ticker, conn=conn),
+    )
+
+
+@router.get("/{ticker}/evasion", response_model=EvasionResponse)
+def get_call_evasion(ticker: str, conn: DbDep, response: Response) -> EvasionResponse:
+    """Return evasion analyses for a call (Notice What Was Avoided section)."""
+    logger.info("GET /api/calls/%s/evasion", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    analysis_repo = AnalysisRepository(_db_url())
+    raw_evasion = analysis_repo.get_evasion_for_ticker(ticker, conn=conn)
+    evasion_analyses = [
+        EvasionItem(
+            analyst_concern=r[0],
+            defensiveness_score=r[1],
+            evasion_explanation=r[2],
+            question_topic=r[3],
+            analyst_name=r[4],
+        )
+        for r in raw_evasion
+    ]
+    evasion_level = None
+    if raw_evasion:
+        avg_score = sum(r[1] for r in raw_evasion) / len(raw_evasion)
+        evasion_level = "high" if avg_score > 6 else ("medium" if avg_score > 3 else "low")
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return EvasionResponse(evasion_analyses=evasion_analyses, evasion_level=evasion_level)
+
+
+@router.get("/{ticker}/strategic-shifts", response_model=StrategicShiftsResponse)
+def get_call_strategic_shifts(ticker: str, conn: DbDep, response: Response) -> StrategicShiftsResponse:
+    """Return strategic shifts for a call (Track What Changed section)."""
+    logger.info("GET /api/calls/%s/strategic-shifts", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    analysis_repo = AnalysisRepository(_db_url())
+    raw_shifts = analysis_repo.get_strategic_shifts_for_ticker(ticker, conn=conn) or []
+    strategic_shifts = [
+        StrategicShift(
+            prior_position=s.get("prior_position", ""),
+            current_position=s.get("current_position", ""),
+            investor_significance=s.get("investor_significance", ""),
+        )
+        for s in raw_shifts
+    ]
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return StrategicShiftsResponse(strategic_shifts=strategic_shifts)
+
+
+@router.get("/{ticker}/competitors", response_model=CompetitorsResponse)
+def get_call_competitors(ticker: str, conn: DbDep, response: Response) -> CompetitorsResponse:
+    """Return competitors for a call with lazy hydration on cache miss (Situate in Context)."""
+    logger.info("GET /api/calls/%s/competitors", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    db_url = _db_url()
+    call_repo = CallRepository(db_url)
     comp_repo = CompetitorRepository(db_url)
     raw_competitors = comp_repo.get(ticker)
     if not raw_competitors:
+        company_name, industry = call_repo.get_company_info(ticker, conn=conn)
         transcript_text = call_repo.get_transcript_text(ticker, conn=conn)
         raw_competitors = fetch_competitors(
             ticker, company_name or "", industry or "", transcript_text
@@ -333,11 +422,27 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         )
         for c in raw_competitors
     ]
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return CompetitorsResponse(competitors=competitors)
 
-    # --- News items (lazy hydration) ---
+
+@router.get("/{ticker}/news", response_model=NewsResponse)
+def get_call_news(ticker: str, conn: DbDep, response: Response) -> NewsResponse:
+    """Return recent news items for a call with lazy hydration on cache miss (Situate in Context)."""
+    logger.info("GET /api/calls/%s/news", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    db_url = _db_url()
+    call_repo = CallRepository(db_url)
+    analysis_repo = AnalysisRepository(db_url)
     news_repo = NewsRepository(db_url)
     raw_news = news_repo.get(ticker)
     if not raw_news:
+        company_name, _ = call_repo.get_company_info(ticker, conn=conn)
+        call_date = call_repo.get_call_date(ticker, conn=conn)
         themes = analysis_repo.get_themes_for_ticker(ticker, conn=conn)
         if call_date is not None:
             raw_news = fetch_recent_news(ticker, company_name or "", call_date, themes)
@@ -353,27 +458,8 @@ def get_call(ticker: str, conn: DbDep, response: Response) -> CallDetail:
         )
         for n in raw_news
     ]
-
     response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
-    return CallDetail(
-        ticker=ticker,
-        company_name=company_name or None,
-        call_date=str(call_date) if call_date else None,
-        industry=industry or None,
-        synthesis=synthesis,
-        keywords=analysis_repo.get_keywords_for_ticker(ticker, conn=conn),
-        themes=analysis_repo.get_themes_for_ticker(ticker, conn=conn),
-        topics=[TopicInfo(**t) for t in analysis_repo.get_topics_for_ticker(ticker, conn=conn)],
-        evasion_analyses=evasion_analyses,
-        strategic_shifts=strategic_shifts,
-        speakers=speakers,
-        brief=brief,
-        takeaways=takeaways,
-        misconceptions=misconceptions,
-        signal_strip=signal_strip,
-        news_items=news_items,
-        competitors=competitors,
-    )
+    return NewsResponse(news_items=news_items)
 
 
 @router.get("/{ticker}/adjacent", response_model=AdjacentCalls)

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -123,6 +123,48 @@ class AnalysisRepository:
             logger.warning(f"Could not fetch strategic_shifts for {ticker}: {e}")
         return None
 
+    def get_signal_strip_flags_for_ticker(
+        self, ticker: str, conn: psycopg.Connection | None = None
+    ) -> tuple[str | None, bool]:
+        """Return (evasion_level, strategic_shift_flagged) for a ticker using lightweight SQL.
+
+        Uses AVG + CASE (same pattern as list_calls) rather than loading full evasion rows.
+        Returns (None, False) if no data exists or the ticker is not found.
+        """
+        try:
+            ctx = nullcontext(conn) if conn is not None else psycopg.connect(self.conn_str)
+            with ctx as c:
+                with c.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                            CASE
+                                WHEN COUNT(ea.id) = 0 THEN NULL
+                                WHEN AVG(ea.defensiveness_score) <= 3 THEN 'low'
+                                WHEN AVG(ea.defensiveness_score) <= 6 THEN 'medium'
+                                ELSE 'high'
+                            END AS evasion_level,
+                            CASE
+                                WHEN cs.strategic_shifts IS NOT NULL
+                                     AND array_length(cs.strategic_shifts, 1) > 0
+                                THEN true
+                                ELSE false
+                            END AS strategic_shift_flagged
+                        FROM calls c
+                        LEFT JOIN call_synthesis cs ON cs.call_id = c.id
+                        LEFT JOIN evasion_analysis ea ON ea.call_id = c.id
+                        WHERE c.ticker = %s
+                        GROUP BY cs.strategic_shifts
+                        """,
+                        (ticker,),
+                    )
+                    row = cur.fetchone()
+                    if row:
+                        return row[0], bool(row[1])
+        except Exception as e:
+            logger.warning(f"Could not fetch signal strip flags for {ticker}: {e}")
+        return None, False
+
     def get_call_summary_for_ticker(self, ticker: str) -> str | None:
         """Return the call_summary paragraph for a ticker, or None if absent."""
         try:

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -97,47 +97,25 @@ class TestGetCall:
         assert any("AAPL" in r.message for r in caplog.records)
 
     def test_returns_call_detail(self, api_client):
-        from core.models import Competitor, NewsItem
-
         with (
             patch("routes.calls._ticker_exists", return_value=True),
             patch("routes.calls.CallRepository") as MockCallRepo,
             patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
-            patch("routes.calls.CompetitorRepository") as MockCompRepo,
-            patch("routes.calls.NewsRepository") as MockNewsRepo,
         ):
             call_repo = MockCallRepo.return_value
             call_repo.get_company_info.return_value = ("Apple Inc.", "Technology")
             call_repo.get_call_date.return_value = None
-            call_repo.get_transcript_text.return_value = ""
 
             analysis_repo = MockAnalysisRepo.return_value
             analysis_repo.get_synthesis_for_ticker.return_value = ("bullish", "confident", "neutral")
             analysis_repo.get_keywords_for_ticker.return_value = ["AI", "cloud"]
-            analysis_repo.get_themes_for_ticker.return_value = ["Growth", "Margins"]
-            analysis_repo.get_topics_for_ticker.return_value = [
-                {"label": "AI & Cloud", "terms": ["ai", "cloud"], "summary": "AI and cloud adoption dominated the discussion."},
-                {"label": "Revenue Growth", "terms": ["revenue"], "summary": ""},
-            ]
-            analysis_repo.get_evasion_for_ticker.return_value = [
-                ("margin compression", 3, "Deflected with guidance", "margin guidance", "John Smith")
-            ]
-            analysis_repo.get_strategic_shifts_for_ticker.return_value = [
-                {"prior_position": "on-prem", "current_position": "cloud", "investor_significance": "high"}
-            ]
             analysis_repo.get_speakers_for_ticker.return_value = [
                 ("Tim Cook", "executive", "CEO", "Apple Inc.")
             ]
             analysis_repo.get_call_brief_for_ticker.return_value = None
             analysis_repo.get_takeaways_for_ticker.return_value = []
             analysis_repo.get_misconceptions_for_ticker.return_value = []
-
-            MockCompRepo.return_value.get.return_value = [
-                Competitor(name="Google", ticker="GOOGL", description="Search giant.", mentioned_in_transcript=True)
-            ]
-            MockNewsRepo.return_value.get.return_value = [
-                NewsItem(headline="Apple beats estimates", url="https://example.com", source="Reuters", date="2025-01-31", summary="Strong Q1.")
-            ]
+            analysis_repo.get_signal_strip_flags_for_ticker.return_value = ("low", True)
 
             response = api_client.get("/api/calls/AAPL")
 
@@ -147,52 +125,41 @@ class TestGetCall:
         assert data["company_name"] == "Apple Inc."
         assert data["synthesis"]["overall_sentiment"] == "bullish"
         assert data["keywords"] == ["AI", "cloud"]
-        assert len(data["evasion_analyses"]) == 1
-        assert data["evasion_analyses"][0]["defensiveness_score"] == 3
-        assert len(data["strategic_shifts"]) == 1
         assert len(data["speakers"]) == 1
         assert data["speakers"][0]["name"] == "Tim Cook"
-        assert len(data["competitors"]) == 1
-        assert data["competitors"][0]["name"] == "Google"
-        assert data["competitors"][0]["mentioned_in_transcript"] is True
-        assert len(data["news_items"]) == 1
-        assert data["news_items"][0]["headline"] == "Apple beats estimates"
+        assert "evasion_analyses" not in data
+        assert "strategic_shifts" not in data
+        assert "topics" not in data
+        assert "themes" not in data
+        assert "news_items" not in data
+        assert "competitors" not in data
 
-    def test_call_detail_empty_news_and_competitors(self, api_client):
-        """When repos return empty and call_date is None, news/competitors default to []."""
+    def test_signal_strip_uses_flags_from_repo(self, api_client):
+        """signal_strip is built from get_signal_strip_flags_for_ticker, not full evasion data."""
         with (
             patch("routes.calls._ticker_exists", return_value=True),
             patch("routes.calls.CallRepository") as MockCallRepo,
             patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
-            patch("routes.calls.CompetitorRepository") as MockCompRepo,
-            patch("routes.calls.NewsRepository") as MockNewsRepo,
         ):
             call_repo = MockCallRepo.return_value
             call_repo.get_company_info.return_value = ("Apple Inc.", "Technology")
             call_repo.get_call_date.return_value = None
-            call_repo.get_transcript_text.return_value = ""
 
             analysis_repo = MockAnalysisRepo.return_value
-            analysis_repo.get_synthesis_for_ticker.return_value = None
+            analysis_repo.get_synthesis_for_ticker.return_value = ("bullish", "confident", "neutral")
             analysis_repo.get_keywords_for_ticker.return_value = []
-            analysis_repo.get_themes_for_ticker.return_value = []
-            analysis_repo.get_topics_for_ticker.return_value = []
-            analysis_repo.get_evasion_for_ticker.return_value = []
-            analysis_repo.get_strategic_shifts_for_ticker.return_value = []
             analysis_repo.get_speakers_for_ticker.return_value = []
             analysis_repo.get_call_brief_for_ticker.return_value = None
             analysis_repo.get_takeaways_for_ticker.return_value = []
             analysis_repo.get_misconceptions_for_ticker.return_value = []
-
-            MockCompRepo.return_value.get.return_value = []
-            MockNewsRepo.return_value.get.return_value = []
+            analysis_repo.get_signal_strip_flags_for_ticker.return_value = ("high", True)
 
             response = api_client.get("/api/calls/AAPL")
 
         assert response.status_code == 200
-        data = response.json()
-        assert data["news_items"] == []
-        assert data["competitors"] == []
+        strip = response.json()["signal_strip"]
+        assert strip["evasion_level"] == "high"
+        assert strip["strategic_shift_flagged"] is True
 
 
 class TestGetSpans:
@@ -495,3 +462,207 @@ class TestNewsContext:
         events = self._parse_sse(response.text)
         assert len(events) == 1
         assert events[0]["type"] == "error"
+
+
+class TestGetCallTopics:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/topics")
+        assert response.status_code == 404
+
+    def test_returns_topics_and_themes(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            repo = MockAnalysisRepo.return_value
+            repo.get_topics_for_ticker.return_value = [
+                {"label": "AI & Cloud", "terms": ["ai", "cloud"], "summary": "Adoption accelerating."},
+            ]
+            repo.get_themes_for_ticker.return_value = ["Growth", "Margins"]
+            response = api_client.get("/api/calls/AAPL/topics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["topics"]) == 1
+        assert data["topics"][0]["label"] == "AI & Cloud"
+        assert data["themes"] == ["Growth", "Margins"]
+
+    def test_empty_state(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            repo = MockAnalysisRepo.return_value
+            repo.get_topics_for_ticker.return_value = []
+            repo.get_themes_for_ticker.return_value = []
+            response = api_client.get("/api/calls/AAPL/topics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["topics"] == []
+        assert data["themes"] == []
+
+
+class TestGetCallEvasion:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/evasion")
+        assert response.status_code == 404
+
+    def test_returns_evasion_analyses_with_level(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_evasion_for_ticker.return_value = [
+                ("margin guidance", 7, "Deflected to top-line", "margins", "John Smith"),
+                ("capex outlook", 8, "Vague non-answer", "capex", "Jane Doe"),
+            ]
+            response = api_client.get("/api/calls/AAPL/evasion")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["evasion_analyses"]) == 2
+        assert data["evasion_analyses"][0]["defensiveness_score"] == 7
+        assert data["evasion_level"] == "high"
+
+    def test_empty_state_returns_null_level(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_evasion_for_ticker.return_value = []
+            response = api_client.get("/api/calls/AAPL/evasion")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["evasion_analyses"] == []
+        assert data["evasion_level"] is None
+
+
+class TestGetCallStrategicShifts:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/strategic-shifts")
+        assert response.status_code == 404
+
+    def test_returns_strategic_shifts(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_strategic_shifts_for_ticker.return_value = [
+                {"prior_position": "on-prem", "current_position": "cloud", "investor_significance": "high"},
+            ]
+            response = api_client.get("/api/calls/AAPL/strategic-shifts")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["strategic_shifts"]) == 1
+        assert data["strategic_shifts"][0]["current_position"] == "cloud"
+
+    def test_empty_state(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_strategic_shifts_for_ticker.return_value = []
+            response = api_client.get("/api/calls/AAPL/strategic-shifts")
+
+        assert response.status_code == 200
+        assert response.json()["strategic_shifts"] == []
+
+
+class TestGetCallCompetitors:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/competitors")
+        assert response.status_code == 404
+
+    def test_returns_cached_competitors(self, api_client):
+        from core.models import Competitor
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.CallRepository"),
+            patch("routes.calls.CompetitorRepository") as MockCompRepo,
+        ):
+            MockCompRepo.return_value.get.return_value = [
+                Competitor(name="Google", ticker="GOOGL", description="Search.", mentioned_in_transcript=True)
+            ]
+            response = api_client.get("/api/calls/AAPL/competitors")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["competitors"]) == 1
+        assert data["competitors"][0]["name"] == "Google"
+        assert data["competitors"][0]["mentioned_in_transcript"] is True
+
+    def test_lazy_hydration_on_cache_miss(self, api_client):
+        """When cache is empty, fetch_competitors is called and result is returned."""
+        from core.models import Competitor
+
+        fetched = [Competitor(name="Microsoft", ticker="MSFT", description="Cloud.", mentioned_in_transcript=False)]
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.CallRepository") as MockCallRepo,
+            patch("routes.calls.CompetitorRepository") as MockCompRepo,
+            patch("routes.calls.fetch_competitors", return_value=fetched) as mock_fetch,
+        ):
+            MockCallRepo.return_value.get_company_info.return_value = ("Apple Inc.", "Technology")
+            MockCallRepo.return_value.get_transcript_text.return_value = "transcript text"
+            MockCompRepo.return_value.get.return_value = []
+            response = api_client.get("/api/calls/AAPL/competitors")
+
+        assert response.status_code == 200
+        mock_fetch.assert_called_once()
+        data = response.json()
+        assert len(data["competitors"]) == 1
+        assert data["competitors"][0]["ticker"] == "MSFT"
+
+
+class TestGetCallNews:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/news")
+        assert response.status_code == 404
+
+    def test_returns_cached_news(self, api_client):
+        from core.models import NewsItem
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.CallRepository"),
+            patch("routes.calls.AnalysisRepository"),
+            patch("routes.calls.NewsRepository") as MockNewsRepo,
+        ):
+            MockNewsRepo.return_value.get.return_value = [
+                NewsItem(headline="Apple beats Q1", url="https://example.com", source="Reuters", date="2025-01-31", summary="Strong quarter.")
+            ]
+            response = api_client.get("/api/calls/AAPL/news")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["news_items"]) == 1
+        assert data["news_items"][0]["headline"] == "Apple beats Q1"
+
+    def test_lazy_hydration_skipped_when_call_date_none(self, api_client):
+        """When cache is empty and call_date is None, fetch_recent_news is not called."""
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.CallRepository") as MockCallRepo,
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+            patch("routes.calls.NewsRepository") as MockNewsRepo,
+            patch("routes.calls.fetch_recent_news") as mock_fetch,
+        ):
+            MockCallRepo.return_value.get_company_info.return_value = ("Apple Inc.", "Technology")
+            MockCallRepo.return_value.get_call_date.return_value = None
+            MockAnalysisRepo.return_value.get_themes_for_ticker.return_value = []
+            MockNewsRepo.return_value.get.return_value = []
+            response = api_client.get("/api/calls/AAPL/news")
+
+        assert response.status_code == 200
+        mock_fetch.assert_not_called()
+        assert response.json()["news_items"] == []


### PR DESCRIPTION
## Summary
- Slims `GET /api/calls/{ticker}` by removing topics, themes, evasion_analyses, strategic_shifts, news_items, and competitors from the core response — these were blocking page render even for collapsed sections
- Adds `get_signal_strip_flags_for_ticker()` in `db/repositories/analysis.py` using the same AVG+CASE SQL pattern as `list_calls`, so signal_strip still returns correct flags without loading full evasion rows
- Adds 5 new on-demand endpoints: `/topics`, `/evasion`, `/strategic-shifts`, `/competitors`, `/news` — the `/competitors` and `/news` endpoints preserve the existing lazy hydration logic

## Test plan
- [x] 202 tests pass (`pytest -q`)
- [ ] `GET /api/calls/AAPL` no longer includes `topics`, `evasion_analyses`, `strategic_shifts`, `news_items`, `competitors`
- [ ] `GET /api/calls/AAPL/topics` returns data that was previously in the core response
- [ ] signal_strip `evasion_level` and `strategic_shift_flagged` remain correct
- [ ] `/competitors` and `/news` lazy hydration still triggers external API on cache miss

Closes #357