### PR TITLE
feat: add highlightTerms + normalizeForMatch utilities (#393)

### DIFF
--- a/web/__tests__/utils/highlight.test.ts
+++ b/web/__tests__/utils/highlight.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildTermRegex,
+  findEvasionSpanIndex,
+  highlightTerms,
+  normalizeForMatch,
+  type SpanItem,
+  type TermDefinition,
+} from "@/lib/highlight";
+
+function makeTermMap(terms: TermDefinition[]): Map<string, TermDefinition> {
+  return new Map(terms.map((t) => [t.term.toLowerCase(), t]));
+}
+
+function makeDef(term: string, category: "industry" | "financial" = "industry"): TermDefinition {
+  return { term, definition: `${term} def`, explanation: `${term} expl`, category };
+}
+
+const renderMarker = (matched: string, _def: TermDefinition, key: string) =>
+  `<<${key}:${matched}>>`;
+
+describe("buildTermRegex", () => {
+  it("returns null for empty list", () => {
+    expect(buildTermRegex([])).toBeNull();
+  });
+
+  it("escapes regex special characters", () => {
+    const rx = buildTermRegex(["S&P 500", "10-K"]);
+    expect(rx).not.toBeNull();
+    expect(rx!.test("The S&P 500 closed up.")).toBe(true);
+    expect(rx!.test("Filed their 10-K.")).toBe(true);
+  });
+
+  it("orders longer terms first so alternation prefers them", () => {
+    const rx = buildTermRegex(["margin", "gross margin"])!;
+    const match = "gross margin expanded".match(rx);
+    expect(match?.[0].toLowerCase()).toBe("gross margin");
+  });
+});
+
+describe("normalizeForMatch", () => {
+  it("collapses whitespace and newlines to single spaces", () => {
+    expect(normalizeForMatch("  hello\n  world  ")).toBe("hello world");
+  });
+
+  it("lowercases input", () => {
+    expect(normalizeForMatch("Hello World")).toBe("hello world");
+  });
+});
+
+describe("highlightTerms", () => {
+  it("wraps a matched term with the renderer", () => {
+    const terms = [makeDef("EBITDA", "financial")];
+    const rx = buildTermRegex(terms.map((t) => t.term));
+    const nodes = highlightTerms("The EBITDA grew 15%", rx, makeTermMap(terms), renderMarker);
+    expect(nodes).toEqual(["The ", "<<term-0:EBITDA>>", " grew 15%"]);
+  });
+
+  it("matches case-insensitively", () => {
+    const terms = [makeDef("EBITDA", "financial")];
+    const rx = buildTermRegex(terms.map((t) => t.term));
+    const nodes = highlightTerms("ebitda grew", rx, makeTermMap(terms), renderMarker);
+    expect(nodes[0]).toBe("<<term-0:ebitda>>");
+  });
+
+  it("returns text unchanged when regex is null", () => {
+    const nodes = highlightTerms("no terms here", null, new Map(), renderMarker);
+    expect(nodes).toEqual(["no terms here"]);
+  });
+
+  it("handles multiple non-overlapping matches", () => {
+    const terms = [makeDef("ARR", "financial"), makeDef("EBITDA", "financial")];
+    const rx = buildTermRegex(terms.map((t) => t.term));
+    const nodes = highlightTerms(
+      "ARR and EBITDA both rose",
+      rx,
+      makeTermMap(terms),
+      renderMarker,
+    );
+    expect(nodes).toEqual([
+      "<<term-0:ARR>>",
+      " and ",
+      "<<term-1:EBITDA>>",
+      " both rose",
+    ]);
+  });
+});
+
+describe("findEvasionSpanIndex", () => {
+  it("returns the index of the span containing the normalized answer", () => {
+    const spans: SpanItem[] = [
+      { speaker: "CEO", section: "qa", text: "We are investing in growth.", sequence_order: 1 },
+      {
+        speaker: "CEO",
+        section: "qa",
+        text: "  Gross margin compression reflects capacity ramp during this period.",
+        sequence_order: 2,
+      },
+    ];
+    const answer = "Gross margin compression reflects capacity ramp during this period.";
+    expect(findEvasionSpanIndex(answer, spans)).toBe(1);
+  });
+
+  it("returns null when no span matches", () => {
+    const spans: SpanItem[] = [
+      { speaker: "CEO", section: "qa", text: "Totally unrelated answer.", sequence_order: 1 },
+    ];
+    expect(findEvasionSpanIndex("we expect higher guidance next quarter", spans)).toBeNull();
+  });
+
+  it("returns null for empty answer", () => {
+    expect(findEvasionSpanIndex("", [])).toBeNull();
+  });
+});

