### PR TITLE
fix: replace raw <a> tags with Next.js Link and extend BreadcrumbBar to admin routes

### DIFF
--- a/web/app/admin/health/page.tsx
+++ b/web/app/admin/health/page.tsx
@@ -78,11 +78,6 @@ export default async function AdminHealthPage() {
 
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
-      <div className="mb-6">
-        <a href="/admin/ingest" className="text-sm text-primary hover:underline">
-          ← Admin Ingest
-        </a>
-      </div>
       <h1 className="mb-8 text-3xl font-semibold text-foreground">Admin — System Health</h1>
 
       {health === null ? (

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -60,14 +60,6 @@ export default function AdminIngestPage() {
 
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
-      <div className="mb-6 flex gap-4 text-sm">
-        <a href="/admin" className="text-primary hover:underline">
-          Analytics
-        </a>
-        <a href="/admin/health" className="text-primary hover:underline">
-          System Health
-        </a>
-      </div>
       <h1 className="mb-2 text-3xl font-semibold text-foreground">Admin — Ingest</h1>
       <p className="mb-8 text-muted-foreground">
         Dispatch a ticker to the ingestion pipeline. Returns immediately — processing runs

--- a/web/app/admin/page.tsx
+++ b/web/app/admin/page.tsx
@@ -172,14 +172,6 @@ export default async function AdminAnalyticsPage() {
 
   return (
     <div className="mx-auto w-full max-w-7xl px-6 py-12">
-      <div className="mb-6 flex gap-4 text-sm">
-        <a href="/admin/health" className="text-primary hover:underline">
-          System Health
-        </a>
-        <a href="/admin/ingest" className="text-primary hover:underline">
-          Ingest
-        </a>
-      </div>
       <h1 className="mb-8 text-3xl font-semibold text-foreground">Admin — Analytics</h1>
 
       <div className="grid gap-6 lg:grid-cols-2">

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 import SignOutButton from "./SignOutButton";
@@ -63,34 +64,34 @@ export default async function RootLayout({
             <>
               <nav className="border-b bg-card">
                 <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
-                  <a
+                  <Link
                     href="/"
                     className="text-lg font-semibold text-foreground hover:text-foreground/80"
                   >
                     EarningsFluency
-                  </a>
+                  </Link>
                   <div className="flex items-center gap-4">
                     {/* Desktop admin links */}
                     {isAdmin && (
                       <div className="hidden items-center gap-4 md:flex">
-                        <a
+                        <Link
                           href="/admin"
                           className="text-sm text-muted-foreground hover:text-foreground"
                         >
                           Admin Analytics
-                        </a>
-                        <a
+                        </Link>
+                        <Link
                           href="/admin/health"
                           className="text-sm text-muted-foreground hover:text-foreground"
                         >
                           Admin Health
-                        </a>
-                        <a
+                        </Link>
+                        <Link
                           href="/admin/ingest"
                           className="text-sm text-muted-foreground hover:text-foreground"
                         >
                           Admin Ingest
-                        </a>
+                        </Link>
                       </div>
                     )}
                     <span className="text-sm text-muted-foreground">{user.email}</span>
@@ -113,24 +114,24 @@ export default async function RootLayout({
                               <SheetTitle>Menu</SheetTitle>
                             </SheetHeader>
                             <nav className="flex flex-col gap-1 px-4 pb-4">
-                              <a
+                              <Link
                                 href="/admin"
                                 className="py-2 text-sm text-muted-foreground hover:text-foreground"
                               >
                                 Admin Analytics
-                              </a>
-                              <a
+                              </Link>
+                              <Link
                                 href="/admin/health"
                                 className="py-2 text-sm text-muted-foreground hover:text-foreground"
                               >
                                 Admin Health
-                              </a>
-                              <a
+                              </Link>
+                              <Link
                                 href="/admin/ingest"
                                 className="py-2 text-sm text-muted-foreground hover:text-foreground"
                               >
                                 Admin Ingest
-                              </a>
+                              </Link>
                             </nav>
                           </SheetContent>
                         </Sheet>

--- a/web/components/BreadcrumbBar.tsx
+++ b/web/components/BreadcrumbBar.tsx
@@ -62,5 +62,58 @@ export function BreadcrumbBar() {
     )
   }
 
+  // /admin/health
+  if (path === "/admin/health") {
+    return (
+      <div className="border-b px-6 py-2">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink render={<Link href="/admin" />}>Admin</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>System Health</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+    )
+  }
+
+  // /admin/ingest
+  if (path === "/admin/ingest") {
+    return (
+      <div className="border-b px-6 py-2">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink render={<Link href="/admin" />}>Admin</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Ingest</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+    )
+  }
+
+  // /admin
+  if (path === "/admin") {
+    return (
+      <div className="border-b px-6 py-2">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbPage>Admin</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+    )
+  }
+
   return null
 }


### PR DESCRIPTION
## Summary

- Replace all raw `<a href>` with Next.js `<Link href>` in `layout.tsx` and all admin pages — eliminates full-page reloads on admin navigation
- Extend `BreadcrumbBar` to handle `/admin`, `/admin/health`, and `/admin/ingest` routes
- Remove redundant inline link strips from each admin page (breadcrumb bar now provides consistent navigation)

## Test plan

- [ ] Navigate between admin pages — no full-page reload (no flash), breadcrumbs visible in bar
- [ ] Breadcrumb shows: `Admin` on `/admin`, `Admin > System Health` on `/admin/health`, `Admin > Ingest` on `/admin/ingest`
- [ ] Logo link in navbar uses client-side navigation
- [ ] Mobile hamburger menu links also navigate without reload

Closes #367