### PR TITLE
feat: add annotation components for the learn page (#395)

### DIFF
--- a/web/__tests__/components/learn/AnnotatedSpanBlock.test.tsx
+++ b/web/__tests__/components/learn/AnnotatedSpanBlock.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AnnotatedSpanBlock } from "@/components/learn/AnnotatedSpanBlock";
+import { buildTermRegex } from "@/lib/highlight";
+import type { SpanItem, TermDefinition } from "@/components/transcript/types";
+import { DEFAULT_LAYERS, type ChatContext } from "@/components/learn/types";
+
+const SPAN: SpanItem = {
+  speaker: "Jensen Huang",
+  section: "qa",
+  text: "Our data center GPU business grew sharply this quarter.",
+  sequence_order: 42,
+};
+
+const TERM: TermDefinition = {
+  term: "data center GPU",
+  definition: "Specialized compute hardware",
+  explanation: "Used primarily for AI training and inference workloads.",
+  category: "industry",
+};
+
+const TERM_MAP = new Map<string, TermDefinition>([[TERM.term.toLowerCase(), TERM]]);
+const TERM_REGEX = buildTermRegex([TERM.term]);
+
+describe("AnnotatedSpanBlock", () => {
+  it("renders the speaker label and span text", () => {
+    render(
+      <AnnotatedSpanBlock
+        span={SPAN}
+        layers={{ ...DEFAULT_LAYERS, terms: false }}
+        termRegex={null}
+        termMap={new Map()}
+        onChatClick={() => {}}
+      />,
+    );
+    expect(screen.getByText("Jensen Huang")).toBeInTheDocument();
+    expect(screen.getByText(SPAN.text)).toBeInTheDocument();
+  });
+
+  it("highlights matched terms as tooltip triggers when the terms layer is on", () => {
+    render(
+      <AnnotatedSpanBlock
+        span={SPAN}
+        layers={DEFAULT_LAYERS}
+        termRegex={TERM_REGEX}
+        termMap={TERM_MAP}
+        onChatClick={() => {}}
+      />,
+    );
+    const trigger = screen
+      .getAllByText("data center GPU")
+      .find((el) => el.getAttribute("data-slot") === "term-trigger");
+    expect(trigger).toBeDefined();
+  });
+
+  it("renders an evasion chat icon when evasionContext is provided and fires onChatClick", async () => {
+    const onChatClick = vi.fn();
+    const context: ChatContext = { type: "evasion", text: "foo", metadata: "bar" };
+    render(
+      <AnnotatedSpanBlock
+        span={SPAN}
+        layers={DEFAULT_LAYERS}
+        termRegex={null}
+        termMap={new Map()}
+        evasionContext={context}
+        onChatClick={onChatClick}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Discuss this passage/i }));
+    expect(onChatClick).toHaveBeenCalledWith(context);
+  });
+});

--- a/web/__tests__/components/learn/EvasionCard.test.tsx
+++ b/web/__tests__/components/learn/EvasionCard.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EvasionCard } from "@/components/learn/EvasionCard";
+import type { QAEvasionItem } from "@/components/transcript/types";
+
+const SAMPLE: QAEvasionItem = {
+  analyst_name: "Jane Doe",
+  question_topic: "Gross margin",
+  question_text: "Why did margin compress?",
+  answer_text: "We're investing in capacity for growth.",
+  analyst_concern: "Dodged the margin question",
+  defensiveness_score: 7,
+  evasion_explanation: "Deflected to a growth narrative instead of addressing margin.",
+};
+
+describe("EvasionCard", () => {
+  it("renders analyst concern and defensiveness score by default", () => {
+    render(<EvasionCard item={SAMPLE} onChatClick={() => {}} />);
+    expect(screen.getByText("Dodged the margin question")).toBeInTheDocument();
+    expect(screen.getByText(/Defensiveness: 7\/10/)).toBeInTheDocument();
+    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+  });
+
+  it("invokes onChatClick with an evasion context when the chat icon is clicked", async () => {
+    const onChatClick = vi.fn();
+    render(<EvasionCard item={SAMPLE} onChatClick={onChatClick} />);
+    await userEvent.click(screen.getByRole("button", { name: /Discuss this evasion/i }));
+    expect(onChatClick).toHaveBeenCalledWith({
+      type: "evasion",
+      text: SAMPLE.answer_text,
+      metadata: SAMPLE.analyst_concern,
+    });
+  });
+});

