### PR TITLE
feat: add evasion_type taxonomy to Q&A ingestion + API

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -64,6 +64,7 @@ class EvasionItem(BaseModel):
     evasion_explanation: str
     question_topic: str | None = None
     analyst_name: str | None = None
+    evasion_type: str | None = None
 
 
 class StrategicShift(BaseModel):
@@ -139,6 +140,7 @@ class QAEvasionItem(BaseModel):
     analyst_concern: str
     defensiveness_score: int
     evasion_explanation: str
+    evasion_type: str | None = None
 
 
 class LearnAnnotationsResponse(BaseModel):
@@ -452,6 +454,7 @@ def get_call_evasion(ticker: str, conn: DbDep, response: Response) -> EvasionRes
             evasion_explanation=r[2],
             question_topic=r[3],
             analyst_name=r[4],
+            evasion_type=r[5],
         )
         for r in raw_evasion
     ]

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -388,7 +388,8 @@ class AnalysisRepository:
         """Return evasion entries ordered by call sequence.
 
         Each row: (analyst_name, question_topic, question_text, answer_text,
-                   analyst_concern, defensiveness_score, evasion_explanation)
+                   analyst_concern, defensiveness_score, evasion_explanation,
+                   evasion_type)
         """
         rows = []
         try:
@@ -399,7 +400,7 @@ class AnalysisRepository:
                         SELECT ea.analyst_name, ea.question_topic,
                                ea.question_text, ea.answer_text,
                                ea.analyst_concern, ea.defensiveness_score,
-                               ea.evasion_explanation
+                               ea.evasion_explanation, ea.evasion_type
                         FROM evasion_analysis ea
                         JOIN transcript_chunks tc ON ea.chunk_id = tc.chunk_id AND ea.call_id = tc.call_id
                         JOIN calls c ON ea.call_id = c.id
@@ -415,11 +416,11 @@ class AnalysisRepository:
 
     def get_evasion_for_ticker(
         self, ticker: str, conn: psycopg.Connection | None = None
-    ) -> list[tuple[str, int, str, str | None, str | None]]:
+    ) -> list[tuple[str, int, str, str | None, str | None, str | None]]:
         """Return evasion analysis entries for a ticker.
 
         Each row: (analyst_concern, defensiveness_score, evasion_explanation,
-                   question_topic, analyst_name)
+                   question_topic, analyst_name, evasion_type)
         """
         rows = []
         try:
@@ -429,7 +430,7 @@ class AnalysisRepository:
                     cur.execute(
                         """
                         SELECT ea.analyst_concern, ea.defensiveness_score, ea.evasion_explanation,
-                               ea.question_topic, ea.analyst_name
+                               ea.question_topic, ea.analyst_name, ea.evasion_type
                         FROM evasion_analysis ea
                         JOIN calls c ON ea.call_id = c.id
                         WHERE c.ticker = %s
@@ -550,6 +551,7 @@ class AnalysisRepository:
                 "analyst_concern": r[4],
                 "defensiveness_score": r[5],
                 "evasion_explanation": r[6],
+                "evasion_type": r[7],
             }
             for r in raw_evasion
         ]
@@ -885,8 +887,9 @@ class AnalysisRepository:
             INSERT INTO evasion_analysis (
                 call_id, chunk_id,
                 analyst_name, question_topic, question_text, answer_text,
-                analyst_concern, defensiveness_score, evasion_explanation
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                analyst_concern, defensiveness_score, evasion_explanation,
+                evasion_type
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             """,
             (
                 str(call_id), chunk.chunk_id,
@@ -897,6 +900,7 @@ class AnalysisRepository:
                 evasion.get("analyst_concern"),
                 evasion.get("defensiveness_score") or 0,
                 evasion.get("evasion_explanation") or "",
+                evasion.get("evasion_type"),
             ),
         )
 

