### PR TITLE
feat: wire chat_enabled and ingestion_enabled kill switches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ Active kill switches and where they are enforced:
 | Flag | Enforced in | Effect when `false` |
 |---|---|---|
 | `chat_enabled` | `api/routes/chat.py`, `web/app/calls/[ticker]/learn/page.tsx` | 503 from API; disabled message in UI |
-| `ingestion_enabled` | `api/routes/admin.py` (`trigger_ingestion`) | 503 from API |
+| `ingestion_enabled` | `api/routes/admin.py` (`trigger_ingestion`), `web/app/admin/ingest/page.tsx` | 503 from API; form disabled in UI |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,23 @@ Use `tools/prompt_tuner.py` to run a side-by-side comparison of production vs. c
 
 ---
 
+## Feature flag conventions
+
+Feature flags are stored in `public.feature_flags` and managed via `/admin/flags`.
+
+**Kill switches** (category `kill_switch`): default to `True` — the system works normally without the flag row. Create the row and set `enabled = false` to disable the feature. Check with `get_flag_provider().is_enabled("key", default=True)`.
+
+**Feature gates** (category `feature`): default to `False` — disabled until explicitly enabled. Check with `get_flag_provider().is_enabled("key", default=False)`.
+
+Active kill switches and where they are enforced:
+
+| Flag | Enforced in | Effect when `false` |
+|---|---|---|
+| `chat_enabled` | `api/routes/chat.py`, `web/app/calls/[ticker]/learn/page.tsx` | 503 from API; disabled message in UI |
+| `ingestion_enabled` | `api/routes/admin.py` (`trigger_ingestion`) | 503 from API |
+
+---
+
 ## Commit and PR message conventions
 
 - Do **not** add `Co-Authored-By` trailers or any other attribution to Claude in commit or PR messages.

--- a/api/routes/admin.py
+++ b/api/routes/admin.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, field_validator
 
 from db.analytics import track
 from db.repositories import AnalyticsRepository, SchemaRepository
-from dependencies import RequireAdminDep
+from dependencies import RequireAdminDep, get_flag_provider
 from settings import INGEST_RATE_LIMIT_WINDOW_SECONDS
 
 logger = logging.getLogger(__name__)
@@ -148,6 +148,9 @@ async def trigger_ingestion(body: IngestRequest, user_id: RequireAdminDep) -> di
                 status_code=429,
                 detail=f"Rate limit: wait {remaining}s before ingesting {body.ticker} again.",
             )
+    if not get_flag_provider().is_enabled("ingestion_enabled", default=True):
+        raise HTTPException(status_code=503, detail="Ingestion is temporarily disabled")
+
     try:
         fn = modal.Function.from_name("earnings-ingestion", "ingest_ticker")
         await fn.spawn.aio(body.ticker)

--- a/api/routes/chat.py
+++ b/api/routes/chat.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 
 from db.analytics import track
 from db.repositories import CallRepository, LearningRepository
-from dependencies import CurrentUserDep
+from dependencies import CurrentUserDep, get_flag_provider
 from limiter import limiter
 from settings import CHAT_MESSAGE_MAX_LENGTH, CHAT_RATE_LIMIT, SESSION_HISTORY_MAX_TURNS
 from shutdown import shutdown_event