--- a/web/__tests__/components/learn/LayerToggle.test.tsx
+++ b/web/__tests__/components/learn/LayerToggle.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LayerToggle } from "@/components/learn/LayerToggle";
+import { DEFAULT_LAYERS } from "@/components/learn/types";
+
+describe("LayerToggle", () => {
+  it("renders a pill for each of the four layers", () => {
+    render(<LayerToggle layers={DEFAULT_LAYERS} onChange={() => {}} />);
+    expect(screen.getByRole("switch", { name: /Guidance/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /Evasion/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /Sentiment/i })).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: /Terms/i })).toBeInTheDocument();
+  });
+
+  it("reflects active state via aria-checked", () => {
+    render(
+      <LayerToggle
+        layers={{ guidance: true, evasion: false, sentiment: true, terms: false }}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("switch", { name: /Guidance/i })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(screen.getByRole("switch", { name: /Evasion/i })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+  });
+
+  it("calls onChange with the layer key when a pill is clicked", async () => {
+    const onChange = vi.fn();
+    render(<LayerToggle layers={DEFAULT_LAYERS} onChange={onChange} />);
+    await userEvent.click(screen.getByRole("switch", { name: /Evasion/i }));
+    expect(onChange).toHaveBeenCalledWith("evasion");
+  });
+});

--- a/web/components/learn/AnnotatedSpanBlock.tsx
+++ b/web/components/learn/AnnotatedSpanBlock.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { highlightTerms } from "@/lib/highlight";
+import type {
+  SpanItem,
+  TermDefinition,
+} from "@/components/transcript/types";
+import { TermTooltip } from "./TermTooltip";
+import type { AnnotationLayers, ChatContext } from "./types";
+
+interface AnnotatedSpanBlockProps {
+  span: SpanItem;
+  layers: AnnotationLayers;
+  termRegex: RegExp | null;
+  termMap: ReadonlyMap<string, TermDefinition>;
+  /** When set, renders a chat icon next to this span (e.g., the span is flagged for evasion). */
+  evasionContext?: ChatContext;
+  onChatClick: (context: ChatContext) => void;
+}
+
+/** Renders a transcript span with optional term highlights and an evasion chat icon. */
+export function AnnotatedSpanBlock({
+  span,
+  layers,
+  termRegex,
+  termMap,
+  evasionContext,
+  onChatClick,
+}: AnnotatedSpanBlockProps) {
+  const content = layers.terms
+    ? highlightTerms(span.text, termRegex, termMap, (matched, definition, key) => (
+        <TermTooltip key={key} term={matched} definition={definition} />
+      ))
+    : [span.text];
+
+  const showEvasionIcon = layers.evasion && evasionContext;
+
+  return (
+    <div className="px-4 py-3">
+      <div className="mb-1 flex items-baseline justify-between gap-2">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {span.speaker}
+        </p>
+        {showEvasionIcon ? (
+          <button
+            type="button"
+            aria-label="Discuss this passage"
+            onClick={() => onChatClick(evasionContext)}
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-amber-600 hover:bg-amber-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+          >
+            <MessageCircle className="h-4 w-4" aria-hidden />
+          </button>
+        ) : null}
+      </div>
+      <p className="text-sm leading-relaxed text-foreground">{content}</p>
+    </div>
+  );
+}