--- a/web/lib/highlight.ts
+++ b/web/lib/highlight.ts
@@ -1,0 +1,100 @@
+import type { ReactNode } from "react";
+
+export interface TermDefinition {
+  term: string;
+  definition: string;
+  explanation: string;
+  category: "industry" | "financial";
+}
+
+export interface SpanItem {
+  speaker: string;
+  section: string;
+  text: string;
+  sequence_order: number;
+}
+
+function escapeRegex(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function buildTermRegex(terms: readonly string[]): RegExp | null {
+  if (terms.length === 0) return null;
+  const sorted = [...terms].sort((a, b) => b.length - a.length);
+  const alternation = sorted.map(escapeRegex).join("|");
+  return new RegExp(`\\b(${alternation})\\b`, "gi");
+}
+
+export function normalizeForMatch(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+export type TermNodeRenderer = (
+  matchedTerm: string,
+  definition: TermDefinition,
+  key: string,
+) => ReactNode;
+
+export function highlightTerms(
+  text: string,
+  termRegex: RegExp | null,
+  termMap: ReadonlyMap<string, TermDefinition>,
+  renderTerm: TermNodeRenderer,
+): ReactNode[] {
+  if (!termRegex || termMap.size === 0 || text.length === 0) {
+    return [text];
+  }
+
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let matchIndex = 0;
+
+  const regex = new RegExp(termRegex.source, termRegex.flags);
+
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    const start = match.index;
+    const end = start + match[0].length;
+
+    if (start > lastIndex) {
+      nodes.push(text.slice(lastIndex, start));
+    }
+
+    const definition = termMap.get(match[0].toLowerCase());
+    if (definition) {
+      nodes.push(renderTerm(match[0], definition, `term-${matchIndex}`));
+    } else {
+      nodes.push(match[0]);
+    }
+
+    lastIndex = end;
+    matchIndex += 1;
+
+    if (match[0].length === 0) {
+      regex.lastIndex += 1;
+    }
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes.length > 0 ? nodes : [text];
+}
+
+export function findEvasionSpanIndex(
+  answerText: string,
+  spans: readonly SpanItem[],
+): number | null {
+  const normalized = normalizeForMatch(answerText);
+  if (normalized.length === 0) return null;
+  const needle = normalized.slice(0, 80);
+
+  for (let i = 0; i < spans.length; i += 1) {
+    if (normalizeForMatch(spans[i].text).includes(needle)) {
+      return i;
+    }
+  }
+  return null;
+}
+


### PR DESCRIPTION
## Summary

Pure TypeScript utilities that the Variant D learn page will use for term highlighting and fuzzy evasion-card placement.

- `buildTermRegex(terms)` — sorts longest-first, regex-escapes special characters (`S&P 500`, `10-K`), returns a case-insensitive word-boundary alternation.
- `highlightTerms(text, regex, termMap, renderTerm)` — walks matches, calls the supplied `renderTerm` for each (keeps this module JSX-free so it stays trivially testable).
- `normalizeForMatch(text)` — lowercases and collapses whitespace.
- `findEvasionSpanIndex(answer, spans)` — fuzzy-locates a Q&A span by normalized 80-char prefix.

## Test plan

- [x] `pnpm test` — 56 tests pass (12 new for highlight utilities)

Covers the 8 cases from the issue spec plus case-insensitive matching, multiple non-overlapping matches, null regex short-circuit, and empty-answer handling.

Second in the 6-PR chain for milestone 5. Unblocks #394 and #395.

Closes #393