### PR TITLE
fix: sweep remaining rounded-full offenders

### DIFF
--- a/web/components/CallCard.tsx
+++ b/web/components/CallCard.tsx
@@ -41,7 +41,7 @@ export function CallCard({ call }: CallCardProps) {
         )}
         {call.industry && (
           <div>
-            <Badge variant="secondary" className="rounded-full">
+            <Badge variant="secondary" className="rounded-md">
               {call.industry}
             </Badge>
           </div>

--- a/web/components/learn/EvasionCard.tsx
+++ b/web/components/learn/EvasionCard.tsx
@@ -44,7 +44,7 @@ export function EvasionCard({ item, onChatClick }: EvasionCardProps) {
             <div className="flex flex-wrap items-center gap-2 text-xs">
               <span
                 className={cn(
-                  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold uppercase tracking-wide",
+                  "inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-semibold uppercase tracking-wide",
                   style.bg,
                   style.text,
                 )}

--- a/web/components/learn/SentimentBar.tsx
+++ b/web/components/learn/SentimentBar.tsx
@@ -37,7 +37,7 @@ export function SentimentBar({ synthesis }: SentimentBarProps) {
           <span
             key={label}
             className={cn(
-              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium",
+              "inline-flex items-center gap-1 rounded-md px-2 py-0.5 font-medium",
               style.bg,
               style.text,
             )}


### PR DESCRIPTION
## Summary

Three live offenders found in the post-ship audit, all wrap-prone text pills that shouldn't have been `rounded-full`:

- `EvasionCard` — the "Evasion · Low/Medium/High" primary tag pill
- `SentimentBar` — the three Overall / Executive / Analyst sentiment badges (values come from the LLM, so they're wrap-prone by definition)
- `CallCard` — the secondary `Badge` showing call industry

All three flipped to `rounded-md` to match the project convention (same treatment as `LayerToggle` in PR #413, same pattern documented in `~/.claude/skills/learned/tailwind-rounded-full-multiline-badge.md`).

## Validation

The PostToolUse hook added in PR #414 stays silent on all three files after this fix — good round-trip validation of the enforcement. Tested locally:

```
✓ silent: web/components/learn/EvasionCard.tsx
✓ silent: web/components/learn/SentimentBar.tsx
✓ silent: web/components/CallCard.tsx
```

- `pnpm test` — 62 pass
- `tsc --noEmit` clean

No behavior change; visual only.

Follow-up (PR 3 in this chain): absorb a "Recurrence" note into the global `tailwind-rounded-full-multiline-badge` skill pointing at the hook.