### PR TITLE
fix: square off LayerToggle pills per multi-line badge standard

### DIFF
--- a/web/components/learn/LayerToggle.tsx
+++ b/web/components/learn/LayerToggle.tsx
@@ -40,7 +40,7 @@ export function LayerToggle({ layers, onChange }: LayerToggleProps) {
             aria-label={`Toggle ${layer.label} layer`}
             onClick={() => onChange(layer.key)}
             className={cn(
-              "inline-flex min-h-[44px] items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors",
+              "inline-flex min-h-[44px] items-center gap-2 rounded-md border px-3 py-1.5 text-sm transition-colors",
               active
                 ? "border-foreground/20 bg-foreground/5 text-foreground"
                 : "border-transparent bg-transparent text-muted-foreground hover:bg-foreground/5",


### PR DESCRIPTION
## Summary

`LayerToggle` used `rounded-full` on its four layer buttons. Per the project's `tailwind-rounded-full-multiline-badge` convention, `rounded-full` is reserved for guaranteed-short, single-line content. On narrow viewports the pill row wraps to two lines and the circular shape reads inconsistently across rows.

Swapped to `rounded-md` to match the treatment used elsewhere (`CallBriefPanel` SignalStrip badges, sentiment badges, etc.).

The inner 2.5×2.5 color dot keeps `rounded-full` — it's a fixed-size circular icon, not a label.

## Test plan

- [x] `pnpm test` LayerToggle — 3 pass
- [x] `tsc --noEmit` clean
- [ ] Manual: confirm pills read consistently when wrapping on narrow viewports.

No behaviour change; visual only.