### PR TITLE
fix: replace raw button elements with shadcn Button for a11y and consistency

### DIFF
--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -103,7 +103,7 @@ export default function LearnPage({
       <div className="mb-6 flex items-center justify-between">
         <div className="flex items-baseline gap-3">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            <h1 className="text-3xl font-semibold text-foreground">
               Learn:{" "}
               <span className="uppercase">{upperTicker}</span>
             </h1>

--- a/web/components/chat/ChatThread.tsx
+++ b/web/components/chat/ChatThread.tsx
@@ -63,15 +63,16 @@ export function ChatThread({ messages, streamingContent, suggestions, loadingSug
         ) : suggestions && suggestions.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full max-w-lg">
             {suggestions.map((suggestion) => (
-              <button
+              <Button
                 key={suggestion}
+                variant="outline"
                 onClick={() => handleSuggestionClick(suggestion)}
-                className={`rounded-lg border bg-card text-card-foreground px-4 py-3 text-sm text-left hover:bg-accent hover:text-accent-foreground active:scale-[0.98] transition-all duration-200 ${
+                className={`h-auto whitespace-normal px-4 py-3 text-left active:scale-[0.98] ${
                   fadingOut === suggestion ? "opacity-0 scale-95" : ""
                 }`}
               >
                 {suggestion}
-              </button>
+              </Button>
             ))}
           </div>
         ) : null}
@@ -95,12 +96,13 @@ export function ChatThread({ messages, streamingContent, suggestions, loadingSug
         <div ref={bottomRef} />
       </div>
       {streamingContent && !isNearBottom && (
-        <button
+        <Button
+          size="sm"
           onClick={scrollToBottom}
-          className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-primary px-3 py-1 text-xs text-primary-foreground shadow-md hover:bg-primary/90 transition-colors"
+          className="absolute bottom-2 left-1/2 -translate-x-1/2 rounded-full shadow-md"
         >
           ↓ New messages
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/web/components/transcript/CallBriefPanel.tsx
+++ b/web/components/transcript/CallBriefPanel.tsx
@@ -8,6 +8,7 @@ import { MisconceptionCard } from "./MisconceptionCard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { getEvasionStyle, getSentimentStyle } from "@/lib/signal-colors";
+import { Button } from "@/components/ui/button";
 
 interface CallBriefPanelProps {
   brief: CallBrief;
@@ -129,12 +130,14 @@ export function CallBriefPanel({ brief, takeaways, misconceptions, signal_strip 
                 Common Misreadings
               </p>
               {misconceptions.length >= 2 && (
-                <button
+                <Button
+                  variant="ghost"
+                  size="xs"
                   onClick={() => setAllExpanded((prev) => !prev)}
-                  className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline"
+                  className="text-muted-foreground"
                 >
                   {allExpanded ? "Collapse all" : "Expand all"}
-                </button>
+                </Button>
               )}
             </div>
             <div className="space-y-2">

--- a/web/components/transcript/KeywordList.tsx
+++ b/web/components/transcript/KeywordList.tsx
@@ -4,6 +4,7 @@
 
 import { useState, useRef } from "react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
 import { lookupTerm } from "@/lib/glossary";
 import { streamDefine } from "@/lib/define";
 
@@ -50,12 +51,14 @@ function KeywordDefContent({ term, ticker }: KeywordDefContentProps) {
       <div>
         <p className="text-xs text-muted-foreground mb-2">Not in the static glossary.</p>
         {ticker && (
-          <button
+          <Button
+            variant="link"
+            size="xs"
             onClick={handleDefine}
-            className="text-xs text-foreground underline underline-offset-2 hover:no-underline"
+            className="text-foreground"
           >
             Define with AI
-          </button>
+          </Button>
         )}
       </div>
     );

--- a/web/components/transcript/SignalsSection.tsx
+++ b/web/components/transcript/SignalsSection.tsx
@@ -3,6 +3,7 @@
 /** Shared "What this signals" section — three-state: content / error / fetch button. */
 
 import ReactMarkdown from "react-markdown";
+import { Button } from "@/components/ui/button";
 import remarkGfm from "remark-gfm";
 
 interface SignalsSectionProps {
@@ -90,12 +91,14 @@ export function SignalsSection({
   }
 
   return (
-    <button
+    <Button
+      variant="outline"
+      size="sm"
       onClick={onFetch}
       disabled={loading}
-      className={`${topMargin} w-full rounded-md border ${s.button} px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50`}
+      className={`${topMargin} w-full ${s.button}`}
     >
       {loading ? "Analysing…" : label}
-    </button>
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces all 5 raw `<button>` elements with the shadcn `Button` component, gaining `focus-visible:ring-3 focus-visible:ring-ring/50` and consistent disabled/hover states
- Fixes page heading typography on the learn page to match the standard `text-3xl font-semibold text-foreground` used everywhere else

| Location | Replacement |
|----------|-------------|
| `SignalsSection.tsx` | `Button variant="outline" size="sm"` |
| `ChatThread.tsx` suggestion chips | `Button variant="outline"` |
| `ChatThread.tsx` scroll pill | `Button size="sm"` |
| `KeywordList.tsx` "Define with AI" | `Button variant="link" size="xs"` |
| `CallBriefPanel.tsx` "Expand/Collapse all" | `Button variant="ghost" size="xs"` |
| `learn/page.tsx` h1 | `text-3xl font-semibold text-foreground` |

Part of UI Consistency milestone (#363), Work Package 7.

## Test plan

- [ ] Tab through signal card buttons — focus ring visible
- [ ] Tab through chat suggestion chips — focus ring visible
- [ ] Tab through "Define with AI" and "Expand/Collapse all" — focus ring visible
- [ ] Scroll button appears during streaming and is keyboard-accessible
- [ ] `/calls/TICKER/learn` h1 matches size/weight of other page headings
- [ ] Build passes: `cd web && npx next build`

Closes #370