### PR TITLE
feat: add useAnnotations hook + shared types (#394)

### DIFF
--- a/web/__tests__/hooks/useAnnotations.test.ts
+++ b/web/__tests__/hooks/useAnnotations.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useAnnotations } from "@/hooks/useAnnotations";
+import { api } from "@/lib/api";
+import type { LearnAnnotationsResponse } from "@/components/transcript/types";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+const getMock = api.get as unknown as ReturnType<typeof vi.fn>;
+
+function makeResponse(
+  overrides: Partial<LearnAnnotationsResponse> = {},
+): LearnAnnotationsResponse {
+  return {
+    terms: [],
+    evasion: [],
+    takeaways: [],
+    misconceptions: [],
+    synthesis: null,
+    ...overrides,
+  };
+}
+
+describe("useAnnotations", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  it("fetches and returns annotations on mount", async () => {
+    const response = makeResponse({
+      terms: [
+        {
+          term: "ARR",
+          definition: "Annual recurring revenue",
+          explanation: "",
+          category: "industry",
+        },
+      ],
+    });
+    getMock.mockResolvedValueOnce(response);
+
+    const { result } = renderHook(() => useAnnotations("NVDA"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getMock).toHaveBeenCalledWith("/api/calls/NVDA/learn-annotations");
+    expect(result.current.annotations).toEqual(response);
+    expect(result.current.error).toBeNull();
+    expect(result.current.termMap.get("arr")).toBeDefined();
+  });
+
+  it("filters out single-word financial terms from the term map", async () => {
+    getMock.mockResolvedValueOnce(
+      makeResponse({
+        terms: [
+          { term: "margin", definition: "", explanation: "", category: "financial" },
+          { term: "gross margin", definition: "", explanation: "", category: "financial" },
+          { term: "EBITDA", definition: "", explanation: "", category: "industry" },
+        ],
+      }),
+    );
+
+    const { result } = renderHook(() => useAnnotations("NVDA"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.termMap.has("margin")).toBe(false);
+    expect(result.current.termMap.has("gross margin")).toBe(true);
+    expect(result.current.termMap.has("ebitda")).toBe(true);
+    expect(result.current.termRegex).not.toBeNull();
+  });
+
+  it("surfaces an error when the fetch fails", async () => {
+    getMock.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useAnnotations("NVDA"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe("network down");
+    expect(result.current.annotations).toBeNull();
+    expect(result.current.termMap.size).toBe(0);
+    expect(result.current.termRegex).toBeNull();
+  });
+});

--- a/web/components/transcript/types.ts
+++ b/web/components/transcript/types.ts
@@ -125,6 +125,31 @@ export interface SpanItem {
   sequence_order: number;
 }
 
+export interface TermDefinition {
+  term: string;
+  definition: string;
+  explanation: string;
+  category: "industry" | "financial";
+}
+
+export interface QAEvasionItem {
+  analyst_name: string | null;
+  question_topic: string | null;
+  question_text: string | null;
+  answer_text: string | null;
+  analyst_concern: string;
+  defensiveness_score: number;
+  evasion_explanation: string;
+}
+
+export interface LearnAnnotationsResponse {
+  terms: TermDefinition[];
+  evasion: QAEvasionItem[];
+  takeaways: TakeawayItem[];
+  misconceptions: MisconceptionItem[];
+  synthesis: SynthesisInfo | null;
+}
+
 export interface SpansResponse {
   total: number;
   page: number;

--- a/web/hooks/useAnnotations.ts
+++ b/web/hooks/useAnnotations.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { buildTermRegex } from "@/lib/highlight";
+import type {
+  LearnAnnotationsResponse,
+  TermDefinition,
+} from "@/components/transcript/types";
+
+export interface UseAnnotationsResult {
+  annotations: LearnAnnotationsResponse | null;
+  termMap: Map<string, TermDefinition>;
+  termRegex: RegExp | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function filterTerms(terms: readonly TermDefinition[]): TermDefinition[] {
+  return terms.filter((t) => {
+    if (t.category === "industry") return true;
+    return t.term.includes(" ");
+  });
+}
+
+export function useAnnotations(ticker: string): UseAnnotationsResult {
+  const [annotations, setAnnotations] = useState<LearnAnnotationsResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    api
+      .get<LearnAnnotationsResponse>(`/api/calls/${ticker}/learn-annotations`)
+      .then((data) => {
+        if (cancelled) return;
+        setAnnotations(data);
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setAnnotations(null);
+        setError(err instanceof Error ? err.message : "Failed to load annotations");
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [ticker]);
+
+  const filteredTerms = useMemo(
+    () => (annotations ? filterTerms(annotations.terms) : []),
+    [annotations],
+  );
+
+  const termMap = useMemo(() => {
+    const map = new Map<string, TermDefinition>();
+    for (const term of filteredTerms) {
+      map.set(term.term.toLowerCase(), term);
+    }
+    return map;
+  }, [filteredTerms]);
+
+  const termRegex = useMemo(
+    () => buildTermRegex(filteredTerms.map((t) => t.term)),
+    [filteredTerms],
+  );
+
+  return { annotations, termMap, termRegex, loading, error };
+}

--- a/web/lib/highlight.ts
+++ b/web/lib/highlight.ts
@@ -1,18 +1,7 @@
 import type { ReactNode } from "react";
+import type { SpanItem, TermDefinition } from "@/components/transcript/types";
 
-export interface TermDefinition {
-  term: string;
-  definition: string;
-  explanation: string;
-  category: "industry" | "financial";
-}
-
-export interface SpanItem {
-  speaker: string;
-  section: string;
-  text: string;
-  sequence_order: number;
-}
+export type { SpanItem, TermDefinition };
 
 function escapeRegex(source: string): string {
   return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Summary

Adds the `useAnnotations` client hook and the three response types that the Variant D learn page needs.

- Canonical `LearnAnnotationsResponse`, `TermDefinition`, and `QAEvasionItem` now live in `components/transcript/types.ts` alongside the other backend response types. `lib/highlight.ts` imports (and re-exports) `TermDefinition` and `SpanItem` from there, eliminating the small duplication PR #404 introduced.
- `useAnnotations(ticker)` fetches `/api/calls/{ticker}/learn-annotations` via the typed `api.get` wrapper (auth token attached automatically — no raw `fetch`).
- Single-word financial terms are filtered out before building the regex, per the eng review (avoids ambiguous matches on `yield`, `call`, `margin`, `note`).
- Both the `termMap` (for O(1) tooltip lookup) and the `termRegex` are memoized.
- Fetch failures surface via `error` without blocking render.

## Test plan

- [x] `pnpm test` — 59 tests pass (3 new for useAnnotations)
  - Fetches and returns annotations on mount
  - Filters single-word financial terms from the term map
  - Returns error state on fetch failure

Third in the 6-PR chain for milestone 5. Unblocks #395 and #396.

Closes #394