### PR TITLE
feat: extend "What this signals" to themes and strategic shifts

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -805,6 +805,141 @@ def news_context(
     )
 
 
+# --- Theme signals ---
+
+_THEME_SIGNALS_SYSTEM_PROMPT = (
+    "You are a financial analyst educator. Return 2–3 numbered points, each on its own line, "
+    "explaining what this recurring theme signals about management's priorities and the company's trajectory. "
+    "Focus on what a careful investor should infer — not just what was said, but what it implies for the investment thesis."
+)
+
+
+class ThemeSignalsRequest(BaseModel):
+    label: str
+    summary: str
+
+
+def _theme_signals_sse_stream(body: ThemeSignalsRequest):
+    """Generator that streams investor-implications framing for a theme as SSE events."""
+    import json as _json
+    from services.llm import stream_investor_signals
+
+    messages = [
+        {
+            "role": "user",
+            "content": f"Theme: {body.label}\nManagement's framing: {body.summary}",
+        }
+    ]
+    logger.debug("theme_signals stream starting")
+    try:
+        has_content = False
+        for chunk in stream_investor_signals(messages, _THEME_SIGNALS_SYSTEM_PROMPT):
+            if not has_content:
+                logger.debug("theme_signals first token received")
+            has_content = True
+            yield f"data: {_json.dumps({'type': 'token', 'content': chunk})}\n\n"
+        logger.debug("theme_signals stream ended has_content=%s", has_content)
+        if has_content:
+            yield f"data: {_json.dumps({'type': 'done'})}\n\n"
+        else:
+            yield f"data: {_json.dumps({'type': 'error', 'message': 'No content received from model'})}\n\n"
+    except Exception:
+        logger.exception("Error streaming theme signals")
+        yield f"data: {_json.dumps({'type': 'error', 'message': 'Stream error'})}\n\n"
+
+
+@router.post("/{ticker}/theme-signals")
+@limiter.limit(CHAT_RATE_LIMIT)
+def theme_signals(
+    request: Request,
+    ticker: str,
+    body: ThemeSignalsRequest,
+    user_id: CurrentUserDep,
+) -> StreamingResponse:
+    """Stream investor-implications framing for a recurring theme as SSE."""
+    if not _ticker_exists(ticker):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+
+    return StreamingResponse(
+        _theme_signals_sse_stream(body),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+# --- Strategic shift signals ---
+
+_SHIFT_SIGNALS_SYSTEM_PROMPT = (
+    "You are a financial analyst educator. Return 2–3 numbered points, each on its own line, "
+    "explaining the magnitude and direction of this strategic shift and what it implies for the investment thesis. "
+    "Focus on what a careful investor should watch for: execution risk, opportunity opened, or thesis change."
+)
+
+
+class StrategicShiftSignalsRequest(BaseModel):
+    prior_position: str
+    current_position: str
+    investor_significance: str
+
+
+def _shift_signals_sse_stream(body: StrategicShiftSignalsRequest):
+    """Generator that streams investor-implications framing for a strategic shift as SSE events."""
+    import json as _json
+    from services.llm import stream_investor_signals
+
+    messages = [
+        {
+            "role": "user",
+            "content": (
+                f"Before: {body.prior_position}\n"
+                f"Now: {body.current_position}\n"
+                f"Context: {body.investor_significance}"
+            ),
+        }
+    ]
+    logger.debug("shift_signals stream starting")
+    try:
+        has_content = False
+        for chunk in stream_investor_signals(messages, _SHIFT_SIGNALS_SYSTEM_PROMPT):
+            if not has_content:
+                logger.debug("shift_signals first token received")
+            has_content = True
+            yield f"data: {_json.dumps({'type': 'token', 'content': chunk})}\n\n"
+        logger.debug("shift_signals stream ended has_content=%s", has_content)
+        if has_content:
+            yield f"data: {_json.dumps({'type': 'done'})}\n\n"
+        else:
+            yield f"data: {_json.dumps({'type': 'error', 'message': 'No content received from model'})}\n\n"
+    except Exception:
+        logger.exception("Error streaming shift signals")
+        yield f"data: {_json.dumps({'type': 'error', 'message': 'Stream error'})}\n\n"
+
+
+@router.post("/{ticker}/shift-signals")
+@limiter.limit(CHAT_RATE_LIMIT)
+def shift_signals(
+    request: Request,
+    ticker: str,
+    body: StrategicShiftSignalsRequest,
+    user_id: CurrentUserDep,
+) -> StreamingResponse:
+    """Stream investor-implications framing for a strategic shift as SSE."""
+    if not _ticker_exists(ticker):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+
+    return StreamingResponse(
+        _shift_signals_sse_stream(body),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
 # --- Section usage tracking ---
 
 class TrackEventRequest(BaseModel):

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -497,6 +497,157 @@ class TestGetCallTopics:
         assert data["themes"] == []
 
 
+class TestThemeSignals:
+    PAYLOAD = {
+        "label": "AI & Cloud",
+        "summary": "Management repeatedly emphasised AI-driven efficiency gains.",
+    }
+
+    def _parse_sse(self, text: str) -> list[dict]:
+        """Parse SSE response body into a list of event dicts."""
+        import json
+        events = []
+        for block in text.split("\n\n"):
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[len("data: "):]))
+        return events
+
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.post("/api/calls/UNKNOWN/theme-signals", json=self.PAYLOAD)
+        assert response.status_code == 404
+
+    def test_happy_path_streams_tokens_and_done(self, api_client):
+        """When stream_investor_signals yields tokens, endpoint emits token events then done."""
+        def _fake_stream(messages, system_prompt):
+            yield "This theme "
+            yield "signals intent."
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_fake_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/theme-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        token_events = [e for e in events if e["type"] == "token"]
+        assert len(token_events) == 2
+        assert token_events[0]["content"] == "This theme "
+        assert token_events[1]["content"] == "signals intent."
+        assert events[-1] == {"type": "done"}
+
+    def test_no_content_emits_error_event(self, api_client):
+        def _empty_stream(messages, system_prompt):
+            return
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_empty_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/theme-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+        assert "No content" in events[0]["message"]
+
+    def test_api_exception_emits_error_event(self, api_client):
+        def _failing_stream(messages, system_prompt):
+            raise RuntimeError("upstream API error")
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_failing_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/theme-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+
+
+class TestShiftSignals:
+    PAYLOAD = {
+        "prior_position": "Focused on hardware margins.",
+        "current_position": "Pivoting to services-led revenue mix.",
+        "investor_significance": "Services carry ~70% gross margin vs ~35% for hardware.",
+    }
+
+    def _parse_sse(self, text: str) -> list[dict]:
+        """Parse SSE response body into a list of event dicts."""
+        import json
+        events = []
+        for block in text.split("\n\n"):
+            for line in block.splitlines():
+                if line.startswith("data: "):
+                    events.append(json.loads(line[len("data: "):]))
+        return events
+
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.post("/api/calls/UNKNOWN/shift-signals", json=self.PAYLOAD)
+        assert response.status_code == 404
+
+    def test_happy_path_streams_tokens_and_done(self, api_client):
+        """When stream_investor_signals yields tokens, endpoint emits token events then done."""
+        def _fake_stream(messages, system_prompt):
+            yield "This shift "
+            yield "changes the thesis."
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_fake_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/shift-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        token_events = [e for e in events if e["type"] == "token"]
+        assert len(token_events) == 2
+        assert token_events[0]["content"] == "This shift "
+        assert token_events[1]["content"] == "changes the thesis."
+        assert events[-1] == {"type": "done"}
+
+    def test_no_content_emits_error_event(self, api_client):
+        def _empty_stream(messages, system_prompt):
+            return
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_empty_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/shift-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+        assert "No content" in events[0]["message"]
+
+    def test_api_exception_emits_error_event(self, api_client):
+        def _failing_stream(messages, system_prompt):
+            raise RuntimeError("upstream API error")
+            yield  # make it a generator
+
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("services.llm.stream_investor_signals", side_effect=_failing_stream),
+        ):
+            response = api_client.post("/api/calls/AAPL/shift-signals", json=self.PAYLOAD)
+
+        assert response.status_code == 200
+        events = self._parse_sse(response.text)
+        assert len(events) == 1
+        assert events[0]["type"] == "error"
+
+
 class TestGetCallEvasion:
     def test_404_for_unknown_ticker(self, api_client):
         with patch("routes.calls._ticker_exists", return_value=False):

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -373,7 +373,7 @@ function UnderstandTheNarrativeStep({ ticker, isOpen }: { ticker: string; isOpen
     return (
       <div className="space-y-3">
         {topics.map((topic, i) => (
-          <ThemeCard key={i} label={topic.label || `Topic ${i + 1}`} summary={topic.summary} />
+          <ThemeCard key={i} label={topic.label || `Topic ${i + 1}`} summary={topic.summary} ticker={ticker} />
         ))}
       </div>
     );
@@ -382,7 +382,7 @@ function UnderstandTheNarrativeStep({ ticker, isOpen }: { ticker: string; isOpen
   return (
     <div className="space-y-3">
       {themes.map((theme, i) => (
-        <ThemeCard key={i} label={theme} summary="" />
+        <ThemeCard key={i} label={theme} summary="" ticker={ticker} />
       ))}
     </div>
   );
@@ -483,7 +483,7 @@ function TrackWhatChangedStep({ ticker, isOpen }: { ticker: string; isOpen: bool
   return (
     <div className="space-y-3">
       {data.strategic_shifts.map((shift, i) => (
-        <StrategicShiftCard key={i} shift={shift} />
+        <StrategicShiftCard key={i} shift={shift} ticker={ticker} />
       ))}
     </div>
   );

--- a/web/components/transcript/StrategicShiftCard.tsx
+++ b/web/components/transcript/StrategicShiftCard.tsx
@@ -2,7 +2,10 @@
 
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { streamShiftSignals } from "@/lib/signals";
 import type { StrategicShift } from "./types";
 import { Card } from "@/components/ui/card";
 import {
@@ -14,10 +17,51 @@ import {
 
 interface StrategicShiftCardProps {
   shift: StrategicShift;
+  ticker: string;
 }
 
-export function StrategicShiftCard({ shift }: StrategicShiftCardProps) {
+export function StrategicShiftCard({ shift, ticker }: StrategicShiftCardProps) {
   const [investorExpanded, setInvestorExpanded] = useState(false);
+  const [signals, setSignals] = useState<string | null>(null);
+  const [loadingSignals, setLoadingSignals] = useState(false);
+  const [signalsError, setSignalsError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function handleSignalsClick() {
+    if (signals) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoadingSignals(true);
+    setSignalsError(null);
+    let accumulated = "";
+
+    await streamShiftSignals(
+      ticker,
+      {
+        prior_position: shift.prior_position,
+        current_position: shift.current_position,
+        investor_significance: shift.investor_significance,
+      },
+      {
+        onToken(token) {
+          accumulated += token;
+          setSignals(accumulated);
+        },
+        onDone() {
+          setLoadingSignals(false);
+        },
+        onError(message) {
+          if (controller.signal.aborted) return;
+          setSignalsError(message);
+          setLoadingSignals(false);
+        },
+      },
+      controller.signal
+    );
+  }
 
   return (
     <Card className="p-4 gap-3">
@@ -55,6 +99,37 @@ export function StrategicShiftCard({ shift }: StrategicShiftCardProps) {
           <p className="text-sm text-foreground/80">{shift.investor_significance}</p>
         </CollapsibleContent>
       </Collapsible>
+
+      {/* Signals section — on-demand "go deeper" action */}
+      {signals ? (
+        <div className="rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
+            📈 What this signals for investors
+          </p>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
+              ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ul>,
+              ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ol>,
+              li: ({ children }) => <li className="text-sm text-warning-foreground border-l-2 border-warning/40 pl-2">{children}</li>,
+              strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
+            }}
+          >
+            {signals}
+          </ReactMarkdown>
+        </div>
+      ) : signalsError ? (
+        <p className="text-xs text-destructive">{signalsError}</p>
+      ) : (
+        <button
+          onClick={handleSignalsClick}
+          disabled={loadingSignals}
+          className="w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
+        >
+          {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
+        </button>
+      )}
     </Card>
   );
 }

--- a/web/components/transcript/ThemeCard.tsx
+++ b/web/components/transcript/ThemeCard.tsx
@@ -1,5 +1,11 @@
-/** Renders a topic cluster as a card with a label and narrative summary. */
+"use client";
 
+/** Renders a topic cluster as a card with a label, narrative summary, and signals button. */
+
+import { useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { streamThemeSignals } from "@/lib/signals";
 import { Card } from "@/components/ui/card";
 
 interface ThemeCardProps {
@@ -7,14 +13,84 @@ interface ThemeCardProps {
   label: string;
   /** One-sentence narrative summary for this theme. */
   summary: string;
+  /** Ticker symbol, required for the signals endpoint. */
+  ticker: string;
 }
 
-export function ThemeCard({ label, summary }: ThemeCardProps) {
+export function ThemeCard({ label, summary, ticker }: ThemeCardProps) {
+  const [signals, setSignals] = useState<string | null>(null);
+  const [loadingSignals, setLoadingSignals] = useState(false);
+  const [signalsError, setSignalsError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function handleSignalsClick() {
+    if (signals) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoadingSignals(true);
+    setSignalsError(null);
+    let accumulated = "";
+
+    await streamThemeSignals(
+      ticker,
+      { label, summary },
+      {
+        onToken(token) {
+          accumulated += token;
+          setSignals(accumulated);
+        },
+        onDone() {
+          setLoadingSignals(false);
+        },
+        onError(message) {
+          if (controller.signal.aborted) return;
+          setSignalsError(message);
+          setLoadingSignals(false);
+        },
+      },
+      controller.signal
+    );
+  }
+
   return (
     <Card className="p-4 gap-2">
       <p className="text-sm font-semibold text-foreground">{label}</p>
       {summary && (
         <p className="text-sm text-muted-foreground leading-snug">{summary}</p>
+      )}
+
+      {/* Signals section */}
+      {signals ? (
+        <div className="mt-1 rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
+            📈 What this signals for investors
+          </p>
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={{
+              p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
+              ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ul>,
+              ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ol>,
+              li: ({ children }) => <li className="text-sm text-warning-foreground border-l-2 border-warning/40 pl-2">{children}</li>,
+              strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
+            }}
+          >
+            {signals}
+          </ReactMarkdown>
+        </div>
+      ) : signalsError ? (
+        <p className="mt-1 text-xs text-destructive">{signalsError}</p>
+      ) : (
+        <button
+          onClick={handleSignalsClick}
+          disabled={loadingSignals}
+          className="mt-1 w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
+        >
+          {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
+        </button>
       )}
     </Card>
   );

--- a/web/lib/signals.ts
+++ b/web/lib/signals.ts
@@ -100,6 +100,182 @@ export async function streamNewsContext(
   }
 }
 
+/** Stream a theme-signals framing for a single theme card via SSE. */
+export async function streamThemeSignals(
+  ticker: string,
+  payload: { label: string; summary: string },
+  callbacks: StreamSignalsCallbacks,
+  signal?: AbortSignal
+): Promise<void> {
+  const supabase = createSupabaseBrowserClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (session?.access_token) {
+    headers["Authorization"] = `Bearer ${session.access_token}`;
+  }
+
+  const response = await fetch(`${API_URL}/api/calls/${ticker}/theme-signals`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    callbacks.onError(`API error ${response.status}: ${text}`);
+    return;
+  }
+
+  if (!response.body) {
+    callbacks.onError("Response body is empty");
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let terminated = false;
+
+  signal?.addEventListener("abort", () => { reader.cancel().catch(() => {}); });
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (signal?.aborted) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
+
+      for (const event of events) {
+        const dataLine = event.split("\n").find((line) => line.startsWith("data: "));
+        if (!dataLine) continue;
+
+        const jsonStr = dataLine.slice("data: ".length);
+        let parsed: { type: string; content?: string; message?: string };
+        try {
+          parsed = JSON.parse(jsonStr);
+        } catch {
+          continue;
+        }
+
+        if (parsed.type === "token" && parsed.content !== undefined) {
+          callbacks.onToken(parsed.content);
+        } else if (parsed.type === "done") {
+          terminated = true;
+          callbacks.onDone();
+        } else if (parsed.type === "error") {
+          terminated = true;
+          callbacks.onError(parsed.message ?? "Unknown error");
+        }
+      }
+    }
+  } catch (err: unknown) {
+    if (!signal?.aborted) {
+      terminated = true;
+      callbacks.onError(err instanceof Error ? err.message : "Stream read error");
+    }
+  } finally {
+    if (!terminated && !signal?.aborted) {
+      callbacks.onError("Stream closed without response");
+    }
+  }
+}
+
+/** Stream a shift-signals framing for a single strategic shift card via SSE. */
+export async function streamShiftSignals(
+  ticker: string,
+  payload: { prior_position: string; current_position: string; investor_significance: string },
+  callbacks: StreamSignalsCallbacks,
+  signal?: AbortSignal
+): Promise<void> {
+  const supabase = createSupabaseBrowserClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (session?.access_token) {
+    headers["Authorization"] = `Bearer ${session.access_token}`;
+  }
+
+  const response = await fetch(`${API_URL}/api/calls/${ticker}/shift-signals`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    callbacks.onError(`API error ${response.status}: ${text}`);
+    return;
+  }
+
+  if (!response.body) {
+    callbacks.onError("Response body is empty");
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let terminated = false;
+
+  signal?.addEventListener("abort", () => { reader.cancel().catch(() => {}); });
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (signal?.aborted) break;
+
+      buffer += decoder.decode(value, { stream: true });
+
+      const events = buffer.split("\n\n");
+      buffer = events.pop() ?? "";
+
+      for (const event of events) {
+        const dataLine = event.split("\n").find((line) => line.startsWith("data: "));
+        if (!dataLine) continue;
+
+        const jsonStr = dataLine.slice("data: ".length);
+        let parsed: { type: string; content?: string; message?: string };
+        try {
+          parsed = JSON.parse(jsonStr);
+        } catch {
+          continue;
+        }
+
+        if (parsed.type === "token" && parsed.content !== undefined) {
+          callbacks.onToken(parsed.content);
+        } else if (parsed.type === "done") {
+          terminated = true;
+          callbacks.onDone();
+        } else if (parsed.type === "error") {
+          terminated = true;
+          callbacks.onError(parsed.message ?? "Unknown error");
+        }
+      }
+    }
+  } catch (err: unknown) {
+    if (!signal?.aborted) {
+      terminated = true;
+      callbacks.onError(err instanceof Error ? err.message : "Stream read error");
+    }
+  } finally {
+    if (!terminated && !signal?.aborted) {
+      callbacks.onError("Stream closed without response");
+    }
+  }
+}
+
 /** Stream an evasion-signals framing for a single evasion item via SSE. */
 export async function streamSignals(
   ticker: string,


### PR DESCRIPTION
## Summary

- Adds the "📈 What this signals for investors" streaming button to **ThemeCard** (Step 3) and **StrategicShiftCard** (Step 5), completing the interpretation scaffold across all major analysis types
- Each content type has its own tailored system prompt (themes: management priorities + trajectory; shifts: magnitude/direction + thesis change)
- StrategicShiftCard keeps the existing static "Investor significance" collapsible — the new button sits below it as an on-demand "go deeper" action

## Changes

- `POST /api/calls/{ticker}/theme-signals` — new SSE endpoint, `CHAT_RATE_LIMIT` applied
- `POST /api/calls/{ticker}/shift-signals` — new SSE endpoint, `CHAT_RATE_LIMIT` applied
- `web/lib/signals.ts` — `streamThemeSignals()` and `streamShiftSignals()` helpers
- `web/components/transcript/ThemeCard.tsx` — converted to `"use client"`, adds `ticker` prop + signals button
- `web/components/transcript/StrategicShiftCard.tsx` — adds `ticker` prop + signals button below static collapsible
- `web/components/transcript/MetadataPanel.tsx` — passes `ticker` to all three call sites

## Test plan

- [ ] 8 new unit tests pass (`TestThemeSignals`, `TestShiftSignals` — 4 each: 404, happy path, empty stream, exception)
- [ ] Full test suite green: 222 passed
- [ ] ThemeCard: click button → streaming markdown appears inline
- [ ] StrategicShiftCard: static "Investor significance" collapsible unchanged; button streams below it
- [ ] AbortController: rapid re-clicks don't stack concurrent streams

Closes #208