--- a/web/components/learn/ChatPanel.tsx
+++ b/web/components/learn/ChatPanel.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ChatInput } from "@/components/chat/ChatInput";
+import { ChatThread } from "@/components/chat/ChatThread";
+import { streamChat, type ChatMessage } from "@/lib/chat";
+import { cn } from "@/lib/utils";
+import type { ChatContext } from "./types";
+
+interface ChatPanelProps {
+  ticker: string;
+  context: ChatContext | null;
+  onClose: () => void;
+}
+
+/** Right-side chat panel wired to the streaming Feynman chat endpoint. */
+export function ChatPanel({ ticker, context, onClose }: ChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [streamingContent, setStreamingContent] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const initialValue = context ? contextToPrompt(context) : "";
+
+  async function handleSend(message: string) {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setMessages((m) => [...m, { role: "user", content: message }]);
+    setIsStreaming(true);
+    setStreamingContent("");
+
+    let accumulated = "";
+    try {
+      await streamChat(
+        ticker,
+        message,
+        sessionId,
+        {
+          onToken: (token) => {
+            accumulated += token;
+            setStreamingContent(accumulated);
+          },
+          onDone: (newSessionId) => {
+            setSessionId(newSessionId);
+            setMessages((m) => [...m, { role: "assistant", content: accumulated }]);
+            setStreamingContent("");
+            setIsStreaming(false);
+          },
+          onError: () => {
+            setIsStreaming(false);
+            setStreamingContent("");
+          },
+        },
+        controller.signal,
+      );
+    } catch {
+      setIsStreaming(false);
+    }
+  }
+
+  function handleAbort() {
+    abortRef.current?.abort();
+    setIsStreaming(false);
+  }
+
+  function handleNewSession() {
+    abortRef.current?.abort();
+    setMessages([]);
+    setStreamingContent("");
+    setSessionId(null);
+    setIsStreaming(false);
+  }
+
+  return (
+    <aside
+      className={cn(
+        "flex h-full w-full flex-col bg-background",
+        "lg:w-[400px] lg:border-l",
+      )}
+      aria-label="Learning chat"
+    >
+      <header className="flex items-center justify-between border-b px-4 py-3">
+        <h2 className="text-sm font-semibold">Discuss</h2>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={handleNewSession}>
+            New session
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            aria-label="Close chat panel"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </Button>
+        </div>
+      </header>
+      <div className="flex-1 overflow-hidden">
+        <ChatThread messages={messages} streamingContent={streamingContent} />
+      </div>
+      <div className="p-4">
+        <ChatInput
+          onSend={handleSend}
+          onAbort={handleAbort}
+          isStreaming={isStreaming}
+          initialValue={initialValue}
+        />
+      </div>
+    </aside>
+  );
+}
+
+function contextToPrompt(context: ChatContext): string {
+  switch (context.type) {
+    case "evasion":
+      return `Help me understand this evasion: ${context.metadata ?? ""}\n\n${context.text}`.trim();
+    case "term":
+      return `Explain "${context.text}" in context${context.metadata ? `: ${context.metadata}` : ""}.`;
+    case "guidance":
+      return `What should I take away from this guidance point? ${context.text}`;
+    default:
+      return context.text;
+  }
+}

