### PR TITLE
refactor: extract SignalsSection and consolidate badge rendering (#368)

### DIFF
--- a/web/components/CallCard.tsx
+++ b/web/components/CallCard.tsx
@@ -51,17 +51,17 @@ export function CallCard({ call }: CallCardProps) {
             {call.overall_sentiment && (() => {
               const s = getSentimentStyle(call.overall_sentiment);
               return (
-                <span className={`inline-block rounded-md px-2.5 py-1 text-xs ${s.bg} ${s.text}`}>
+                <Badge className={`rounded-md ${s.bg} ${s.text}`}>
                   {call.overall_sentiment}
-                </span>
+                </Badge>
               );
             })()}
             {call.evasion_level && (() => {
               const s = getEvasionStyle(call.evasion_level);
               return (
-                <span className={`inline-block rounded-md px-2.5 py-1 text-xs ${s.bg} ${s.text}`}>
+                <Badge className={`rounded-md ${s.bg} ${s.text}`}>
                   {call.evasion_level} evasion
-                </span>
+                </Badge>
               );
             })()}
           </div>

--- a/web/components/transcript/CallBriefPanel.tsx
+++ b/web/components/transcript/CallBriefPanel.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import type { CallBrief, TakeawayItem, MisconceptionItem, SignalStrip } from "./types";
 import { MisconceptionCard } from "./MisconceptionCard";
 import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { getEvasionStyle, getSentimentStyle } from "@/lib/signal-colors";
 
 interface CallBriefPanelProps {
@@ -25,9 +26,9 @@ function SignalBadge({ label, value }: SignalBadgeProps) {
   if (!value) return null;
   const s = getSentimentStyle(value);
   return (
-    <span className={`rounded-md px-2.5 py-1 text-xs font-medium ${s.bg} ${s.text}`}>
+    <Badge className={`rounded-md ${s.bg} ${s.text}`}>
       {label}: {value}
-    </span>
+    </Badge>
   );
 }
 
@@ -39,9 +40,9 @@ function EvasionBadge({ level }: EvasionBadgeProps) {
   if (!level) return null;
   const s = getEvasionStyle(level);
   return (
-    <span className={`rounded-md px-2.5 py-1 text-xs font-medium ${s.bg} ${s.text}`}>
+    <Badge className={`rounded-md ${s.bg} ${s.text}`}>
       Evasion: {level}
-    </span>
+    </Badge>
   );
 }
 
@@ -113,9 +114,9 @@ export function CallBriefPanel({ brief, takeaways, misconceptions, signal_strip 
             <SignalBadge label="Analyst mood" value={signal_strip.analyst_sentiment} />
             <EvasionBadge level={signal_strip.evasion_level} />
             {signal_strip.strategic_shift_flagged && (
-              <span className="rounded-md px-2.5 py-1 text-xs font-medium bg-info/10 text-info-foreground">
+              <Badge className="rounded-md bg-info/10 text-info-foreground">
                 Strategic shift flagged
-              </span>
+              </Badge>
             )}
           </div>
         )}

--- a/web/components/transcript/CompetitorList.tsx
+++ b/web/components/transcript/CompetitorList.tsx
@@ -1,6 +1,7 @@
 /** Renders a split list of competitors: mentioned in call vs. other. */
 
 import type { Competitor } from "./types";
+import { Badge } from "@/components/ui/badge";
 
 interface CompetitorListProps {
   competitors: Competitor[];
@@ -13,9 +14,9 @@ function CompetitorItem({ competitor }: { competitor: Competitor }) {
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-sm font-medium text-foreground">{competitor.name}</span>
           {competitor.ticker && (
-            <span className="inline-flex rounded px-1.5 py-0.5 text-xs font-mono font-semibold bg-muted text-muted-foreground">
+            <Badge variant="secondary" className="rounded font-mono">
               {competitor.ticker}
-            </span>
+            </Badge>
           )}
         </div>
         {competitor.description && (

--- a/web/components/transcript/EvasionCard.tsx
+++ b/web/components/transcript/EvasionCard.tsx
@@ -3,8 +3,6 @@
 /** Reveal-card for a single evasion item. Curiosity-first pattern. */
 
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { streamSignals } from "@/lib/signals";
 import type { EvasionItem } from "./types";
 import {
@@ -14,6 +12,7 @@ import {
   CollapsibleChevron,
 } from "@/components/ui/collapsible";
 import { getEvasionStyle, evasionScoreToLevel } from "@/lib/signal-colors";
+import { SignalsSection } from "./SignalsSection";
 
 interface EvasionCardProps {
   item: EvasionItem;
@@ -92,36 +91,13 @@ export function EvasionCard({ item, ticker }: EvasionCardProps) {
       <CollapsibleContent className="px-4 pb-4 pt-1 border-t">
         <p className="text-sm text-foreground/80">{item.evasion_explanation}</p>
 
-        {/* Signals section */}
-        {signals ? (
-          <div className="mt-3 rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
-              📈 What this signals for investors
-            </p>
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              components={{
-                p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
-                ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ul>,
-                ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ol>,
-                li: ({ children }) => <li className="text-sm text-warning-foreground border-l-2 border-warning/40 pl-2">{children}</li>,
-                strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
-              }}
-            >
-              {signals}
-            </ReactMarkdown>
-          </div>
-        ) : signalsError ? (
-          <p className="mt-3 text-xs text-destructive">{signalsError}</p>
-        ) : (
-          <button
-            onClick={handleSignalsClick}
-            disabled={loadingSignals}
-            className="mt-3 w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
-          >
-            {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
-          </button>
-        )}
+        <SignalsSection
+          signals={signals}
+          loading={loadingSignals}
+          error={signalsError}
+          onFetch={handleSignalsClick}
+          topMargin="mt-3"
+        />
       </CollapsibleContent>
     </Collapsible>
   );

--- a/web/components/transcript/MetadataPanel.tsx
+++ b/web/components/transcript/MetadataPanel.tsx
@@ -21,6 +21,7 @@ import { StrategicShiftCard } from "./StrategicShiftCard";
 import { NewsCard } from "./NewsCard";
 import { CompetitorList } from "./CompetitorList";
 import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/EmptyState";
 import {
   Collapsible,
@@ -426,9 +427,9 @@ function NoticeWhatWasAvoidedStep({
       {evasionLevel && (() => {
         const style = getEvasionStyle(evasionLevel);
         return (
-          <div className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-semibold ${style.bg} ${style.text}`}>
+          <Badge className={`rounded-full gap-1 ${style.bg} ${style.text}`}>
             {style.emoji} Evasion index: {evasionLevel}
-          </div>
+          </Badge>
         );
       })()}
 

--- a/web/components/transcript/NewsCard.tsx
+++ b/web/components/transcript/NewsCard.tsx
@@ -3,10 +3,9 @@
 /** Card for a single news item with a streaming "Why does this matter?" explainer. */
 
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { streamNewsContext } from "@/lib/signals";
 import type { NewsItem } from "./types";
+import { SignalsSection } from "./SignalsSection";
 
 interface NewsCardProps {
   item: NewsItem;
@@ -72,33 +71,15 @@ export function NewsCard({ item, ticker }: NewsCardProps) {
         </p>
       </div>
 
-      {context ? (
-        <div className="rounded-md bg-muted/50 border px-3 py-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-1">
-            Why this matters for this call
-          </p>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => (
-                <p className="text-sm text-foreground/80 mb-1 last:mb-0">{children}</p>
-              ),
-            }}
-          >
-            {context}
-          </ReactMarkdown>
-        </div>
-      ) : error ? (
-        <p className="text-xs text-destructive">{error}</p>
-      ) : (
-        <button
-          onClick={handleContextClick}
-          disabled={loading}
-          className="w-full rounded-md border bg-muted/30 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-muted/60 transition-colors disabled:opacity-50"
-        >
-          {loading ? "Analysing…" : "Why does this matter for this call?"}
-        </button>
-      )}
+      <SignalsSection
+        signals={context}
+        loading={loading}
+        error={error}
+        onFetch={handleContextClick}
+        label="Why does this matter for this call?"
+        variant="muted"
+        topMargin=""
+      />
     </div>
   );
 }

--- a/web/components/transcript/SignalsSection.tsx
+++ b/web/components/transcript/SignalsSection.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+/** Shared "What this signals" section — three-state: content / error / fetch button. */
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+interface SignalsSectionProps {
+  /** Markdown content once loaded, or null if not yet fetched. */
+  signals: string | null;
+  /** Whether the stream is currently loading. */
+  loading: boolean;
+  /** Error message if the stream failed. */
+  error: string | null;
+  /** Called when the user clicks the fetch button. */
+  onFetch: () => void;
+  /** Button and heading label text. */
+  label?: string;
+  /** Color variant: "warning" uses amber tones; "muted" uses neutral tones. */
+  variant?: "warning" | "muted";
+  /** Extra top margin class — defaults to "mt-1" for inline use, "mt-3" for collapsible use. */
+  topMargin?: string;
+}
+
+const WARNING_STYLES = {
+  box: "bg-warning/10 border-warning/30",
+  heading: "text-warning-foreground",
+  text: "text-warning-foreground",
+  border: "border-warning/40",
+  button: "border-warning/30 bg-warning/10 text-warning-foreground hover:bg-warning/20",
+};
+
+const MUTED_STYLES = {
+  box: "bg-muted/50 border",
+  heading: "text-muted-foreground",
+  text: "text-foreground/80",
+  border: "border-muted",
+  button: "border bg-muted/30 text-muted-foreground hover:bg-muted/60",
+};
+
+export function SignalsSection({
+  signals,
+  loading,
+  error,
+  onFetch,
+  label = "📈 What this signals for investors",
+  variant = "warning",
+  topMargin = "mt-1",
+}: SignalsSectionProps) {
+  const s = variant === "muted" ? MUTED_STYLES : WARNING_STYLES;
+
+  if (signals) {
+    return (
+      <div className={`${topMargin} rounded-md ${s.box} border px-3 py-2`}>
+        <p className={`text-xs font-semibold uppercase tracking-wide ${s.heading} mb-1`}>
+          {label}
+        </p>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            p: ({ children }) => (
+              <p className={`text-sm ${s.text} mb-1 last:mb-0`}>{children}</p>
+            ),
+            ul: ({ children }) => (
+              <ul className={`list-disc list-inside text-sm ${s.text} space-y-2 mb-1`}>
+                {children}
+              </ul>
+            ),
+            ol: ({ children }) => (
+              <ol className={`list-decimal list-inside text-sm ${s.text} space-y-2 mb-1`}>
+                {children}
+              </ol>
+            ),
+            li: ({ children }) => (
+              <li className={`text-sm ${s.text} border-l-2 ${s.border} pl-2`}>{children}</li>
+            ),
+            strong: ({ children }) => (
+              <strong className={`font-semibold ${s.text}`}>{children}</strong>
+            ),
+          }}
+        >
+          {signals}
+        </ReactMarkdown>
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className={`${topMargin} text-xs text-destructive`}>{error}</p>;
+  }
+
+  return (
+    <button
+      onClick={onFetch}
+      disabled={loading}
+      className={`${topMargin} w-full rounded-md border ${s.button} px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50`}
+    >
+      {loading ? "Analysing…" : label}
+    </button>
+  );
+}

--- a/web/components/transcript/StrategicShiftCard.tsx
+++ b/web/components/transcript/StrategicShiftCard.tsx
@@ -3,8 +3,6 @@
 "use client";
 
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { streamShiftSignals } from "@/lib/signals";
 import type { StrategicShift } from "./types";
 import { Card } from "@/components/ui/card";
@@ -14,6 +12,7 @@ import {
   CollapsibleContent,
   CollapsibleChevron,
 } from "@/components/ui/collapsible";
+import { SignalsSection } from "./SignalsSection";
 
 interface StrategicShiftCardProps {
   shift: StrategicShift;
@@ -100,36 +99,13 @@ export function StrategicShiftCard({ shift, ticker }: StrategicShiftCardProps) {
         </CollapsibleContent>
       </Collapsible>
 
-      {/* Signals section — on-demand "go deeper" action */}
-      {signals ? (
-        <div className="rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
-            📈 What this signals for investors
-          </p>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
-              ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ul>,
-              ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ol>,
-              li: ({ children }) => <li className="text-sm text-warning-foreground border-l-2 border-warning/40 pl-2">{children}</li>,
-              strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
-            }}
-          >
-            {signals}
-          </ReactMarkdown>
-        </div>
-      ) : signalsError ? (
-        <p className="text-xs text-destructive">{signalsError}</p>
-      ) : (
-        <button
-          onClick={handleSignalsClick}
-          disabled={loadingSignals}
-          className="w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
-        >
-          {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
-        </button>
-      )}
+      <SignalsSection
+        signals={signals}
+        loading={loadingSignals}
+        error={signalsError}
+        onFetch={handleSignalsClick}
+        topMargin=""
+      />
     </Card>
   );
 }

--- a/web/components/transcript/ThemeCard.tsx
+++ b/web/components/transcript/ThemeCard.tsx
@@ -3,10 +3,9 @@
 /** Renders a topic cluster as a card with a label, narrative summary, and signals button. */
 
 import { useRef, useState } from "react";
-import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { streamThemeSignals } from "@/lib/signals";
 import { Card } from "@/components/ui/card";
+import { SignalsSection } from "./SignalsSection";
 
 interface ThemeCardProps {
   /** The theme label (topic name). */
@@ -62,36 +61,12 @@ export function ThemeCard({ label, summary, ticker }: ThemeCardProps) {
         <p className="text-sm text-muted-foreground leading-snug">{summary}</p>
       )}
 
-      {/* Signals section */}
-      {signals ? (
-        <div className="mt-1 rounded-md bg-warning/10 border border-warning/30 px-3 py-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-warning-foreground mb-1">
-            📈 What this signals for investors
-          </p>
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              p: ({ children }) => <p className="text-sm text-warning-foreground mb-1 last:mb-0">{children}</p>,
-              ul: ({ children }) => <ul className="list-disc list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ul>,
-              ol: ({ children }) => <ol className="list-decimal list-inside text-sm text-warning-foreground space-y-2 mb-1">{children}</ol>,
-              li: ({ children }) => <li className="text-sm text-warning-foreground border-l-2 border-warning/40 pl-2">{children}</li>,
-              strong: ({ children }) => <strong className="font-semibold text-warning-foreground">{children}</strong>,
-            }}
-          >
-            {signals}
-          </ReactMarkdown>
-        </div>
-      ) : signalsError ? (
-        <p className="mt-1 text-xs text-destructive">{signalsError}</p>
-      ) : (
-        <button
-          onClick={handleSignalsClick}
-          disabled={loadingSignals}
-          className="mt-1 w-full rounded-md border border-warning/30 bg-warning/10 px-3 py-1.5 text-xs font-medium text-warning-foreground hover:bg-warning/20 transition-colors disabled:opacity-50"
-        >
-          {loadingSignals ? "Analysing…" : "📈 What this signals for investors"}
-        </button>
-      )}
+      <SignalsSection
+        signals={signals}
+        loading={loadingSignals}
+        error={signalsError}
+        onFetch={handleSignalsClick}
+      />
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts a shared `SignalsSection` component from the copy-pasted three-state signals UI block (content / error / fetch button + ReactMarkdown renderer) that existed identically in `ThemeCard`, `EvasionCard`, `StrategicShiftCard`, and `NewsCard`
- `SignalsSection` accepts a `variant` prop (`"warning"` | `"muted"`) to switch between amber warning tones and neutral muted tones (used by `NewsCard`)
- Replaces six hand-rolled badge `<span>` elements with the existing `Badge` component, passing `signal-colors.ts` bg+text classes via `className`

## Files changed

- **New:** `web/components/transcript/SignalsSection.tsx`
- **Modified (signals extraction):** `ThemeCard`, `EvasionCard`, `StrategicShiftCard`, `NewsCard`
- **Modified (badge consolidation):** `CallCard`, `CallBriefPanel`, `MetadataPanel`, `CompetitorList`

## Test plan

- [ ] `npm run build` passes with no type errors ✅
- [ ] Call detail page: theme/evasion/shift cards show "📈 What this signals for investors" button with amber styling
- [ ] Streaming response renders correctly in each card type
- [ ] News cards show "Why does this matter for this call?" button with neutral muted styling
- [ ] Signal badges in `CallBriefPanel` and `MetadataPanel` look visually identical to before
- [ ] Sentiment/evasion badges on `CallCard` list unchanged
- [ ] Competitor ticker chips unchanged

Closes #368