### PR TITLE
feat: rewrite learn page as annotated transcript + chat (#396)

### DIFF
--- a/web/__tests__/components/LearnPage.test.tsx
+++ b/web/__tests__/components/LearnPage.test.tsx
@@ -1,9 +1,10 @@
 import React, { Suspense } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi } from "vitest";
+import { vi, describe, it, expect, beforeEach } from "vitest";
 import LearnPage from "@/app/calls/[ticker]/learn/page";
-import { callDetail } from "../utils/fixtures";
+import { callDetail, spansResponse } from "../utils/fixtures";
+import type { LearnAnnotationsResponse } from "@/components/transcript/types";
 
 /**
  * React 19's use() hook checks promise.status === "fulfilled" to return
@@ -47,10 +48,29 @@ vi.mock("@/lib/chat", () => ({
 }));
 
 import { api } from "@/lib/api";
-import { streamChat } from "@/lib/chat";
 
 const mockGet = api.get as ReturnType<typeof vi.fn>;
-const mockStreamChat = streamChat as ReturnType<typeof vi.fn>;
+
+const emptyAnnotations: LearnAnnotationsResponse = {
+  terms: [],
+  evasion: [],
+  takeaways: [],
+  misconceptions: [],
+  synthesis: null,
+};
+
+function setupApiResponses(overrides: Partial<{ annotations: LearnAnnotationsResponse }> = {}) {
+  mockGet.mockImplementation((path: string) => {
+    if (path.includes("/learn-annotations")) {
+      return Promise.resolve(overrides.annotations ?? emptyAnnotations);
+    }
+    if (path.includes("/spans")) {
+      return Promise.resolve(spansResponse);
+    }
+    // /api/calls/{ticker}
+    return Promise.resolve(callDetail);
+  });
+}
 
 function renderLearnPage(ticker = "aapl", topic?: string) {
   return render(
@@ -59,100 +79,53 @@ function renderLearnPage(ticker = "aapl", topic?: string) {
         params={fulfilledPromise({ ticker })}
         searchParams={fulfilledPromise({ topic })}
       />
-    </Suspense>
+    </Suspense>,
   );
 }
 
 describe("LearnPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGet.mockResolvedValue(callDetail);
-    mockStreamChat.mockResolvedValue(undefined);
+    setupApiResponses();
   });
 
   it("renders the heading with the uppercased ticker", async () => {
     renderLearnPage("aapl");
-    expect(screen.getByText(/AAPL/)).toBeInTheDocument();
-    // Wait for the suggestions useEffect to settle so act() warnings don't appear
+    expect(screen.getByRole("heading", { name: /Learn:/i })).toHaveTextContent(/AAPL/);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
   });
 
-  it("loads CallDetail and shows suggestion buttons from themes", async () => {
+  it("fetches learn-annotations, spans, and call detail on mount", async () => {
     renderLearnPage("aapl");
-    // callDetail has themes: ["services growth", "hardware resilience"]
-    // buildSuggestions generates questions from those
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith(expect.stringContaining("/api/calls/aapl"));
+      const paths = mockGet.mock.calls.map(([p]) => p as string);
+      expect(paths.some((p) => p.includes("/learn-annotations"))).toBe(true);
+      expect(paths.some((p) => p.includes("/spans"))).toBe(true);
+      expect(paths.some((p) => p === "/api/calls/aapl")).toBe(true);
     });
   });
 
-  it("appends user message to thread when Send is clicked", async () => {
+  it("renders all four annotation layer switches", async () => {
     renderLearnPage("aapl");
-    const textarea = screen.getByRole("textbox");
-    await userEvent.type(textarea, "What drove services revenue?");
-    await userEvent.keyboard("{Enter}");
     await waitFor(() => {
-      expect(screen.getByText("What drove services revenue?")).toBeInTheDocument();
-    });
-    expect(mockStreamChat).toHaveBeenCalledWith(
-      "aapl",
-      "What drove services revenue?",
-      null,
-      expect.any(Object),
-      expect.any(AbortSignal)
-    );
-  });
-
-  it("shows a dismissible error banner when streamChat calls onError", async () => {
-    mockStreamChat.mockImplementation(
-      (_ticker: unknown, _message: unknown, _sessionId: unknown, callbacks: { onError: (msg: string) => void }) => {
-        callbacks.onError("Something went wrong.");
-        return Promise.resolve();
-      }
-    );
-
-    renderLearnPage("aapl");
-    const textarea = screen.getByRole("textbox");
-    await userEvent.type(textarea, "Tell me about revenue");
-    await userEvent.keyboard("{Enter}");
-
-    await waitFor(() => {
-      expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByRole("button", { name: /dismiss error/i }));
-
-    await waitFor(() => {
-      expect(screen.queryByText("Something went wrong.")).not.toBeInTheDocument();
+      expect(screen.getByRole("switch", { name: /Guidance/i })).toBeInTheDocument();
+      expect(screen.getByRole("switch", { name: /Evasion/i })).toBeInTheDocument();
+      expect(screen.getByRole("switch", { name: /Sentiment/i })).toBeInTheDocument();
+      expect(screen.getByRole("switch", { name: /Terms/i })).toBeInTheDocument();
     });
   });
 
-  it("clears messages and resets state when New session is clicked", async () => {
-    // Make streamChat call onDone to add an assistant message
-    mockStreamChat.mockImplementation(
-      (_ticker: unknown, _message: unknown, _sessionId: unknown, callbacks: { onToken: (t: string) => void; onDone: (id: string) => void }) => {
-        callbacks.onToken("Great question.");
-        callbacks.onDone("session-1");
-        return Promise.resolve();
-      }
-    );
-
+  it("opens the chat panel when the Discuss button is clicked", async () => {
     renderLearnPage("aapl");
-    const textarea = screen.getByRole("textbox");
-    await userEvent.type(textarea, "Tell me about iPhone");
-    await userEvent.keyboard("{Enter}");
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole("button", { name: /Discuss/i }));
+    expect(screen.getByRole("complementary", { name: /Learning chat/i })).toBeInTheDocument();
+  });
 
-    // Wait for the assistant message to appear
+  it("pre-opens the chat panel when a ?topic= search param is supplied", async () => {
+    renderLearnPage("aapl", "EBITDA");
     await waitFor(() => {
-      expect(screen.getByText("Tell me about iPhone")).toBeInTheDocument();
-    });
-
-    // Click "New session"
-    await userEvent.click(screen.getByRole("button", { name: /new session/i }));
-
-    // Messages should be gone
-    await waitFor(() => {
-      expect(screen.queryByText("Tell me about iPhone")).not.toBeInTheDocument();
+      expect(screen.getByRole("complementary", { name: /Learning chat/i })).toBeInTheDocument();
     });
   });
 });

--- a/web/app/calls/[ticker]/learn/page.tsx
+++ b/web/app/calls/[ticker]/learn/page.tsx
@@ -1,18 +1,35 @@
 "use client";
 
-import { use, useEffect, useRef, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { MessageCircle } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { ChatThread } from "@/components/chat/ChatThread";
-import { ChatInput } from "@/components/chat/ChatInput";
-import { streamChat } from "@/lib/chat";
 import { api } from "@/lib/api";
 import { useFlag } from "@/lib/useFlag";
-import { buildSuggestions } from "@/lib/suggestions";
-import type { ChatMessage } from "@/lib/chat";
-import type { TopicsResponse, KeywordsResponse } from "@/components/transcript/types";
+import { findEvasionSpanIndex } from "@/lib/highlight";
+import { useAnnotations } from "@/hooks/useAnnotations";
+import { AnnotatedSpanBlock } from "@/components/learn/AnnotatedSpanBlock";
+import { ChatPanel } from "@/components/learn/ChatPanel";
+import { EvasionCard } from "@/components/learn/EvasionCard";
+import { LayerToggle } from "@/components/learn/LayerToggle";
+import { SectionCheckpoint } from "@/components/learn/SectionCheckpoint";
+import { SentimentBar } from "@/components/learn/SentimentBar";
+import { CallBriefPanel } from "@/components/transcript/CallBriefPanel";
+import {
+  DEFAULT_LAYERS,
+  type AnnotationLayer,
+  type AnnotationLayers,
+  type ChatContext,
+} from "@/components/learn/types";
+import type {
+  CallDetail,
+  QAEvasionItem,
+  SpansResponse,
+} from "@/components/transcript/types";
 
-/** Feynman-style learning chat for a given ticker's transcript. */
+const PAGE_SIZE = 50;
+
+/** Annotated transcript + chat panel learning experience. */
 export default function LearnPage({
   params,
   searchParams,
@@ -23,153 +40,259 @@ export default function LearnPage({
   const { ticker } = use(params);
   const { topic } = use(searchParams);
   const upperTicker = ticker.toUpperCase();
-
   const chatEnabled = useFlag("chat_enabled", true);
 
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [streamingContent, setStreamingContent] = useState("");
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [loadingSuggestions, setLoadingSuggestions] = useState(true);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const [layers, setLayers] = useState<AnnotationLayers>(DEFAULT_LAYERS);
+  const [chatContext, setChatContext] = useState<ChatContext | null>(
+    topic ? { type: "term", text: topic } : null,
+  );
+  const [chatOpen, setChatOpen] = useState<boolean>(Boolean(topic));
 
-  // Cancel any in-flight stream when the component unmounts (navigation away)
-  useEffect(() => {
-    return () => { abortControllerRef.current?.abort(); };
-  }, []);
+  const [call, setCall] = useState<CallDetail | null>(null);
+  const [spans, setSpans] = useState<SpansResponse | null>(null);
+  const [page, setPage] = useState<number>(1);
+  const [spansError, setSpansError] = useState<string | null>(null);
+
+  const {
+    annotations,
+    termMap,
+    termRegex,
+    loading: annotationsLoading,
+    error: annotationsError,
+  } = useAnnotations(ticker);
 
   useEffect(() => {
-    Promise.all([
-      api.get<TopicsResponse>(`/api/calls/${ticker}/topics`),
-      api.get<KeywordsResponse>(`/api/calls/${ticker}/keywords`),
-    ])
-      .then(([topics, kw]) => setSuggestions(buildSuggestions(topics.themes, kw.keywords)))
-      .catch(() => {
-        // Silent degradation — suggestions are a progressive enhancement
-      })
-      .finally(() => setLoadingSuggestions(false));
+    api
+      .get<CallDetail>(`/api/calls/${ticker}`)
+      .then(setCall)
+      .catch(() => setCall(null));
   }, [ticker]);
 
-  function handleAbort() {
-    abortControllerRef.current?.abort();
-    setStreamingContent("");
-    setIsStreaming(false);
-  }
+  useEffect(() => {
+    setSpansError(null);
+    api
+      .get<SpansResponse>(
+        `/api/calls/${ticker}/spans?section=all&page=${page}&page_size=${PAGE_SIZE}`,
+      )
+      .then(setSpans)
+      .catch((err: unknown) => {
+        setSpans(null);
+        setSpansError(err instanceof Error ? err.message : "Failed to load transcript");
+      });
+  }, [ticker, page]);
 
-  async function handleSend(message: string) {
-    abortControllerRef.current?.abort();
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
+  const evasionBySpanIndex = useMemo(() => {
+    const map = new Map<number, QAEvasionItem>();
+    if (!annotations || !spans) return map;
+    for (const item of annotations.evasion) {
+      if (!item.answer_text) continue;
+      const idx = findEvasionSpanIndex(item.answer_text, spans.spans);
+      if (idx !== null && !map.has(idx)) {
+        map.set(idx, item);
+      }
+    }
+    return map;
+  }, [annotations, spans]);
 
-    setError(null);
-    setIsStreaming(true);
-    setStreamingContent("");
-    setMessages((prev) => [...prev, { role: "user", content: message }]);
+  const preparedToQaBoundary = useMemo(() => {
+    if (!spans) return -1;
+    for (let i = 0; i < spans.spans.length; i += 1) {
+      if (spans.spans[i].section === "qa") return i;
+    }
+    return -1;
+  }, [spans]);
 
-    let accumulated = "";
+  const toggleLayer = useCallback((layer: AnnotationLayer) => {
+    setLayers((prev) => ({ ...prev, [layer]: !prev[layer] }));
+  }, []);
 
-    await streamChat(ticker, message, sessionId, {
-      onToken(token) {
-        accumulated += token;
-        setStreamingContent(accumulated);
-      },
-      onDone(newSessionId) {
-        setSessionId(newSessionId);
-        setMessages((prev) => [
-          ...prev,
-          { role: "assistant", content: accumulated },
-        ]);
-        setStreamingContent("");
-        setIsStreaming(false);
-      },
-      onError(msg) {
-        if (controller.signal.aborted) return;
-        setError(msg);
-        setStreamingContent("");
-        setIsStreaming(false);
-      },
-    }, controller.signal);
-  }
+  const handleChatClick = useCallback((context: ChatContext) => {
+    setChatContext(context);
+    setChatOpen(true);
+  }, []);
 
-  function handleNewSession() {
-    setMessages([]);
-    setStreamingContent("");
-    setSessionId(null);
-    setError(null);
-  }
+  const handleOpenChat = useCallback(() => {
+    setChatContext(null);
+    setChatOpen(true);
+  }, []);
+
+  const handleCloseChat = useCallback(() => {
+    setChatOpen(false);
+  }, []);
+
+  const totalPages = spans ? Math.max(1, Math.ceil(spans.total / spans.page_size)) : 1;
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-1 min-h-0 flex-col px-6 py-8">
-      {/* Header */}
-      <div className="mb-6 flex items-center justify-between">
-        <div className="flex items-baseline gap-3">
+    <div className="flex h-[calc(100dvh-var(--nav-height))] w-full overflow-hidden">
+      <section
+        className={chatOpen ? "hidden min-w-0 flex-1 lg:flex lg:flex-col" : "flex min-w-0 flex-1 flex-col"}
+        aria-label="Annotated transcript"
+      >
+        {/* Header */}
+        <header className="flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3">
           <div>
-            <h1 className="text-3xl font-semibold text-foreground">
-              Learn:{" "}
-              <span className="uppercase">{upperTicker}</span>
+            <h1 className="text-xl font-semibold text-foreground">
+              Learn: <span className="uppercase">{upperTicker}</span>
             </h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Explain what you&apos;ve learned in your own words — the AI will probe your understanding
+            <p className="text-xs text-muted-foreground">
+              Toggle layers to explore guidance, evasion, sentiment, and terms.
             </p>
           </div>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleNewSession}
-            disabled={isStreaming}
-          >
-            New session
-          </Button>
-          <Link
-            href={`/calls/${upperTicker}`}
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-          >
-            View transcript
-          </Link>
-        </div>
-      </div>
-
-      {!chatEnabled ? (
-        <div className="flex flex-1 items-center justify-center">
-          <p className="text-sm text-muted-foreground">
-            Chat is temporarily unavailable. Please check back later.
-          </p>
-        </div>
-      ) : (
-        <>
-          {/* Error banner */}
-          {error && (
-            <div className="mb-4 flex items-start gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-              <span className="flex-1">{error}</span>
-              <button
-                onClick={() => setError(null)}
-                aria-label="Dismiss error"
-                className="shrink-0 text-destructive/60 hover:text-destructive"
-              >
-                ✕
-              </button>
-            </div>
-          )}
-
-          {/* Chat thread */}
-          <ChatThread
-            messages={messages}
-            streamingContent={streamingContent}
-            suggestions={suggestions}
-            loadingSuggestions={loadingSuggestions}
-            onSuggestionClick={handleSend}
-          />
-
-          {/* Input */}
-          <div className="mt-4">
-            <ChatInput onSend={handleSend} onAbort={handleAbort} isStreaming={isStreaming} initialValue={topic ?? ""} />
+          <div className="flex items-center gap-2">
+            {chatEnabled ? (
+              <Button variant="outline" size="sm" onClick={handleOpenChat}>
+                <MessageCircle className="mr-1 h-4 w-4" aria-hidden />
+                Discuss
+              </Button>
+            ) : null}
+            <Link
+              href={`/calls/${upperTicker}`}
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              View transcript
+            </Link>
           </div>
-        </>
-      )}
+        </header>
+
+        {/* Layer toggle + sentiment bar */}
+        <LayerToggle layers={layers} onChange={toggleLayer} />
+        {layers.sentiment ? <SentimentBar synthesis={annotations?.synthesis ?? null} /> : null}
+
+        {/* Scrollable content area */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="mx-auto w-full max-w-3xl px-4 py-6">
+            {/* Brief */}
+            {call?.brief ? (
+              <CallBriefPanel
+                brief={call.brief}
+                takeaways={call.takeaways}
+                misconceptions={call.misconceptions}
+                signal_strip={call.signal_strip ?? null}
+              />
+            ) : null}
+
+            {/* Errors */}
+            {spansError ? (
+              <div
+                role="alert"
+                className="mb-4 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+              >
+                {spansError}
+              </div>
+            ) : null}
+            {annotationsError ? (
+              <div
+                role="alert"
+                className="mb-4 rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-foreground"
+              >
+                Some annotations could not load. The transcript is still readable.
+              </div>
+            ) : null}
+
+            {/* Transcript */}
+            {spans ? (
+              <div className="divide-y rounded-lg border bg-background">
+                {spans.spans.map((span, index) => {
+                  const elements: React.ReactNode[] = [];
+
+                  if (
+                    layers.guidance &&
+                    index === preparedToQaBoundary &&
+                    call?.misconceptions?.length
+                  ) {
+                    elements.push(
+                      <SectionCheckpoint
+                        key={`checkpoint-${span.sequence_order}`}
+                        misconceptions={call.misconceptions}
+                      />,
+                    );
+                  }
+
+                  elements.push(
+                    <AnnotatedSpanBlock
+                      key={`span-${span.sequence_order}`}
+                      span={span}
+                      layers={layers}
+                      termRegex={layers.terms ? termRegex : null}
+                      termMap={termMap}
+                      evasionContext={
+                        layers.evasion && evasionBySpanIndex.has(index)
+                          ? {
+                              type: "evasion",
+                              text: span.text,
+                              metadata:
+                                evasionBySpanIndex.get(index)?.analyst_concern,
+                            }
+                          : undefined
+                      }
+                      onChatClick={handleChatClick}
+                    />,
+                  );
+
+                  if (layers.evasion && evasionBySpanIndex.has(index)) {
+                    elements.push(
+                      <EvasionCard
+                        key={`evasion-${span.sequence_order}`}
+                        item={evasionBySpanIndex.get(index)!}
+                        onChatClick={handleChatClick}
+                      />,
+                    );
+                  }
+
+                  return <div key={span.sequence_order}>{elements}</div>;
+                })}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {annotationsLoading ? "Loading transcript…" : "No transcript spans found."}
+              </p>
+            )}
+
+            {/* Pagination */}
+            {spans && totalPages > 1 ? (
+              <nav
+                aria-label="Transcript pagination"
+                className="mt-6 flex items-center justify-between gap-3"
+              >
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                >
+                  Previous
+                </Button>
+                <span className="text-xs text-muted-foreground">
+                  Page {page} of {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={page >= totalPages}
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                >
+                  Next
+                </Button>
+              </nav>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      {chatEnabled && chatOpen ? (
+        <div className="fixed inset-0 z-40 flex lg:static lg:z-auto lg:inset-auto">
+          {/* Backdrop for mobile */}
+          <button
+            type="button"
+            aria-label="Close chat overlay"
+            onClick={handleCloseChat}
+            className="flex-1 bg-black/30 lg:hidden"
+          />
+          <div className="h-full w-full bg-background lg:w-[400px] lg:border-l">
+            <ChatPanel ticker={ticker} context={chatContext} onClose={handleCloseChat} />
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/app/calls/[ticker]/page.tsx
+++ b/web/app/calls/[ticker]/page.tsx
@@ -135,9 +135,9 @@ export default async function TranscriptPage({
           <MetadataPanel call={call} />
           <Link href={`/calls/${call.ticker}/learn`} className="mt-4 block group">
             <Card className="p-4 transition-colors group-hover:bg-muted">
-              <p className="text-sm font-semibold text-foreground">Study with Feynman chat</p>
+              <p className="text-sm font-semibold text-foreground">Study the annotated transcript</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Explain what you&apos;ve learned — the AI will probe your understanding
+                Toggle guidance, evasion, sentiment, and term layers — then chat about any passage.
               </p>
             </Card>
           </Link>


### PR DESCRIPTION
## Summary

Capstone of the Variant D milestone. Replaces the single-column Feynman chat with a two-panel layout: annotated transcript on the left, togglable chat panel on the right (overlay on mobile). Assembles the pieces landed in #392–#395.

### Transcript panel
- `LayerToggle` + optional `SentimentBar` are sticky above the scroll area.
- `CallBriefPanel` renders at the top (reused, unchanged).
- Spans paginated via the existing `/spans` endpoint (page_size 50), rendered as `AnnotatedSpanBlock`.
- `EvasionCard`s interleaved after matching Q&A spans via `findEvasionSpanIndex`.
- `SectionCheckpoint` inserted at the first prepared→Q&A boundary when guidance layer is active and misconceptions exist.
- Non-blocking error banners for spans/annotations failures.

### Chat panel
- Hidden by default. Opens on Discuss click, any evasion chat icon, or any span chat icon.
- `?topic=…` query param pre-opens the panel with a term context — preserves existing deep-links from the analysis page.
- Desktop: 400px right rail. Mobile: full-screen overlay with dismissible backdrop.

### Copy update
- Analysis page "Study with Feynman chat" card → "Study the annotated transcript" + updated description.

## Test plan

- [x] `pnpm test` — 67 tests pass (LearnPage test rewritten for the new layout)
- [x] `tsc --noEmit` clean
- [x] `pytest -q` — 262 tests pass (no backend changes, but verified)

New LearnPage tests:
- Heading reflects uppercased ticker
- Mount fetches learn-annotations, spans, and call detail
- Four annotation layer switches render
- Discuss button opens the chat panel
- `?topic=` pre-opens the chat panel with a term context

## Manual verification (reviewer)

Run `./dev.sh`, open `/calls/NVDA/learn`:
1. Two-panel chrome with sticky layer toggle.
2. Click each layer — highlights/badges/icons appear/disappear.
3. Click a Q&A evasion chat icon — panel opens with pre-filled context.
4. Click a term — tooltip renders with definition.
5. Resize to <1024px — chat becomes an overlay.

Fifth in the 6-PR chain for milestone 5. Unblocks #397 (TranscriptBrowser retirement), which should wait until this has real-usage validation.

Closes #396