--- a/web/components/learn/EvasionCard.tsx
+++ b/web/components/learn/EvasionCard.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { MessageCircle } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleChevron,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { evasionScoreToLevel, getEvasionStyle } from "@/lib/signal-colors";
+import { cn } from "@/lib/utils";
+import type { QAEvasionItem } from "@/components/transcript/types";
+import type { ChatContext } from "./types";
+
+interface EvasionCardProps {
+  item: QAEvasionItem;
+  onChatClick: (context: ChatContext) => void;
+}
+
+/** Amber-bordered collapsible card summarizing a Q&A evasion moment. */
+export function EvasionCard({ item, onChatClick }: EvasionCardProps) {
+  const [open, setOpen] = useState(false);
+  const level = evasionScoreToLevel(item.defensiveness_score);
+  const style = getEvasionStyle(level);
+
+  function handleChatClick() {
+    onChatClick({
+      type: "evasion",
+      text: item.answer_text ?? item.evasion_explanation,
+      metadata: item.analyst_concern,
+    });
+  }
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="my-3 overflow-hidden rounded-lg border border-amber-500/40 bg-amber-50/40 dark:bg-amber-500/5"
+    >
+      <div className="flex w-full items-start gap-3 px-4 py-3">
+        <CollapsibleTrigger className="flex flex-1 items-start gap-3 rounded text-left hover:bg-amber-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500">
+          <div className="flex-1 space-y-1">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <span
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+                  style.bg,
+                  style.text,
+                )}
+              >
+                <span aria-hidden>{style.emoji}</span>
+                Defensiveness: {item.defensiveness_score}/10
+              </span>
+              {item.analyst_name ? (
+                <span className="text-muted-foreground">{item.analyst_name}</span>
+              ) : null}
+              {item.question_topic ? (
+                <span className="text-muted-foreground">· {item.question_topic}</span>
+              ) : null}
+            </div>
+            <p className="text-sm font-medium text-foreground">{item.analyst_concern}</p>
+          </div>
+          <CollapsibleChevron open={open} className="mt-1 text-amber-700" />
+        </CollapsibleTrigger>
+        <button
+          type="button"
+          aria-label="Discuss this evasion"
+          onClick={handleChatClick}
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full text-amber-700 hover:bg-amber-500/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+        >
+          <MessageCircle className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+      <CollapsibleContent className="border-t border-amber-500/30 px-4 py-3 space-y-3 text-sm">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            What the executive avoided
+          </p>
+          <p>{item.evasion_explanation}</p>
+        </div>
+        {item.question_text ? (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Question
+            </p>
+            <p className="text-muted-foreground">{item.question_text}</p>
+          </div>
+        ) : null}
+        {item.answer_text ? (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Answer
+            </p>
+            <p className="text-muted-foreground">{item.answer_text}</p>
+          </div>
+        ) : null}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/web/components/learn/LayerToggle.tsx
+++ b/web/components/learn/LayerToggle.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { AnnotationLayer, AnnotationLayers } from "./types";
+
+interface LayerConfig {
+  key: AnnotationLayer;
+  label: string;
+  dotClass: string;
+}
+
+const LAYER_CONFIG: readonly LayerConfig[] = [
+  { key: "guidance", label: "Guidance", dotClass: "bg-blue-500" },
+  { key: "evasion", label: "Evasion", dotClass: "bg-amber-500" },
+  { key: "sentiment", label: "Sentiment", dotClass: "bg-purple-500" },
+  { key: "terms", label: "Terms", dotClass: "bg-green-500" },
+];
+
+interface LayerToggleProps {
+  layers: AnnotationLayers;
+  onChange: (layer: AnnotationLayer) => void;
+}
+
+/** Sticky pill bar for toggling annotation layers on the learn page. */
+export function LayerToggle({ layers, onChange }: LayerToggleProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Annotation layers"
+      className="sticky top-0 z-10 flex flex-wrap gap-2 border-b bg-background/95 px-4 py-3 backdrop-blur"
+    >
+      {LAYER_CONFIG.map((layer) => {
+        const active = layers[layer.key];
+        return (
+          <button
+            key={layer.key}
+            type="button"
+            role="switch"
+            aria-checked={active}
+            aria-label={`Toggle ${layer.label} layer`}
+            onClick={() => onChange(layer.key)}
+            className={cn(
+              "inline-flex min-h-[44px] items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors",
+              active
+                ? "border-foreground/20 bg-foreground/5 text-foreground"
+                : "border-transparent bg-transparent text-muted-foreground hover:bg-foreground/5",
+            )}
+          >
+            <span
+              aria-hidden
+              className={cn(
+                "h-2.5 w-2.5 rounded-full",
+                layer.dotClass,
+                !active && "opacity-40",
+              )}
+            />
+            {layer.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/learn/SectionCheckpoint.tsx
+++ b/web/components/learn/SectionCheckpoint.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { MisconceptionCard } from "@/components/transcript/MisconceptionCard";
+import type { MisconceptionItem } from "@/components/transcript/types";
+
+interface SectionCheckpointProps {
+  misconceptions: MisconceptionItem[];
+  title?: string;
+  subtitle?: string;
+}
+
+/** Checkpoint card rendered at the prepared→Q&A section boundary. Surfaces misconceptions. */
+export function SectionCheckpoint({
+  misconceptions,
+  title = "Check your understanding",
+  subtitle = "Before the Q&A begins, make sure these don't trip you up.",
+}: SectionCheckpointProps) {
+  if (misconceptions.length === 0) return null;
+
+  return (
+    <section className="my-6 rounded-xl border bg-muted/30 p-4">
+      <header className="mb-3">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </header>
+      <div className="space-y-2">
+        {misconceptions.map((item, index) => (
+          <MisconceptionCard key={index} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/components/learn/SentimentBar.tsx
+++ b/web/components/learn/SentimentBar.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { getSentimentStyle } from "@/lib/signal-colors";
+import { cn } from "@/lib/utils";
+import type { SynthesisInfo } from "@/components/transcript/types";
+
+interface SentimentBarProps {
+  synthesis: SynthesisInfo | null;
+}
+
+interface Badge {
+  label: string;
+  value: string | null;
+}
+
+/** Sticky sub-bar with overall / executive / analyst sentiment badges. */
+export function SentimentBar({ synthesis }: SentimentBarProps) {
+  if (!synthesis) return null;
+
+  const badges: Badge[] = [
+    { label: "Overall", value: synthesis.overall_sentiment },
+    { label: "Executive", value: synthesis.executive_tone },
+    { label: "Analyst", value: synthesis.analyst_sentiment },
+  ];
+
+  const visible = badges.filter((b): b is { label: string; value: string } => !!b.value);
+  if (visible.length === 0) return null;
+
+  return (
+    <div className="sticky top-[56px] z-[9] flex flex-wrap gap-2 border-b bg-background/90 px-4 py-2 text-xs backdrop-blur">
+      {visible.map(({ label, value }) => {
+        const style = getSentimentStyle(value);
+        return (
+          <span
+            key={label}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+              style.bg,
+              style.text,
+            )}
+          >
+            <span className="text-muted-foreground">{label}:</span>
+            <span>{value}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/components/learn/TermTooltip.tsx
+++ b/web/components/learn/TermTooltip.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import type { TermDefinition } from "@/components/transcript/types";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+interface TermTooltipProps {
+  term: string;
+  definition: TermDefinition;
+}
+
+/** Inline term with a dotted green underline. Click/focus reveals definition in a popover. */
+export function TermTooltip({ term, definition }: TermTooltipProps) {
+  return (
+    <Popover>
+      <PopoverTrigger
+        data-slot="term-trigger"
+        className="cursor-help border-b border-dashed border-green-500/70 text-foreground hover:text-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+        aria-label={`Definition of ${term}`}
+      >
+        {term}
+      </PopoverTrigger>
+      <PopoverContent
+        role="tooltip"
+        className="max-w-xs space-y-2 text-sm"
+        sideOffset={4}
+      >
+        <p className="font-semibold">{definition.term}</p>
+        <p className="text-muted-foreground">{definition.definition}</p>
+        {definition.explanation ? (
+          <p className="text-xs text-muted-foreground">{definition.explanation}</p>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/components/learn/types.ts
+++ b/web/components/learn/types.ts
@@ -1,0 +1,18 @@
+/** Shared types for the Variant D learn page components. */
+
+export type AnnotationLayer = "guidance" | "evasion" | "sentiment" | "terms";
+
+export type AnnotationLayers = Record<AnnotationLayer, boolean>;
+
+export const DEFAULT_LAYERS: AnnotationLayers = {
+  guidance: true,
+  evasion: true,
+  sentiment: true,
+  terms: true,
+};
+
+export interface ChatContext {
+  type: "evasion" | "term" | "guidance";
+  text: string;
+  metadata?: string;
+}


### PR DESCRIPTION
## Summary

New directory `web/components/learn/` with the primitives the upcoming learn page rewrite will assemble:

- **LayerToggle** — sticky pill bar, `role=switch` + `aria-checked` per layer.
- **TermTooltip** — dotted green underline + Popover (Base UI) with term/definition/explanation.
- **AnnotatedSpanBlock** — renders a span, pipes text through `highlightTerms` when the terms layer is active, shows an evasion chat icon when a `ChatContext` is supplied for that span.
- **EvasionCard** — amber-bordered Collapsible. Trigger and chat button are siblings (not nested) to keep the markup valid. Reuses `evasionScoreToLevel` + `getEvasionStyle`.
- **SentimentBar** — sticky sub-bar with overall / executive / analyst badges, reuses `getSentimentStyle`.
- **SectionCheckpoint** — wraps `MisconceptionCard` for the prepared→Q&A boundary.
- **ChatPanel** — wraps `ChatThread` + `ChatInput`, owns `streamChat` state, maps `ChatContext.type` (evasion/term/guidance) to an initial prompt.

Shared types live in `web/components/learn/types.ts`: `AnnotationLayer`, `AnnotationLayers`, `DEFAULT_LAYERS`, `ChatContext`.

## Test plan

- [x] `pnpm test` — 67 tests pass (3 new test files, 8 new cases)
- [x] `tsc --noEmit` clean
- [x] No React nested-button warnings

Render tests cover:
- `LayerToggle` — 4 pills render, `aria-checked` reflects state, click calls `onChange(layerKey)`
- `EvasionCard` — analyst concern + defensiveness score render, chat icon fires `onChatClick` with evasion context
- `AnnotatedSpanBlock` — speaker label + text render, term highlights appear when terms layer is on, evasion chat icon fires `onChatClick`

Fourth in the 6-PR chain for milestone 5. Unblocks #396.

Closes #395