@@ -173,6 +173,12 @@ def chat(
            data: {type: done, session_id: ...} on completion,
            data: {type: error, message: ...}  on failure.
     """
+    if not get_flag_provider().is_enabled("chat_enabled", default=True):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chat is temporarily unavailable",
+        )
+
     if not _ticker_exists(ticker):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/tests/unit/api/test_admin.py
+++ b/tests/unit/api/test_admin.py
@@ -479,3 +479,28 @@ def test_startup_succeeds_with_all_required_vars():
             pass
         with TestClient(app):
             pass  # No exception raised
+
+
+# ---------------------------------------------------------------------------
+# Kill switch — POST /admin/ingest
+# ---------------------------------------------------------------------------
+
+def test_ingest_503_when_ingestion_disabled_via_flag(client):
+    """ingestion_enabled=False returns 503 before Modal dispatch."""
+    mock_provider = MagicMock()
+    mock_provider.is_enabled.return_value = False
+    with patch("routes.admin.get_flag_provider", return_value=mock_provider):
+        resp = client.post("/admin/ingest", json={"ticker": "AAPL"}, headers=ADMIN_AUTH)
+    assert resp.status_code == 503
+    assert "disabled" in resp.json()["detail"].lower()
+
+
+def test_ingest_dispatches_when_flag_enabled(client):
+    """ingestion_enabled=True does not short-circuit; Modal dispatch proceeds."""
+    mock_fn = _make_modal_fn()
+    MODAL_STUB.Function.from_name.return_value = mock_fn
+    mock_provider = MagicMock()
+    mock_provider.is_enabled.return_value = True
+    with patch("routes.admin.get_flag_provider", return_value=mock_provider):
+        resp = client.post("/admin/ingest", json={"ticker": "AAPL"}, headers=ADMIN_AUTH)
+    assert resp.status_code == 202

--- a/tests/unit/api/test_chat.py
+++ b/tests/unit/api/test_chat.py
@@ -309,3 +309,34 @@ class TestChatInputBounds:
                 headers={"Authorization": AUTH_HEADER},
             )
         assert response.status_code == 429
+
+
+class TestChatKillSwitch:
+    def test_503_when_chat_disabled_via_flag(self, client):
+        """chat_enabled=False returns 503 before any ticker or key check."""
+        mock_provider = MagicMock()
+        mock_provider.is_enabled.return_value = False
+        with patch("routes.chat.get_flag_provider", return_value=mock_provider):
+            response = client.post(
+                "/api/calls/AAPL/chat",
+                json={"message": "explain revenue"},
+                headers={"Authorization": AUTH_HEADER},
+            )
+        assert response.status_code == 503
+        assert "unavailable" in response.json()["detail"].lower()
+
+    def test_chat_works_normally_when_flag_enabled(self, client):
+        """chat_enabled=True does not short-circuit the endpoint."""
+        mock_provider = MagicMock()
+        mock_provider.is_enabled.return_value = True
+        with (
+            patch("routes.chat.get_flag_provider", return_value=mock_provider),
+            patch("routes.chat._ticker_exists", return_value=False),
+        ):
+            response = client.post(
+                "/api/calls/AAPL/chat",
+                json={"message": "explain revenue"},
+                headers={"Authorization": AUTH_HEADER},
+            )
+        # Kill switch passed → reaches ticker check → 404, not 503
+        assert response.status_code == 404

--- a/web/app/admin/ingest/page.tsx
+++ b/web/app/admin/ingest/page.tsx
@@ -6,10 +6,13 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
+import { useFlag } from "@/lib/useFlag";
 
 type Status = "idle" | "submitting" | "accepted" | "error";
 
 export default function AdminIngestPage() {
+  const ingestionEnabled = useFlag("ingestion_enabled", true);
+
   const [ticker, setTicker] = useState("");
   const [status, setStatus] = useState<Status>("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -66,6 +69,12 @@ export default function AdminIngestPage() {
         asynchronously.
       </p>
 
+      {!ingestionEnabled && (
+        <p className="mb-6 text-sm text-muted-foreground">
+          Ingestion is temporarily disabled. Enable the <code>ingestion_enabled</code> flag to dispatch jobs.
+        </p>
+      )}
+
       <Card className="max-w-sm">
         <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -82,14 +91,14 @@ export default function AdminIngestPage() {
               value={ticker}
               onChange={(e) => setTicker(e.target.value)}
               placeholder="e.g. AAPL"
-              disabled={status === "submitting"}
+              disabled={status === "submitting" || !ingestionEnabled}
               className="font-mono uppercase placeholder:normal-case"
             />
           </div>
 
           <Button
             type="submit"
-            disabled={status === "submitting" || !ticker.trim()}
+            disabled={status === "submitting" || !ticker.trim() || !ingestionEnabled}
             className="w-full"
           >
             {status === "submitting" ? "Submitting…" : "Ingest transcript"}

--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -7,6 +7,7 @@ import { ChatThread } from "@/components/chat/ChatThread";
 import { ChatInput } from "@/components/chat/ChatInput";
 import { streamChat } from "@/lib/chat";
 import { api } from "@/lib/api";
+import { useFlag } from "@/lib/useFlag";
 import { buildSuggestions } from "@/lib/suggestions";
 import type { ChatMessage } from "@/lib/chat";
 import type { TopicsResponse, KeywordsResponse } from "@/components/transcript/types";
@@ -22,6 +23,8 @@ export default function LearnPage({
   const { ticker } = use(params);
   const { topic } = use(searchParams);
   const upperTicker = ticker.toUpperCase();
+
+  const chatEnabled = useFlag("chat_enabled", true);
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [streamingContent, setStreamingContent] = useState("");
@@ -130,33 +133,43 @@ export default function LearnPage({
         </div>
       </div>
 
-      {/* Error banner */}
-      {error && (
-        <div className="mb-4 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-          <span className="flex-1">{error}</span>
-          <button
-            onClick={() => setError(null)}
-            aria-label="Dismiss error"
-            className="shrink-0 text-destructive/60 hover:text-destructive"
-          >
-            ✕
-          </button>
+      {!chatEnabled ? (
+        <div className="flex flex-1 items-center justify-center">
+          <p className="text-sm text-muted-foreground">
+            Chat is temporarily unavailable. Please check back later.
+          </p>
         </div>
+      ) : (
+        <>
+          {/* Error banner */}
+          {error && (
+            <div className="mb-4 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              <span className="flex-1">{error}</span>
+              <button
+                onClick={() => setError(null)}
+                aria-label="Dismiss error"
+                className="shrink-0 text-destructive/60 hover:text-destructive"
+              >
+                ✕
+              </button>
+            </div>
+          )}
+
+          {/* Chat thread */}
+          <ChatThread
+            messages={messages}
+            streamingContent={streamingContent}
+            suggestions={suggestions}
+            loadingSuggestions={loadingSuggestions}
+            onSuggestionClick={handleSend}
+          />
+
+          {/* Input */}
+          <div className="mt-4">
+            <ChatInput onSend={handleSend} onAbort={handleAbort} isStreaming={isStreaming} initialValue={topic ?? ""} />
+          </div>
+        </>
       )}
-
-      {/* Chat thread */}
-      <ChatThread
-        messages={messages}
-        streamingContent={streamingContent}
-        suggestions={suggestions}
-        loadingSuggestions={loadingSuggestions}
-        onSuggestionClick={handleSend}
-      />
-
-      {/* Input */}
-      <div className="mt-4">
-        <ChatInput onSend={handleSend} onAbort={handleAbort} isStreaming={isStreaming} initialValue={topic ?? ""} />
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `api/routes/chat.py`: checks `chat_enabled` kill switch before the ticker/key checks; returns 503 if disabled
- `api/routes/admin.py` (`trigger_ingestion`): checks `ingestion_enabled` kill switch before Modal dispatch; returns 503 if disabled
- `web/app/calls/[ticker]/learn/page.tsx`: reads `chat_enabled` via `useFlag` hook; shows a graceful disabled message instead of the chat interface when false
- `CLAUDE.md`: documents the kill switch convention and the active flag table

## Test plan

- [ ] Toggle `chat_enabled` to false in admin UI → `/api/calls/AAPL/chat` returns 503
- [ ] Learn page at `/calls/AAPL/learn` shows "Chat is temporarily unavailable" message
- [ ] Toggle `chat_enabled` back to true → chat works normally
- [ ] Toggle `ingestion_enabled` to false → `POST /admin/ingest` returns 503
- [ ] `pytest -q` → 259 tests pass
- [ ] `cd web && npm run build` → no type errors

Closes #382