### PR TITLE
feat: feature flag admin management UI

### DIFF
--- a/web/app/admin/flags/page.tsx
+++ b/web/app/admin/flags/page.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+/** Admin page for managing feature flags. Client component (toggle + create + delete state). */
+
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface FlagRow {
+  key: string;
+  enabled: boolean;
+  description: string;
+  category: string;
+  updated_at: string;
+}
+
+interface FlagListResponse {
+  flags: FlagRow[];
+}
+
+type Category = "feature" | "kill_switch";
+
+function categoryBadge(category: string) {
+  return category === "kill_switch" ? (
+    <Badge variant="destructive">kill switch</Badge>
+  ) : (
+    <Badge variant="outline">feature</Badge>
+  );
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function AdminFlagsPage() {
+  const [flags, setFlags] = useState<FlagRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create form state
+  const [newKey, setNewKey] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newCategory, setNewCategory] = useState<Category>("feature");
+  const [newEnabled, setNewEnabled] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadFlags() {
+      try {
+        const resp = await fetch("/api/admin/flags");
+        if (!resp.ok) {
+          const data = (await resp.json()) as { error?: string };
+          setError(data.error ?? `Failed to load flags (${resp.status}).`);
+          return;
+        }
+        const data = (await resp.json()) as FlagListResponse;
+        setFlags(data.flags);
+      } catch {
+        setError("Network error — could not reach the server.");
+      } finally {
+        setLoading(false);
+      }
+    }
+    void loadFlags();
+  }, []);
+
+  async function handleToggle(flag: FlagRow) {
+    const next = !flag.enabled;
+    // Optimistic update
+    setFlags((prev) =>
+      prev.map((f) => (f.key === flag.key ? { ...f, enabled: next } : f))
+    );
+    try {
+      const resp = await fetch(`/api/admin/flags/${encodeURIComponent(flag.key)}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!resp.ok) {
+        // Revert on failure
+        setFlags((prev) =>
+          prev.map((f) => (f.key === flag.key ? { ...f, enabled: flag.enabled } : f))
+        );
+      } else {
+        const updated = (await resp.json()) as FlagRow;
+        setFlags((prev) =>
+          prev.map((f) => (f.key === flag.key ? updated : f))
+        );
+      }
+    } catch {
+      // Revert on network error
+      setFlags((prev) =>
+        prev.map((f) => (f.key === flag.key ? { ...f, enabled: flag.enabled } : f))
+      );
+    }
+  }
+
+  async function handleCreate(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!newKey.trim()) return;
+
+    setCreating(true);
+    setCreateError(null);
+
+    try {
+      const resp = await fetch("/api/admin/flags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          key: newKey.trim(),
+          description: newDescription.trim(),
+          category: newCategory,
+          enabled: newEnabled,
+        }),
+      });
+      const data = (await resp.json()) as FlagRow & { error?: string; detail?: string };
+      if (resp.status === 201) {
+        setFlags((prev) => [...prev, data]);
+        setNewKey("");
+        setNewDescription("");
+        setNewCategory("feature");
+        setNewEnabled(false);
+      } else {
+        setCreateError(data.detail ?? data.error ?? `Error (${resp.status}).`);
+      }
+    } catch {
+      setCreateError("Network error — could not reach the server.");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleDelete(key: string) {
+    try {
+      const resp = await fetch(`/api/admin/flags/${encodeURIComponent(key)}`, {
+        method: "DELETE",
+      });
+      if (resp.ok || resp.status === 204) {
+        setFlags((prev) => prev.filter((f) => f.key !== key));
+      }
+    } catch {
+      // Silent — flag remains in list if delete fails
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-6 py-12">
+      <h1 className="mb-2 text-3xl font-semibold text-foreground">Admin — Feature Flags</h1>
+      <p className="mb-8 text-muted-foreground">
+        Create, toggle, and delete feature flags. Changes take effect immediately.
+      </p>
+
+      {error && <p className="mb-6 text-sm text-destructive">{error}</p>}
+
+      {/* Create form */}
+      <Card className="mb-8 max-w-lg">
+        <CardContent>
+          <form onSubmit={handleCreate} className="flex flex-col gap-4">
+            <h2 className="text-base font-medium text-foreground">New flag</h2>
+
+            <div>
+              <label htmlFor="flag-key" className="mb-1.5 block text-sm font-medium text-foreground">
+                Key
+              </label>
+              <Input
+                id="flag-key"
+                value={newKey}
+                onChange={(e) => setNewKey(e.target.value)}
+                placeholder="e.g. chat_enabled"
+                disabled={creating}
+                className="font-mono"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="flag-description" className="mb-1.5 block text-sm font-medium text-foreground">
+                Description
+              </label>
+              <Input
+                id="flag-description"
+                value={newDescription}
+                onChange={(e) => setNewDescription(e.target.value)}
+                placeholder="What does this flag control?"
+                disabled={creating}
+              />
+            </div>
+
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-foreground">
+                Category
+              </label>
+              <Select value={newCategory} onValueChange={(v) => setNewCategory(v as Category)}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="feature">Feature</SelectItem>
+                  <SelectItem value="kill_switch">Kill Switch</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <Switch
+                id="flag-enabled"
+                checked={newEnabled}
+                onCheckedChange={setNewEnabled}
+                disabled={creating}
+              />
+              <label htmlFor="flag-enabled" className="text-sm text-foreground">
+                Enabled
+              </label>
+            </div>
+
+            {createError && <p className="text-sm text-destructive">{createError}</p>}
+
+            <Button type="submit" disabled={creating || !newKey.trim()} className="w-full">
+              {creating ? "Creating…" : "Create flag"}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {/* Flags table */}
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : flags.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No flags found.</p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Key</TableHead>
+              <TableHead>Enabled</TableHead>
+              <TableHead>Category</TableHead>
+              <TableHead>Description</TableHead>
+              <TableHead>Updated</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {flags.map((flag) => (
+              <TableRow key={flag.key}>
+                <TableCell className="font-mono text-sm">{flag.key}</TableCell>
+                <TableCell>
+                  <Switch
+                    checked={flag.enabled}
+                    onCheckedChange={() => void handleToggle(flag)}
+                    aria-label={`Toggle ${flag.key}`}
+                  />
+                </TableCell>
+                <TableCell>{categoryBadge(flag.category)}</TableCell>
+                <TableCell className="text-muted-foreground">{flag.description}</TableCell>
+                <TableCell className="text-muted-foreground">{formatDate(flag.updated_at)}</TableCell>
+                <TableCell>
+                  <AlertDialog>
+                    <AlertDialogTrigger
+                      render={
+                        <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive" />
+                      }
+                    >
+                      Delete
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete flag?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This will permanently delete{" "}
+                          <span className="font-mono font-medium">{flag.key}</span>. This action cannot be
+                          undone.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          variant="destructive"
+                          onClick={() => void handleDelete(flag.key)}
+                        >
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}

--- a/web/app/api/admin/flags/[key]/route.ts
+++ b/web/app/api/admin/flags/[key]/route.ts
@@ -1,0 +1,70 @@
+/** Server-side proxy for PUT /admin/flags/{key} (update) and DELETE /admin/flags/{key}. Admin only. */
+import { requireAdminUser } from "@/lib/admin-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+type Context = { params: Promise<{ key: string }> };
+
+function apiUrl(): string | undefined {
+  return process.env.NEXT_PUBLIC_API_URL;
+}
+
+function misconfigured(): NextResponse {
+  return NextResponse.json(
+    { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+    { status: 500 }
+  );
+}
+
+export async function PUT(request: NextRequest, { params }: Context): Promise<NextResponse> {
+  if (!apiUrl()) return misconfigured();
+
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { key } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl()}/admin/flags/${encodeURIComponent(key)}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${authResult.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}
+
+export async function DELETE(_request: NextRequest, { params }: Context): Promise<NextResponse> {
+  if (!apiUrl()) return misconfigured();
+
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
+
+  const { key } = await params;
+
+  try {
+    const resp = await fetch(`${apiUrl()}/admin/flags/${encodeURIComponent(key)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
+    });
+    if (resp.status === 204) {
+      return new NextResponse(null, { status: 204 });
+    }
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}

--- a/web/app/api/admin/flags/route.ts
+++ b/web/app/api/admin/flags/route.ts
@@ -1,0 +1,61 @@
+/** Server-side proxy for GET /admin/flags (list) and POST /admin/flags (create). Admin only. */
+import { requireAdminUser } from "@/lib/admin-auth";
+import { NextRequest, NextResponse } from "next/server";
+
+function apiUrl(): string | undefined {
+  return process.env.NEXT_PUBLIC_API_URL;
+}
+
+function misconfigured(): NextResponse {
+  return NextResponse.json(
+    { error: "Server misconfiguration: NEXT_PUBLIC_API_URL is not set" },
+    { status: 500 }
+  );
+}
+
+export async function GET(): Promise<NextResponse> {
+  if (!apiUrl()) return misconfigured();
+
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const resp = await fetch(`${apiUrl()}/admin/flags`, {
+      headers: { Authorization: `Bearer ${authResult.accessToken}` },
+      cache: "no-store",
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  if (!apiUrl()) return misconfigured();
+
+  const authResult = await requireAdminUser();
+  if (authResult instanceof NextResponse) return authResult;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  try {
+    const resp = await fetch(`${apiUrl()}/admin/flags`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${authResult.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const data: unknown = await resp.json();
+    return NextResponse.json(data, { status: resp.status });
+  } catch {
+    return NextResponse.json({ error: "Failed to reach backend" }, { status: 502 });
+  }
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -107,6 +107,12 @@ export default async function RootLayout({
                           >
                             Admin Ingest
                           </Link>
+                          <Link
+                            href="/admin/flags"
+                            className="text-sm text-muted-foreground hover:text-foreground"
+                          >
+                            Feature Flags
+                          </Link>
                         </div>
                       )}
                       <span className="text-sm text-muted-foreground">{user.email}</span>
@@ -146,6 +152,12 @@ export default async function RootLayout({
                                   className="py-2 text-sm text-muted-foreground hover:text-foreground"
                                 >
                                   Admin Ingest
+                                </Link>
+                                <Link
+                                  href="/admin/flags"
+                                  className="py-2 text-sm text-muted-foreground hover:text-foreground"
+                                >
+                                  Feature Flags
                                 </Link>
                               </nav>
                             </SheetContent>

--- a/web/components/ui/alert-dialog.tsx
+++ b/web/components/ui/alert-dialog.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/web/components/ui/select.tsx
+++ b/web/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/web/components/ui/switch.tsx
+++ b/web/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/web/components/ui/table.tsx
+++ b/web/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary

- Adds `/admin/flags` page with a flags table (key, enabled toggle, category badge, description, updated date) and a create form
- Adds Next.js API proxy routes (`GET`/`POST /api/admin/flags`, `PUT`/`DELETE /api/admin/flags/[key]`) that authenticate via `requireAdminUser()` before forwarding to the FastAPI admin endpoints
- Adds "Feature Flags" link to the admin nav (desktop + mobile)
- Installs four shadcn components needed by the page: Table, Switch, Select, AlertDialog

## Test plan

- [ ] Log in as admin — "Feature Flags" link appears in nav bar
- [ ] `/admin/flags` loads and lists existing flags
- [ ] Create a flag — appears in table immediately
- [ ] Toggle enabled switch — updates optimistically, reverts on error
- [ ] Delete a flag via AlertDialog confirmation — removed from table
- [ ] Non-admin user receives 403 from proxy routes
- [ ] Build passes: `cd web && npm run build`
- [ ] Backend tests pass: `pytest -q` (255 tests)

Closes #381