### PR TITLE
fix: add missing loading.tsx and error.tsx route boundaries (#366)

### DIFF
--- a/web/app/calls/[ticker]/error.tsx
+++ b/web/app/calls/[ticker]/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/** Error boundary for the transcript route — shown when fetchCallDetail throws. */
+export default function TranscriptError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-8">
+      <div className="flex justify-center">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-destructive">Failed to load transcript</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">{error.message}</p>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={reset}>
+                Try again
+              </Button>
+              <Link href="/" className={buttonVariants({ variant: "ghost" })}>
+                Back to library
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/app/error.tsx
+++ b/web/app/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+/** Root error boundary — shown when a server component in the app shell throws. */
+export default function RootError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      <div className="flex justify-center">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle className="text-destructive">Something went wrong</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">{error.message}</p>
+            <Button variant="outline" onClick={reset}>
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/app/loading.tsx
+++ b/web/app/loading.tsx
@@ -1,0 +1,24 @@
+/** Shown automatically by Next.js while the home page server component loads. */
+export default function HomePageLoading() {
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      {/* Heading skeleton */}
+      <div className="mb-2 h-9 w-64 animate-pulse rounded bg-muted" />
+      <div className="mb-8 h-5 w-80 animate-pulse rounded bg-muted" />
+
+      {/* Call card grid skeleton */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="animate-pulse rounded-xl border p-6 shadow-sm bg-card">
+            <div className="flex items-start justify-between gap-4">
+              <div className="h-7 w-16 rounded bg-muted" />
+              <div className="h-4 w-24 rounded bg-muted" />
+            </div>
+            <div className="mt-2 h-4 w-40 rounded bg-muted" />
+            <div className="mt-3 h-5 w-20 rounded-full bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `web/app/loading.tsx` — route-level skeleton for the home page, matching the heading + 6-card grid layout of `LibraryPage`
- Adds `web/app/error.tsx` — root styled error boundary using `Card` + `Button` with design tokens
- Adds `web/app/calls/[ticker]/error.tsx` — transcript-specific error boundary with a "Try again" reset and "Back to library" link

## Test plan

- [ ] `cd web && npx next build` passes clean
- [ ] Navigate to `/` with network throttled — loading skeleton appears before cards load
- [ ] Break `NEXT_PUBLIC_API_URL` on the transcript page — styled error boundary renders instead of Next.js default
- [ ] "Try again" button on error boundaries calls `reset()` and re-attempts the render

Closes #366