### PR TITLE
feat: feature flag provider abstraction and Supabase schema (#378)

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -3,12 +3,15 @@
 import logging
 import os
 from collections.abc import Generator
-from typing import Annotated
+from typing import Annotated, TYPE_CHECKING
 
 import jwt
 import psycopg
 from jwt import PyJWKClient
 from fastapi import Depends, Header, HTTPException, status
+
+if TYPE_CHECKING:
+    from flags.provider import FeatureFlagProvider
 
 logger = logging.getLogger(__name__)
 
@@ -117,3 +120,13 @@ def require_admin(user_id: CurrentUserDep, conn: DbDep) -> str:
 
 
 RequireAdminDep = Annotated[str, Depends(require_admin)]
+
+
+def get_flag_provider() -> "FeatureFlagProvider":
+    """Return the module-level feature flag provider singleton."""
+    from flags import get_flag_provider as _get_flag_provider
+
+    return _get_flag_provider()
+
+
+FlagsDep = Annotated["FeatureFlagProvider", Depends(get_flag_provider)]

--- a/api/flags/__init__.py
+++ b/api/flags/__init__.py
@@ -1,0 +1,16 @@
+"""Feature flag system — provider protocol and singleton factory."""
+
+from flags.provider import FeatureFlagProvider
+from flags.supabase_provider import SupabaseFlagProvider
+
+__all__ = ["FeatureFlagProvider", "SupabaseFlagProvider", "get_flag_provider"]
+
+_provider: SupabaseFlagProvider | None = None
+
+
+def get_flag_provider() -> FeatureFlagProvider:
+    """Return the module-level SupabaseFlagProvider, creating it on first call."""
+    global _provider
+    if _provider is None:
+        _provider = SupabaseFlagProvider()
+    return _provider

--- a/api/flags/provider.py
+++ b/api/flags/provider.py
@@ -1,0 +1,20 @@
+"""FeatureFlagProvider protocol — the interface all providers must implement."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class FeatureFlagProvider(Protocol):
+    """Protocol for checking feature flag state."""
+
+    def is_enabled(self, key: str, *, default: bool = False) -> bool:
+        """Return the flag's enabled state, or default if the key is not found."""
+        ...
+
+    def get_all(self) -> dict[str, bool]:
+        """Return all flags as a {key: enabled} dict."""
+        ...
+
+    def invalidate_cache(self) -> None:
+        """Invalidate the in-memory cache so the next call reloads from storage."""
+        ...

--- a/api/flags/supabase_provider.py
+++ b/api/flags/supabase_provider.py
@@ -1,0 +1,99 @@
+"""SupabaseFlagProvider — TTL-cached feature flag provider backed by a Postgres table."""
+
+import logging
+import os
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import psycopg
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+_TTL = 30.0  # seconds before the in-memory cache is refreshed
+
+
+class SupabaseFlagProvider:
+    """Thread-safe, TTL-cached feature flag provider reading from the feature_flags table.
+
+    On cache miss or TTL expiry, all flags are loaded in a single query.
+    If the DB is unavailable and a stale cache exists, the stale data is served.
+    """
+
+    _TTL = _TTL
+
+    def __init__(self) -> None:
+        """Initialise with an empty cache."""
+        self._cache: dict[str, bool] | None = None
+        self._cache_loaded_at: float | None = None
+        self._lock = threading.Lock()
+
+    def is_enabled(self, key: str, *, default: bool = False) -> bool:
+        """Return the flag's enabled state, or default if the key is not found."""
+        self._maybe_refresh()
+        assert self._cache is not None
+        return self._cache.get(key, default)
+
+    def get_all(self) -> dict[str, bool]:
+        """Return a copy of all flags as a {key: enabled} dict."""
+        self._maybe_refresh()
+        assert self._cache is not None
+        return dict(self._cache)
+
+    def invalidate_cache(self) -> None:
+        """Force the next call to reload from the database."""
+        with self._lock:
+            self._cache = None
+            self._cache_loaded_at = None
+
+    def _maybe_refresh(self) -> None:
+        """Reload the cache if it is absent or expired."""
+        with self._lock:
+            if self._cache is None or self._is_expired():
+                self._load_cache()
+
+    def _is_expired(self) -> bool:
+        """Return True if the cache TTL has elapsed."""
+        return self._cache_loaded_at is None or (
+            time.monotonic() - self._cache_loaded_at > self._TTL
+        )
+
+    def _load_cache(self) -> None:
+        """Query the feature_flags table and populate the in-memory cache.
+
+        Serves stale data on DB error if a previous cache exists.
+        Raises the original exception if there is no cache to fall back to.
+        """
+        try:
+            rows = self._fetch_rows()
+            self._cache = {key: enabled for key, enabled in rows}
+            self._cache_loaded_at = time.monotonic()
+        except Exception:
+            if self._cache is not None:
+                logger.warning(
+                    "feature_flags DB refresh failed — serving stale cache", exc_info=True
+                )
+            else:
+                raise
+
+    def _fetch_rows(self) -> list[tuple[str, bool]]:
+        """Fetch all rows from the feature_flags table."""
+        from dependencies import _pool  # avoid circular import at module load
+
+        if _pool is not None:
+            with _pool.connection() as conn:
+                return conn.execute(
+                    "SELECT key, enabled FROM public.feature_flags"
+                ).fetchall()
+        else:
+            database_url = os.environ["DATABASE_URL"]
+            conn = psycopg.connect(database_url)
+            try:
+                return conn.execute(
+                    "SELECT key, enabled FROM public.feature_flags"
+                ).fetchall()
+            finally:
+                conn.close()

--- a/supabase/migrations/20260406000000_feature_flags.sql
+++ b/supabase/migrations/20260406000000_feature_flags.sql
@@ -1,0 +1,36 @@
+-- Feature flags table for operational kill switches and feature gates.
+-- No RLS policies: only the service role (backend API) can read/write.
+
+CREATE TABLE IF NOT EXISTS public.feature_flags (
+    key         TEXT PRIMARY KEY,
+    enabled     BOOLEAN NOT NULL DEFAULT FALSE,
+    description TEXT NOT NULL DEFAULT '',
+    category    TEXT NOT NULL DEFAULT 'feature'
+                    CHECK (category IN ('feature', 'kill_switch', 'experiment')),
+    metadata    JSONB NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.feature_flags ENABLE ROW LEVEL SECURITY;
+
+-- Auto-update updated_at on every row modification.
+CREATE OR REPLACE FUNCTION public.feature_flags_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER feature_flags_updated_at
+    BEFORE UPDATE ON public.feature_flags
+    FOR EACH ROW EXECUTE FUNCTION public.feature_flags_set_updated_at();
+
+-- Seed kill switches (default enabled=true so the system works without intervention).
+INSERT INTO public.feature_flags (key, enabled, description, category) VALUES
+    ('chat_enabled',       TRUE, 'Kill switch for the Feynman learning chat feature', 'kill_switch'),
+    ('ingestion_enabled',  TRUE, 'Kill switch for the admin transcript ingestion pipeline', 'kill_switch')
+ON CONFLICT (key) DO NOTHING;

--- a/tests/unit/api/test_flag_provider.py
+++ b/tests/unit/api/test_flag_provider.py
@@ -1,0 +1,259 @@
+"""Unit tests for the FeatureFlagProvider (SupabaseFlagProvider)."""
+
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+API_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../api"))
+if API_DIR not in sys.path:
+    sys.path.insert(0, API_DIR)
+
+
+def _make_mock_conn(rows: list[tuple]) -> MagicMock:
+    """Return a mock psycopg connection returning the given rows from fetchall()."""
+    mock_conn = MagicMock()
+    mock_conn.execute.return_value.fetchall.return_value = rows
+    return mock_conn
+
+
+def _make_pool(rows: list[tuple]) -> MagicMock:
+    """Return a mock pool whose connection() context manager yields a conn with given rows."""
+    mock_conn = _make_mock_conn(rows)
+    mock_pool = MagicMock()
+    mock_pool.connection.return_value.__enter__ = MagicMock(return_value=mock_conn)
+    mock_pool.connection.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_pool
+
+
+@pytest.fixture(autouse=True)
+def fresh_provider():
+    """Import a fresh SupabaseFlagProvider for each test."""
+    # Remove cached module so singleton state doesn't bleed between tests
+    for mod in list(sys.modules.keys()):
+        if "flags" in mod:
+            del sys.modules[mod]
+    yield
+    for mod in list(sys.modules.keys()):
+        if "flags" in mod:
+            del sys.modules[mod]
+
+
+def _make_provider(rows: list[tuple], use_pool: bool = True):
+    """Create a SupabaseFlagProvider with a mocked pool or connection."""
+    from flags.supabase_provider import SupabaseFlagProvider
+
+    provider = SupabaseFlagProvider()
+    if use_pool:
+        import dependencies
+        dependencies._pool = _make_pool(rows)
+    else:
+        import dependencies
+        dependencies._pool = None
+    return provider
+
+
+# --- Cache loading ---
+
+def test_get_all_loads_from_db():
+    """get_all() returns all flags as a {key: bool} dict."""
+    rows = [("chat_enabled", True), ("ingestion_enabled", True), ("beta_feature", False)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        result = provider.get_all()
+    assert result == {"chat_enabled": True, "ingestion_enabled": True, "beta_feature": False}
+
+
+def test_get_all_returns_copy():
+    """Mutating the result of get_all() doesn't affect the cache."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        result = provider.get_all()
+        result["injected"] = True
+        assert "injected" not in provider.get_all()
+
+
+# --- is_enabled ---
+
+def test_is_enabled_returns_true_for_enabled_flag():
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        assert provider.is_enabled("chat_enabled") is True
+
+
+def test_is_enabled_returns_false_for_disabled_flag():
+    rows = [("beta_feature", False)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        assert provider.is_enabled("beta_feature") is False
+
+
+def test_is_enabled_returns_default_false_for_missing_key():
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        assert provider.is_enabled("nonexistent") is False
+
+
+def test_is_enabled_returns_explicit_default_for_missing_key():
+    """When default=True and key missing, returns True (kill switch pattern)."""
+    rows = []
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        assert provider.is_enabled("chat_enabled", default=True) is True
+
+
+def test_is_enabled_flag_value_overrides_default():
+    """Explicit flag value in DB overrides the default argument."""
+    rows = [("chat_enabled", False)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        assert provider.is_enabled("chat_enabled", default=True) is False
+
+
+# --- TTL caching ---
+
+def test_cache_not_refreshed_within_ttl():
+    """Second call within TTL reuses the cache without hitting the DB."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        provider.get_all()  # First call — loads cache
+        import dependencies
+        pool = dependencies._pool
+        call_count_after_first = pool.connection.call_count
+        provider.get_all()  # Second call — should use cache
+        assert pool.connection.call_count == call_count_after_first
+
+
+def test_cache_refreshed_after_ttl():
+    """Cache is reloaded after TTL expires."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        provider.get_all()  # First load
+
+        # Expire the cache by backdating the loaded_at timestamp
+        provider._cache_loaded_at = time.monotonic() - provider._TTL - 1
+
+        import dependencies
+        pool = dependencies._pool
+        call_count_before = pool.connection.call_count
+        provider.get_all()
+        assert pool.connection.call_count > call_count_before
+
+
+# --- Stale-on-error ---
+
+def test_stale_cache_returned_on_db_error():
+    """If DB fails and cache exists, returns stale data without raising."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        provider.get_all()  # Populate cache
+
+        # Expire cache and break the DB
+        provider._cache_loaded_at = time.monotonic() - provider._TTL - 1
+        import dependencies
+        dependencies._pool.connection.side_effect = Exception("DB is down")
+
+        # Should return stale data instead of raising
+        result = provider.get_all()
+        assert result == {"chat_enabled": True}
+
+
+def test_no_stale_cache_on_error_raises():
+    """If DB fails and no cache exists, the error propagates."""
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        import dependencies
+        dependencies._pool = MagicMock()
+        dependencies._pool.connection.side_effect = Exception("DB is down")
+
+        from flags.supabase_provider import SupabaseFlagProvider
+        provider = SupabaseFlagProvider()
+
+        with pytest.raises(Exception, match="DB is down"):
+            provider.get_all()
+
+
+# --- invalidate_cache ---
+
+def test_invalidate_cache_forces_reload():
+    """invalidate_cache() causes the next call to reload from DB."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        provider.get_all()  # Populate cache
+
+        import dependencies
+        pool = dependencies._pool
+        call_count_after_first = pool.connection.call_count
+
+        provider.invalidate_cache()
+        provider.get_all()  # Should reload
+        assert pool.connection.call_count > call_count_after_first
+
+
+def test_invalidate_cache_clears_state():
+    """invalidate_cache() sets cache to None."""
+    rows = [("chat_enabled", True)]
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+        provider.get_all()
+        assert provider._cache is not None
+
+        provider.invalidate_cache()
+        assert provider._cache is None
+        assert provider._cache_loaded_at is None
+
+
+# --- Pool fallback ---
+
+def test_falls_back_to_direct_connection_when_no_pool():
+    """Uses psycopg.connect() directly when no pool is configured."""
+    rows = [("chat_enabled", True)]
+    mock_conn = _make_mock_conn(rows)
+
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        import dependencies
+        dependencies._pool = None
+
+        with patch("psycopg.connect", return_value=mock_conn) as mock_connect:
+            from flags.supabase_provider import SupabaseFlagProvider
+            provider = SupabaseFlagProvider()
+            result = provider.get_all()
+
+        mock_connect.assert_called_once_with("postgresql://test")
+    assert result == {"chat_enabled": True}
+
+
+# --- Thread safety ---
+
+def test_concurrent_calls_dont_corrupt_cache():
+    """Concurrent is_enabled() calls all return correct values."""
+    rows = [("chat_enabled", True), ("beta_feature", False)]
+    errors = []
+
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        provider = _make_provider(rows)
+
+        def check_flags():
+            try:
+                assert provider.is_enabled("chat_enabled") is True
+                assert provider.is_enabled("beta_feature") is False
+                assert provider.is_enabled("missing", default=True) is True
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=check_flags) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert errors == [], f"Thread errors: {errors}"


### PR DESCRIPTION
## Summary
- Adds `feature_flags` Postgres table with RLS enabled (service role only)
- Implements `FeatureFlagProvider` protocol and `SupabaseFlagProvider` with TTL-based caching (30s), thread safety, and stale-on-error fallback
- Seeds two kill switches: `chat_enabled` and `ingestion_enabled` (both `enabled=true`)
- Adds `FlagsDep` annotated type to `api/dependencies.py` for use in route handlers

## Test plan
- [x] 15 unit tests: cache loading, `is_enabled` semantics, TTL refresh, stale-on-error, `invalidate_cache`, thread safety, pool fallback
- [x] Full suite: 237 passed

Closes #378