### PR TITLE
fix: replace raw HTML elements with shadcn components

### DIFF
--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -3,6 +3,9 @@
 /** Admin page for triggering transcript ingestion. Client component (form state). */
 
 import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
 
 type Status = "idle" | "submitting" | "accepted" | "error";
 
@@ -71,7 +74,8 @@ export default function AdminIngestPage() {
         asynchronously.
       </p>
 
-      <div className="max-w-sm rounded-lg border border-border bg-card p-6">
+      <Card className="max-w-sm">
+        <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <div>
             <label
@@ -80,24 +84,24 @@ export default function AdminIngestPage() {
             >
               Ticker symbol
             </label>
-            <input
+            <Input
               id="ticker"
               type="text"
               value={ticker}
               onChange={(e) => setTicker(e.target.value)}
               placeholder="e.g. AAPL"
               disabled={status === "submitting"}
-              className="w-full rounded-md border border-input px-3 py-2 font-mono text-sm uppercase text-foreground placeholder:normal-case placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-1 focus:ring-ring disabled:bg-muted disabled:text-muted-foreground"
+              className="font-mono uppercase placeholder:normal-case"
             />
           </div>
 
-          <button
+          <Button
             type="submit"
             disabled={status === "submitting" || !ticker.trim()}
-            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:bg-muted"
+            className="w-full"
           >
             {status === "submitting" ? "Submitting…" : "Ingest transcript"}
-          </button>
+          </Button>
         </form>
 
         {status === "accepted" && (
@@ -108,7 +112,8 @@ export default function AdminIngestPage() {
         {status === "error" && errorMessage && (
           <p className="mt-4 text-sm text-destructive">{errorMessage}</p>
         )}
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/app/auth/sign-in/page.tsx
+++ b/web/app/auth/sign-in/page.tsx
@@ -3,6 +3,8 @@
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 
 function SignInContent() {
   const searchParams = useSearchParams();
@@ -20,45 +22,47 @@ function SignInContent() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-background">
-      <div className="w-full max-w-sm rounded-xl border border-border bg-card p-8 shadow-sm">
-        <h1 className="mb-2 text-2xl font-semibold text-foreground">
-          EarningsFluency
-        </h1>
-        <p className="mb-8 text-sm text-muted-foreground">
-          Sign in to access your earnings transcript library.
-        </p>
+      <Card className="w-full max-w-sm shadow-sm">
+        <CardHeader>
+          <CardTitle className="text-2xl">EarningsFluency</CardTitle>
+          <CardDescription>
+            Sign in to access your earnings transcript library.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {error && (
+            <p className="rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              {decodeURIComponent(error)}
+            </p>
+          )}
 
-        {error && (
-          <p className="mb-4 rounded-lg bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {decodeURIComponent(error)}
-          </p>
-        )}
-
-        <button
-          onClick={signInWithGoogle}
-          className="flex w-full items-center justify-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-sm font-medium text-card-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-        >
-          <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-              fill="#4285F4"
-            />
-            <path
-              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-              fill="#34A853"
-            />
-            <path
-              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
-              fill="#FBBC05"
-            />
-            <path
-              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-              fill="#EA4335"
-            />
-          </svg>
-          Sign in with Google
-        </button>
-      </div>
+          <Button
+            variant="outline"
+            onClick={signInWithGoogle}
+            className="w-full gap-3"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Sign in with Google
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/components/ThemePicker.tsx
+++ b/web/components/ThemePicker.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 
 /** Dropdown to switch between light, dark, and system themes. */
 export function ThemePicker() {
@@ -18,8 +19,7 @@ export function ThemePicker() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        aria-label="Toggle theme"
-        className="inline-flex h-9 w-9 items-center justify-center rounded-md hover:bg-accent hover:text-accent-foreground transition-colors"
+        render={<Button variant="ghost" size="icon" aria-label="Toggle theme" />}
       >
         <Icon className="h-4 w-4" />
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary

- **admin/ingest**: `<input>` → `Input`, `<button>` → `Button`, hand-rolled `<div>` card → `Card`/`CardContent`
- **auth/sign-in**: hand-rolled card `<div>` → `Card`/`CardHeader`/`CardContent`, raw `<button>` → `Button variant="outline"`
- **ThemePicker**: bare `DropdownMenuTrigger` → composed with `Button variant="ghost" size="icon"` via Base UI `render` prop — consistent focus ring and hover states

No functional changes. Pure visual consistency fix from the UI audit (#363, Work Package 2).

## Test plan

- [ ] Visit `/admin/ingest` — card renders, input has focus ring on click, button shows correct hover/disabled states
- [ ] Visit `/auth/sign-in` — card structure correct, Google button has focus ring and hover state
- [ ] Open theme picker in header — dropdown still opens, button has hover/focus ring

Closes #365