### PR TITLE
feat: add /learn-annotations composite endpoint (#392)

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -124,6 +124,31 @@ class CompetitorInfo(BaseModel):
     mentioned_in_transcript: bool
 
 
+class TermDefinition(BaseModel):
+    term: str
+    definition: str
+    explanation: str
+    category: str
+
+
+class QAEvasionItem(BaseModel):
+    analyst_name: str | None = None
+    question_topic: str | None = None
+    question_text: str | None = None
+    answer_text: str | None = None
+    analyst_concern: str
+    defensiveness_score: int
+    evasion_explanation: str
+
+
+class LearnAnnotationsResponse(BaseModel):
+    terms: list[TermDefinition] = []
+    evasion: list[QAEvasionItem] = []
+    takeaways: list[TakeawayItem] = []
+    misconceptions: list[MisconceptionItem] = []
+    synthesis: SynthesisInfo | None = None
+
+
 class CallDetail(BaseModel):
     ticker: str
     company_name: str | None = None
@@ -339,6 +364,27 @@ def get_call_synthesis(ticker: str, conn: DbDep, response: Response) -> Synthesi
     )
     response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
     return SynthesisResponse(synthesis=synthesis)
+
+
+@router.get("/{ticker}/learn-annotations", response_model=LearnAnnotationsResponse)
+def get_learn_annotations(ticker: str, conn: DbDep, response: Response) -> LearnAnnotationsResponse:
+    """Return composite annotation data for the learn page (terms, evasion, takeaways, misconceptions, synthesis)."""
+    logger.info("GET /api/calls/%s/learn-annotations", ticker)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    analysis_repo = AnalysisRepository(_db_url())
+    raw = analysis_repo.get_learn_annotations_for_ticker(ticker)
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return LearnAnnotationsResponse(
+        terms=[TermDefinition(**t) for t in raw["terms"]],
+        evasion=[QAEvasionItem(**e) for e in raw["evasion"]],
+        takeaways=[TakeawayItem(**t) for t in raw["takeaways"]],
+        misconceptions=[MisconceptionItem(**m) for m in raw["misconceptions"]],
+        synthesis=SynthesisInfo(**raw["synthesis"]) if raw["synthesis"] else None,
+    )
 
 
 @router.get("/{ticker}/speakers", response_model=SpeakersResponse)

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -507,6 +507,81 @@ class AnalysisRepository:
             logger.warning(f"Could not fetch financial terms: {e}")
         return terms
 
+    def get_learn_annotations_for_ticker(self, ticker: str, term_limit: int = 50) -> dict:
+        """Return composed annotation data for the learn page.
+
+        Combines industry + financial terms (capped at `term_limit` total, industry first),
+        Q&A evasion entries, takeaways, misconceptions, and synthesis for a ticker.
+        """
+        # Industry first (usually fewer, higher value), then financial to fill the budget.
+        industry = self.get_industry_terms_for_ticker(ticker, limit=term_limit)
+        remaining = max(0, term_limit - len(industry))
+        financial = (
+            self.get_financial_terms_for_ticker(ticker, limit=remaining) if remaining else []
+        )
+
+        terms: list[dict] = []
+        for term, definition, explanation in industry:
+            terms.append(
+                {
+                    "term": term,
+                    "definition": definition,
+                    "explanation": explanation,
+                    "category": "industry",
+                }
+            )
+        for term, definition, explanation in financial:
+            terms.append(
+                {
+                    "term": term,
+                    "definition": definition,
+                    "explanation": explanation,
+                    "category": "financial",
+                }
+            )
+
+        raw_evasion = self.get_qa_evasion_for_ticker(ticker)
+        evasion = [
+            {
+                "analyst_name": r[0],
+                "question_topic": r[1],
+                "question_text": r[2],
+                "answer_text": r[3],
+                "analyst_concern": r[4],
+                "defensiveness_score": r[5],
+                "evasion_explanation": r[6],
+            }
+            for r in raw_evasion
+        ]
+
+        raw_takeaways = self.get_takeaways_for_ticker(ticker)
+        takeaways = [{"takeaway": r[0], "why_it_matters": r[1]} for r in raw_takeaways]
+
+        raw_misconceptions = self.get_misconceptions_for_ticker(ticker)
+        misconceptions = [
+            {"fact": r[0], "misinterpretation": r[1], "correction": r[2]}
+            for r in raw_misconceptions
+        ]
+
+        raw_synthesis = self.get_synthesis_for_ticker(ticker)
+        synthesis = (
+            {
+                "overall_sentiment": raw_synthesis[0],
+                "executive_tone": raw_synthesis[1],
+                "analyst_sentiment": raw_synthesis[2],
+            }
+            if raw_synthesis
+            else None
+        )
+
+        return {
+            "terms": terms,
+            "evasion": evasion,
+            "takeaways": takeaways,
+            "misconceptions": misconceptions,
+            "synthesis": synthesis,
+        }
+
     def get_extracted_terms_for_ticker(self, ticker: str, limit: int = 15) -> list[tuple[str, str, str]]:
         """Return deduplicated terms of all categories for a ticker (legacy method)."""
         terms = []

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -846,6 +846,96 @@ class TestGetCallSynthesis:
         assert response.json()["synthesis"] is None
 
 