--- a/ingestion/prompts.py
+++ b/ingestion/prompts.py
@@ -71,7 +71,7 @@ Respond ONLY with valid JSON matching this schema:
 }
 """
 
-TIER_2_SYSTEM_PROMPT = """You are an expert financial educator. 
+TIER_2_SYSTEM_PROMPT = """You are an expert financial educator.
 Your goal is to help a beginner understand the nuances, themes, and subtext of an earnings call.
 You are given a chunk of an earnings transcript that has been flagged as strategically important.
 
@@ -84,8 +84,21 @@ Follow these instructions depending on whether the chunk is from Prepared Remark
    - answer_text: the executive's verbatim response from the transcript
    - analyst_concern: the analyst's underlying concern or worry in 1-2 sentences
    - defensiveness_score: 1-10 score of how much the executive evaded or deflected
-   - evasion_explanation: explain why the response was or was not evasive
+   - evasion_type: the dominant evasion pattern from the Evasion Taxonomy below. Pick exactly one. Use "none" when the executive answered the question directly.
+   - evasion_explanation: explain why the response was or was not evasive, naming the specific pivot, omission, or substitution that earned the evasion_type.
 3. **Misconceptions ("Gotchas")**: Identify any counter-intuitive business logic that a student might misunderstand from this text. (e.g., {"fact": "Revenue dropped", "misinterpretation": "They lost customers", "correction": "They changed billing cycles"}).
+
+## Evasion Taxonomy
+
+Use one of these values for evasion_type. Pick the single most prominent pattern when more than one applies. Default to "none" when the answer addresses the question on its merits — typically when defensiveness_score is 1–4.
+
+- deflect_to_forward_looking: the analyst asked about a current or recent metric/event; the executive pivots to future guidance, optimism about next year, or long-term strategy. Example: asked why this quarter's gross margin compressed, the CFO talks about confidence in their long-term margin trajectory.
+- reframe: the executive accepts the topic but recasts the question into a different one they prefer to answer. Example: asked specifically about China revenue, the executive answers about "international markets overall."
+- verbose_non_answer: the executive talks at length, repeats prepared-remark talking points, and never lands on the specific number or judgment that was asked for. Length without substance.
+- redirect_to_different_metric: the analyst asked about metric A; the executive answers using metric B that paints a more favorable picture. Example: asked about unit volume decline, the executive cites revenue growth driven by price.
+- partial_answer: the executive answers part of a multi-part question and leaves the harder or more sensitive part untouched.
+- run_out_clock: the executive thanks the analyst, defers ("we'll cover that at the upcoming investor day", "we don't break that out"), and moves on without engaging.
+- none: the executive answered the question directly with the requested data, judgment, or admission.
 
 Respond ONLY with valid JSON matching this schema:
 {
@@ -100,6 +113,7 @@ Respond ONLY with valid JSON matching this schema:
     "answer_text": "string",
     "analyst_concern": "string",
     "defensiveness_score": 5,
+    "evasion_type": "deflect_to_forward_looking",
     "evasion_explanation": "string"
   },
   "misconceptions": [

--- a/supabase/migrations/20260427000000_evasion_type.sql
+++ b/supabase/migrations/20260427000000_evasion_type.sql
@@ -1,0 +1,31 @@
+-- Migration: add evasion_type categorical column to evasion_analysis
+-- Powers Q&A Forensics mode: pattern recognition across exchanges requires
+-- a named taxonomy (deflect, reframe, verbose non-answer, etc.) rather than
+-- only the free-text evasion_explanation.
+--
+-- Nullable on existing rows; new ingestions populate it from the Tier 2 prompt.
+
+ALTER TABLE evasion_analysis
+    ADD COLUMN IF NOT EXISTS evasion_type TEXT;
+
+ALTER TABLE evasion_analysis
+    DROP CONSTRAINT IF EXISTS evasion_analysis_evasion_type_check;
+
+ALTER TABLE evasion_analysis
+    ADD CONSTRAINT evasion_analysis_evasion_type_check
+    CHECK (
+        evasion_type IS NULL
+        OR evasion_type IN (
+            'deflect_to_forward_looking',
+            'reframe',
+            'verbose_non_answer',
+            'redirect_to_different_metric',
+            'partial_answer',
+            'run_out_clock',
+            'none'
+        )
+    );
+
+CREATE INDEX IF NOT EXISTS idx_evasion_analysis_type
+    ON evasion_analysis(evasion_type)
+    WHERE evasion_type IS NOT NULL;

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -660,8 +660,8 @@ class TestGetCallEvasion:
             patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
         ):
             MockAnalysisRepo.return_value.get_evasion_for_ticker.return_value = [
-                ("margin guidance", 7, "Deflected to top-line", "margins", "John Smith"),
-                ("capex outlook", 8, "Vague non-answer", "capex", "Jane Doe"),
+                ("margin guidance", 7, "Deflected to top-line", "margins", "John Smith", "deflect_to_forward_looking"),
+                ("capex outlook", 8, "Vague non-answer", "capex", "Jane Doe", "verbose_non_answer"),
             ]
             response = api_client.get("/api/calls/AAPL/evasion")
 


### PR DESCRIPTION
## Summary

Phase 1 of Q&A Forensics mode — establishes the data foundation by categorizing each Q&A evasion exchange with a dominant pattern.

The current ingestion captures `evasion_explanation` as free text but no category. Without a taxonomy, the upcoming forensics UI can't teach pattern recognition (e.g. "you've now seen three reframes this week"). This PR adds a 7-value enum (`deflect_to_forward_looking`, `reframe`, `verbose_non_answer`, `redirect_to_different_metric`, `partial_answer`, `run_out_clock`, `none`) and threads it through the prompt, DB, repo, and API.

## Changes

- **Migration** (`supabase/migrations/20260427000000_evasion_type.sql`): nullable `evasion_type` column on `evasion_analysis` with a `CHECK` constraint and a partial index. Existing rows stay `NULL` until re-ingested.
- **Tier 2 prompt** (`ingestion/prompts.py`): added a separate `## Evasion Taxonomy` section with one-line definitions per type, plus `evasion_type` in the instruction list and JSON schema.
- **Repo** (`db/repositories/analysis.py`): `_save_chunk_evasion` inserts the field; `get_qa_evasion_for_ticker`, `get_evasion_for_ticker`, and `get_learn_annotations_for_ticker` all surface it.
- **API** (`api/routes/calls.py`): `EvasionItem` and `QAEvasionItem` expose `evasion_type: str | None = None`; `/evasion` route handler unpacks the new column.
- **Tests** (`tests/unit/api/test_calls.py`): `get_evasion_for_ticker` mocks updated from 5- to 6-tuples.

## Backward compatibility

- Existing `evasion_analysis` rows have `NULL` `evasion_type` and remain valid.
- New Pydantic fields default to `None`, so existing API consumers ignoring the extra key continue to work.
- The frontend `QAEvasionItem` TS type doesn't reference the new field yet — no UI surface uses it in this PR. That comes in Phase 3 when the Q&A Forensics mode is built.

## What this unblocks

- **Phase 2**: \`GET /api/calls/{ticker}/qa-forensics\` endpoint (filtered by \`defensiveness_score >= 5\`, sorted descending, returns \`evasion_type\` for the wrap-up screen).
- **Phase 3**: Q&A Forensics UI mode — per-exchange judgment hinge (MC + free-text), reveal panel showing the system's verdict, hand-off to the existing Feynman chat seeded with the user's own judgment.
- **Phase 4**: cleanup of inline evasion icons on the transcript view once the dedicated mode is shipped.

## Validation

- Python files pass \`py_compile\`.
- All cross-references (prompt JSON schema, INSERT, SELECT, dict composer, Pydantic models, route handler, test mocks) audited via grep — column ordering matches.
- Tests not run locally because the project's \`.venv/bin/python\` symlinks to a removed \`pyenv 3.11.7\` interpreter — venv needs rebuild before \`pytest\` will run.

## Test plan

- [ ] Rebuild venv against an available Python 3.11+ and confirm \`pytest tests/unit/api/test_calls.py\` passes.
- [ ] Apply migration to a dev Supabase: confirm \`evasion_type\` column exists, CHECK constraint accepts the 7 values, rejects others.
- [ ] Re-ingest 2–3 recent calls (suggest using \`tools/prompt_tuner.py\` to compare current vs. updated Tier 2 output) and eyeball \`evasion_type\` categorizations against the underlying transcripts.
- [ ] Hit \`GET /api/calls/{ticker}/evasion\` and confirm \`evasion_type\` appears in the JSON response (will be \`null\` for un-re-ingested rows).