### PR TITLE
fix: sentiment bar width + reframe evasion cards

### DIFF
--- a/web/__tests__/components/learn/EvasionCard.test.tsx
+++ b/web/__tests__/components/learn/EvasionCard.test.tsx
@@ -15,11 +15,14 @@ const SAMPLE: QAEvasionItem = {
 };
 
 describe("EvasionCard", () => {
-  it("renders analyst concern and defensiveness score by default", () => {
+  it("renders analyst concern, evasion tag, and defensiveness detail by default", () => {
     render(<EvasionCard item={SAMPLE} onChatClick={() => {}} />);
     expect(screen.getByText("Dodged the margin question")).toBeInTheDocument();
-    expect(screen.getByText(/Defensiveness: 7\/10/)).toBeInTheDocument();
-    expect(screen.getByText("Jane Doe")).toBeInTheDocument();
+    // Primary framing: "Evasion · [Level]"
+    expect(screen.getByText(/Evasion · Medium/i)).toBeInTheDocument();
+    // Numeric score demoted to secondary metadata
+    expect(screen.getByText(/defensiveness 7\/10/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane Doe/)).toBeInTheDocument();
   });
 
   it("invokes onChatClick with an evasion context when the chat icon is clicked", async () => {

--- a/web/app/calls/[ticker]/GuidedAnalysisView.tsx
+++ b/web/app/calls/[ticker]/GuidedAnalysisView.tsx
@@ -192,15 +192,17 @@ export function GuidedAnalysisView({ call, adjacent, initialTopic }: GuidedAnaly
           </div>
         </header>
 
-        {/* Layer toggle + sentiment bar */}
+        {/* Layer toggle */}
         <LayerToggle layers={layers} onChange={toggleLayer} />
-        {layers.sentiment ? (
-          <SentimentBar synthesis={annotations?.synthesis ?? null} />
-        ) : null}
 
         {/* Scrollable content area */}
         <div className="flex-1 overflow-y-auto">
           <div className="mx-auto w-full max-w-3xl px-4 py-6">
+            {/* Sentiment summary — inline so it scrolls with the content */}
+            {layers.sentiment ? (
+              <SentimentBar synthesis={annotations?.synthesis ?? null} />
+            ) : null}
+
             {/* Brief */}
             {call.brief ? (
               <CallBriefPanel

--- a/web/components/learn/EvasionCard.tsx
+++ b/web/components/learn/EvasionCard.tsx
@@ -44,16 +44,19 @@ export function EvasionCard({ item, onChatClick }: EvasionCardProps) {
             <div className="flex flex-wrap items-center gap-2 text-xs">
               <span
                 className={cn(
-                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold uppercase tracking-wide",
                   style.bg,
                   style.text,
                 )}
               >
                 <span aria-hidden>{style.emoji}</span>
-                Defensiveness: {item.defensiveness_score}/10
+                Evasion · {style.label}
+              </span>
+              <span className="text-muted-foreground">
+                defensiveness {item.defensiveness_score}/10
               </span>
               {item.analyst_name ? (
-                <span className="text-muted-foreground">{item.analyst_name}</span>
+                <span className="text-muted-foreground">· {item.analyst_name}</span>
               ) : null}
               {item.question_topic ? (
                 <span className="text-muted-foreground">· {item.question_topic}</span>

--- a/web/components/learn/SentimentBar.tsx
+++ b/web/components/learn/SentimentBar.tsx
@@ -27,7 +27,10 @@ export function SentimentBar({ synthesis }: SentimentBarProps) {
   if (visible.length === 0) return null;
 
   return (
-    <div className="sticky top-[56px] z-[9] flex flex-wrap gap-2 border-b bg-background/90 px-4 py-2 text-xs backdrop-blur">
+    <div className="mb-4 flex flex-wrap items-center gap-2 text-xs">
+      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Sentiment
+      </span>
       {visible.map(({ label, value }) => {
         const style = getSentimentStyle(value);
         return (


### PR DESCRIPTION
## Summary

Two visual fixes reported after Guided Analysis shipped:

### 1. SentimentBar overflowed and blocked scrolling

Previously sticky, full-width, and pinned to the top of the viewport — it spilled outside the `max-w-3xl` transcript column and visually interfered with scroll. Moved it inside the scrollable content container so it inherits the width constraint and scrolls out of the way as the user reads. Dropped the sticky positioning and the full-width `border-b` bar in favour of a simple inline badge row prefixed with a "Sentiment" label.

### 2. EvasionCard buried the pedagogical signal

Led with "Defensiveness: N/10", which reads like a score, not a finding. Promoted **"Evasion · [Low/Medium/High]"** to the primary pill (using the level label from `getEvasionStyle`) and demoted the numeric score to secondary metadata ("defensiveness N/10" in muted text alongside analyst name / topic).

Readers now see "this is evasion" at a glance, with the underlying score available for detail.

## Test plan

- [x] `pnpm test` — 62 pass (EvasionCard test updated for the new copy)
- [x] `tsc --noEmit` clean
- [ ] Manual: sentiment bar no longer overlaps the viewport edge; evasion cards lead with "Evasion · …" tag