### PR TITLE
fix: make annotation term highlights actually visible

### DIFF
--- a/web/__tests__/components/learn/AnnotatedSpanBlock.test.tsx
+++ b/web/__tests__/components/learn/AnnotatedSpanBlock.test.tsx
@@ -52,6 +52,10 @@ describe("AnnotatedSpanBlock", () => {
       .getAllByText("data center GPU")
       .find((el) => el.getAttribute("data-slot") === "term-trigger");
     expect(trigger).toBeDefined();
+    // Must be visibly styled (not the default unstyled inline button) —
+    // confirms the green highlight wraps the term text.
+    expect(trigger!.className).toMatch(/bg-green/);
+    expect(trigger!.className).toMatch(/underline/);
   });
 
   it("renders an evasion chat icon when evasionContext is provided and fires onChatClick", async () => {

--- a/web/__tests__/hooks/useAnnotations.test.ts
+++ b/web/__tests__/hooks/useAnnotations.test.ts
@@ -52,13 +52,19 @@ describe("useAnnotations", () => {
     expect(result.current.termMap.get("arr")).toBeDefined();
   });
 
-  it("filters out single-word financial terms from the term map", async () => {
+  it("filters ambiguous lowercase financial words but keeps acronyms and multi-word terms", async () => {
     getMock.mockResolvedValueOnce(
       makeResponse({
         terms: [
+          // Ambiguous lowercase single word — filtered out
           { term: "margin", definition: "", explanation: "", category: "financial" },
+          // Multi-word financial — kept
           { term: "gross margin", definition: "", explanation: "", category: "financial" },
-          { term: "EBITDA", definition: "", explanation: "", category: "industry" },
+          // Financial acronym — kept (was the bug: previous rule dropped these)
+          { term: "EBITDA", definition: "", explanation: "", category: "financial" },
+          { term: "ARR", definition: "", explanation: "", category: "financial" },
+          // Industry — always kept regardless of shape
+          { term: "yield", definition: "", explanation: "", category: "industry" },
         ],
       }),
     );
@@ -69,6 +75,8 @@ describe("useAnnotations", () => {
     expect(result.current.termMap.has("margin")).toBe(false);
     expect(result.current.termMap.has("gross margin")).toBe(true);
     expect(result.current.termMap.has("ebitda")).toBe(true);
+    expect(result.current.termMap.has("arr")).toBe(true);
+    expect(result.current.termMap.has("yield")).toBe(true); // industry category bypasses filter
     expect(result.current.termRegex).not.toBeNull();
   });
 

--- a/web/components/learn/TermTooltip.tsx
+++ b/web/components/learn/TermTooltip.tsx
@@ -18,8 +18,14 @@ export function TermTooltip({ term, definition }: TermTooltipProps) {
     <Popover>
       <PopoverTrigger
         data-slot="term-trigger"
-        className="cursor-help border-b border-dashed border-green-500/70 text-foreground hover:text-green-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
         aria-label={`Definition of ${term}`}
+        render={
+          <span
+            tabIndex={0}
+            role="button"
+            className="cursor-help rounded bg-green-500/10 px-0.5 text-foreground underline decoration-green-600 decoration-dashed decoration-2 underline-offset-2 hover:bg-green-500/20 hover:text-green-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500"
+          />
+        }
       >
         {term}
       </PopoverTrigger>

--- a/web/hooks/useAnnotations.ts
+++ b/web/hooks/useAnnotations.ts
@@ -16,10 +16,28 @@ export interface UseAnnotationsResult {
   error: string | null;
 }
 
+// Common lowercase financial words that are ambiguous in prose — they appear
+// constantly in sentences without referring to the financial concept.
+// Everything else (acronyms like EBITDA/ARR, multi-word phrases, industry
+// terms) passes through.
+const AMBIGUOUS_SINGLE_WORDS = new Set([
+  "call",
+  "margin",
+  "note",
+  "yield",
+  "cash",
+  "debt",
+  "equity",
+  "bond",
+  "share",
+  "unit",
+]);
+
 function filterTerms(terms: readonly TermDefinition[]): TermDefinition[] {
   return terms.filter((t) => {
     if (t.category === "industry") return true;
-    return t.term.includes(" ");
+    if (t.term.includes(" ")) return true;
+    return !AMBIGUOUS_SINGLE_WORDS.has(t.term.toLowerCase());
   });
 }
 


### PR DESCRIPTION
## Summary

Two bugs were suppressing **all** term highlighting on `/calls/[ticker]/learn`. Toggling the Terms layer produced no visible change in production.

### Bug 1 — Filter was too aggressive

`useAnnotations`'s `filterTerms` excluded *every* single-word financial term. In practice the highest-value terms in an earnings call (EBITDA, ARR, SaaS, FCF, CapEx, …) are all single-word financial, so `termMap` routinely ended up empty and no matches could fire.

Replaced with a small deny-list: drop only the ambiguous lowercase words that appear constantly in prose without referring to the financial concept (`margin`, `yield`, `call`, `note`, `cash`, `debt`, `equity`, `bond`, `share`, `unit`). Acronyms and multi-word phrases pass through, as do all industry-category terms.

### Bug 2 — Trigger markup collapsed visually

`TermTooltip` rendered its trigger as Base UI's default `<button>`, which inherits the project's button reset and can collapse inline layout inside a `<p>`. Switched to the Popover `render` prop with an inline `<span role="button" tabIndex="0">`, and strengthened the visual: light green background + dashed green underline. The term is now unmistakable on the page.

## Test plan

- [x] `pnpm test` — 67 pass (filter tests updated, highlight visibility asserted)
- [x] `tsc --noEmit` clean
- [x] Manual: open `/calls/<ticker with EBITDA in transcript>/learn`, toggle Terms layer, confirm matches highlight.

## Context

Part of the Guided Analysis polish pass on milestone 5. PR B will consolidate `/learn` into `/calls/[ticker]`; PR C will retire `TranscriptBrowser`. This fix lands first so the downstream restructuring happens on top of working highlighting.