### PR TITLE
fix: replace hardcoded colors with semantic design tokens

### DIFF
--- a/web/app/admin/loading.tsx
+++ b/web/app/admin/loading.tsx
@@ -3,16 +3,16 @@ export default function AdminLoading() {
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
       {/* Title skeleton */}
-      <div className="mb-8 h-9 w-64 animate-pulse rounded bg-zinc-200" />
+      <div className="mb-8 h-9 w-64 animate-pulse rounded bg-muted" />
 
       {/* Stat card row skeleton */}
       <div className="mb-8 grid gap-6 sm:grid-cols-3">
         {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="rounded-lg border border-zinc-200 bg-white p-5">
-            <div className="mb-3 h-3 w-24 animate-pulse rounded bg-zinc-200" />
+          <div key={i} className="rounded-lg border border-border bg-card p-5">
+            <div className="mb-3 h-3 w-24 animate-pulse rounded bg-muted" />
             <div className="space-y-2">
               {Array.from({ length: 4 }).map((_, j) => (
-                <div key={j} className="h-4 w-full animate-pulse rounded bg-zinc-100" />
+                <div key={j} className="h-4 w-full animate-pulse rounded bg-muted" />
               ))}
             </div>
           </div>
@@ -20,13 +20,13 @@ export default function AdminLoading() {
       </div>
 
       {/* Table-like skeleton */}
-      <div className="rounded-lg border border-zinc-200 bg-white p-5">
-        <div className="mb-3 h-3 w-32 animate-pulse rounded bg-zinc-200" />
+      <div className="rounded-lg border border-border bg-card p-5">
+        <div className="mb-3 h-3 w-32 animate-pulse rounded bg-muted" />
         <div className="space-y-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="flex items-center gap-4">
-              <div className="h-4 w-24 animate-pulse rounded bg-zinc-200" />
-              <div className="h-4 flex-1 animate-pulse rounded bg-zinc-100" />
+              <div className="h-4 w-24 animate-pulse rounded bg-muted" />
+              <div className="h-4 flex-1 animate-pulse rounded bg-muted" />
             </div>
           ))}
         </div>

--- a/web/components/transcript/CallBriefPanel.tsx
+++ b/web/components/transcript/CallBriefPanel.tsx
@@ -113,7 +113,7 @@ export function CallBriefPanel({ brief, takeaways, misconceptions, signal_strip 
             <SignalBadge label="Analyst mood" value={signal_strip.analyst_sentiment} />
             <EvasionBadge level={signal_strip.evasion_level} />
             {signal_strip.strategic_shift_flagged && (
-              <span className="rounded-md px-2.5 py-1 text-xs font-medium bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400">
+              <span className="rounded-md px-2.5 py-1 text-xs font-medium bg-info/10 text-info-foreground">
                 Strategic shift flagged
               </span>
             )}


### PR DESCRIPTION
## Summary
- Fix admin loading skeleton invisible in dark mode — replaced `bg-zinc-*`/`bg-white`/`border-zinc-200` with `bg-muted`/`bg-card`/`border-border` to match the pattern in `admin/health/loading.tsx`
- Fix strategic shift badge bypassing token system — replaced hand-written `bg-violet-50 text-violet-700 dark:bg-violet-900/30 dark:text-violet-400` with `bg-info/10 text-info-foreground`

Closes #364

## Test plan
- [ ] Admin page loading skeleton visible in both light and dark mode
- [ ] "Strategic shift flagged" badge renders correctly in both themes on a call detail page with a flagged strategic shift