+class TestGetLearnAnnotations:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/learn-annotations")
+        assert response.status_code == 404
+
+    def test_returns_composed_annotations(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_learn_annotations_for_ticker.return_value = {
+                "terms": [
+                    {
+                        "term": "ARR",
+                        "definition": "Annual recurring revenue",
+                        "explanation": "Revenue from subscriptions normalized to one year.",
+                        "category": "financial",
+                    },
+                    {
+                        "term": "Data center GPU",
+                        "definition": "Specialized compute hardware",
+                        "explanation": "Used for AI workloads.",
+                        "category": "industry",
+                    },
+                ],
+                "evasion": [
+                    {
+                        "analyst_name": "Jane Doe",
+                        "question_topic": "Margins",
+                        "question_text": "Why did gross margin compress?",
+                        "answer_text": "We're investing in growth.",
+                        "analyst_concern": "Dodging margin question",
+                        "defensiveness_score": 7,
+                        "evasion_explanation": "Deflected to growth narrative.",
+                    }
+                ],
+                "takeaways": [
+                    {"takeaway": "Q4 revenue beat guidance", "why_it_matters": "Confirms demand."}
+                ],
+                "misconceptions": [
+                    {"fact": "CapEx rose 30%", "misinterpretation": "Growth slowing", "correction": "Scaling capacity."}
+                ],
+                "synthesis": {
+                    "overall_sentiment": "bullish",
+                    "executive_tone": "confident",
+                    "analyst_sentiment": "neutral",
+                },
+            }
+            response = api_client.get("/api/calls/NVDA/learn-annotations")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["terms"]) == 2
+        assert data["terms"][0]["term"] == "ARR"
+        assert data["terms"][0]["category"] == "financial"
+        assert len(data["evasion"]) == 1
+        assert data["evasion"][0]["defensiveness_score"] == 7
+        assert data["evasion"][0]["analyst_name"] == "Jane Doe"
+        assert len(data["takeaways"]) == 1
+        assert data["takeaways"][0]["takeaway"] == "Q4 revenue beat guidance"
+        assert len(data["misconceptions"]) == 1
+        assert data["misconceptions"][0]["fact"] == "CapEx rose 30%"
+        assert data["synthesis"]["overall_sentiment"] == "bullish"
+        assert data["synthesis"]["executive_tone"] == "confident"
+        assert data["synthesis"]["analyst_sentiment"] == "neutral"
+
+    def test_empty_state(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_learn_annotations_for_ticker.return_value = {
+                "terms": [],
+                "evasion": [],
+                "takeaways": [],
+                "misconceptions": [],
+                "synthesis": None,
+            }
+            response = api_client.get("/api/calls/EMPTY/learn-annotations")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["terms"] == []
+        assert data["evasion"] == []
+        assert data["takeaways"] == []
+        assert data["misconceptions"] == []
+        assert data["synthesis"] is None
+
+
 class TestGetCallSpeakers:
     def test_404_for_unknown_ticker(self, api_client):
         with patch("routes.calls._ticker_exists", return_value=False):


### PR DESCRIPTION
## Summary

Adds `GET /api/calls/{ticker}/learn-annotations`, a single endpoint that returns all annotation data needed by the Variant D learn page rewrite (terms, Q&A evasion, takeaways, misconceptions, synthesis). Replaces what would otherwise be 5 parallel client requests.

- `AnalysisRepository.get_learn_annotations_for_ticker` composes six existing read methods — no new SQL.
- Combined terms capped at 50 (industry first, then financial to fill the remaining budget), per the issue spec.
- Route uses `DbDep`, standard 404 via `_ticker_exists`, 5-minute Cache-Control matching sibling read endpoints.
- `LearnAnnotationsResponse` is a new Pydantic model composing `TermDefinition`, `QAEvasionItem`, existing `TakeawayItem`/`MisconceptionItem`/`SynthesisInfo`.

## Test plan

- [x] `pytest -q` — 262 tests pass
- [x] New unit tests: happy path, empty state, 404

First in a 6-PR chain for milestone 5 (Learning UX Enhancements). Unblocks #394.

Closes #392