### PR TITLE
feat: add /qa-forensics endpoint for dedicated learning mode

### DIFF
--- a/api/routes/calls.py
+++ b/api/routes/calls.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import time
+from collections import Counter
 from contextlib import nullcontext
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,19 @@ def _ticker_exists(ticker: str, conn: psycopg.Connection | None = None) -> bool:
         with c.cursor() as cur:
             cur.execute("SELECT 1 FROM calls WHERE ticker = %s LIMIT 1", (ticker,))
             return cur.fetchone() is not None
+
+
+def _dominant_evasion_type(types: list[str | None]) -> str | None:
+    """Return the most common evasion_type across exchanges, ignoring 'none' and null.
+
+    Used by /qa-forensics to seed the wrap-up screen ("the dominant pattern in this
+    call was X — watch for it next call"). Returns None when every exchange was
+    'none' or unclassified.
+    """
+    filtered = [t for t in types if t and t != "none"]
+    if not filtered:
+        return None
+    return Counter(filtered).most_common(1)[0][0]
 
 
 # --- Response models ---
@@ -182,6 +196,26 @@ class TopicsResponse(BaseModel):
 class EvasionResponse(BaseModel):
     evasion_analyses: list[EvasionItem] = []
     evasion_level: str | None = None
+
+
+class QAForensicsExchange(BaseModel):
+    """One Q&A exchange surfaced for the dedicated forensics learning mode."""
+
+    id: str
+    analyst_name: str | None = None
+    question_topic: str | None = None
+    question_text: str | None = None
+    answer_text: str | None = None
+    analyst_concern: str
+    defensiveness_score: int
+    evasion_explanation: str
+    evasion_type: str | None = None
+
+
+class QAForensicsResponse(BaseModel):
+    exchanges: list[QAForensicsExchange] = []
+    total: int = 0
+    dominant_evasion_type: str | None = None
 
 
 class StrategicShiftsResponse(BaseModel):
@@ -464,6 +498,50 @@ def get_call_evasion(ticker: str, conn: DbDep, response: Response) -> EvasionRes
         evasion_level = "high" if avg_score > 6 else ("medium" if avg_score > 3 else "low")
     response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
     return EvasionResponse(evasion_analyses=evasion_analyses, evasion_level=evasion_level)
+
+
+@router.get("/{ticker}/qa-forensics", response_model=QAForensicsResponse)
+def get_qa_forensics(
+    ticker: str,
+    conn: DbDep,
+    response: Response,
+    min_score: int = Query(5, ge=1, le=10),
+) -> QAForensicsResponse:
+    """Return Q&A evasion exchanges for the dedicated forensics learning mode.
+
+    Filters to defensiveness_score >= min_score and orders by score DESC then
+    chronological sequence. Computes the dominant evasion_type across the
+    returned exchanges (excluding 'none') for the wrap-up screen.
+    """
+    logger.info("GET /api/calls/%s/qa-forensics min_score=%d", ticker, min_score)
+    if not _ticker_exists(ticker, conn):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No call found for ticker {ticker!r}",
+        )
+    analysis_repo = AnalysisRepository(_db_url())
+    rows = analysis_repo.get_qa_forensics_for_ticker(ticker, min_score=min_score)
+    exchanges = [
+        QAForensicsExchange(
+            id=str(r[0]),
+            analyst_name=r[1],
+            question_topic=r[2],
+            question_text=r[3],
+            answer_text=r[4],
+            analyst_concern=r[5],
+            defensiveness_score=r[6],
+            evasion_explanation=r[7],
+            evasion_type=r[8],
+        )
+        for r in rows
+    ]
+    dominant = _dominant_evasion_type([e.evasion_type for e in exchanges])
+    response.headers["Cache-Control"] = "public, max-age=300, stale-while-revalidate=60"
+    return QAForensicsResponse(
+        exchanges=exchanges,
+        total=len(exchanges),
+        dominant_evasion_type=dominant,
+    )
 
 
 @router.get("/{ticker}/strategic-shifts", response_model=StrategicShiftsResponse)

--- a/db/repositories/analysis.py
+++ b/db/repositories/analysis.py
@@ -443,6 +443,46 @@ class AnalysisRepository:
             logger.warning(f"Could not fetch evasion analysis for {ticker}: {e}")
         return rows
 
+    def get_qa_forensics_for_ticker(
+        self, ticker: str, min_score: int = 5
+    ) -> list[tuple]:
+        """Return Q&A evasion exchanges for the dedicated forensics learning mode.
+
+        Filters to defensiveness_score >= min_score and excludes rows missing
+        both question_text and answer_text (unusable as a teaching surface).
+        Ordered by defensiveness_score DESC, then chronological sequence —
+        most-evasive first, ties broken by call order.
+
+        Each row: (id, analyst_name, question_topic, question_text, answer_text,
+                   analyst_concern, defensiveness_score, evasion_explanation,
+                   evasion_type)
+        """
+        rows = []
+        try:
+            with psycopg.connect(self.conn_str) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT ea.id, ea.analyst_name, ea.question_topic,
+                               ea.question_text, ea.answer_text,
+                               ea.analyst_concern, ea.defensiveness_score,
+                               ea.evasion_explanation, ea.evasion_type
+                        FROM evasion_analysis ea
+                        JOIN transcript_chunks tc
+                            ON ea.chunk_id = tc.chunk_id AND ea.call_id = tc.call_id
+                        JOIN calls c ON ea.call_id = c.id
+                        WHERE c.ticker = %s
+                          AND ea.defensiveness_score >= %s
+                          AND (ea.question_text IS NOT NULL OR ea.answer_text IS NOT NULL)
+                        ORDER BY ea.defensiveness_score DESC, tc.sequence_order ASC
+                        """,
+                        (ticker, min_score),
+                    )
+                    rows = cur.fetchall()
+        except Exception as e:
+            logger.warning(f"Could not fetch Q&A forensics for {ticker}: {e}")
+        return rows
+
     def get_misconceptions_for_ticker(self, ticker: str) -> list[tuple[str, str, str]]:
         """Return misconception entries for a ticker as (fact, misinterpretation, correction)."""
         rows = []

--- a/tests/unit/api/test_calls.py
+++ b/tests/unit/api/test_calls.py
@@ -685,6 +685,114 @@ class TestGetCallEvasion:
         assert data["evasion_level"] is None
 
 
+class TestGetQAForensics:
+    def test_404_for_unknown_ticker(self, api_client):
+        with patch("routes.calls._ticker_exists", return_value=False):
+            response = api_client.get("/api/calls/UNKNOWN/qa-forensics")
+        assert response.status_code == 404
+
+    def test_returns_exchanges_and_dominant_type(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.return_value = [
+                (
+                    "exch-1", "John Smith", "margin guidance",
+                    "Why did gross margin compress?", "We feel great about long-term trajectory.",
+                    "Dodging margin question", 8,
+                    "Pivoted to long-term narrative.", "deflect_to_forward_looking",
+                ),
+                (
+                    "exch-2", "Jane Doe", "China revenue",
+                    "Can you break out China specifically?", "International overall is strong.",
+                    "Avoiding regional disclosure", 7,
+                    "Reframed China as international.", "reframe",
+                ),
+                (
+                    "exch-3", "Mike Lee", "capex outlook",
+                    "What's Q4 capex?", "We're investing for the future.",
+                    "Vague capex framing", 7,
+                    "Repeated talking points without numbers.", "deflect_to_forward_looking",
+                ),
+            ]
+            response = api_client.get("/api/calls/AAPL/qa-forensics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 3
+        assert len(data["exchanges"]) == 3
+        assert data["exchanges"][0]["id"] == "exch-1"
+        assert data["exchanges"][0]["evasion_type"] == "deflect_to_forward_looking"
+        assert data["dominant_evasion_type"] == "deflect_to_forward_looking"
+
+    def test_empty_state(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.return_value = []
+            response = api_client.get("/api/calls/AAPL/qa-forensics")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["exchanges"] == []
+        assert data["total"] == 0
+        assert data["dominant_evasion_type"] is None
+
+    def test_min_score_param_passed_through(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.return_value = []
+            response = api_client.get("/api/calls/AAPL/qa-forensics?min_score=8")
+
+        assert response.status_code == 200
+        MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.assert_called_once_with(
+            "AAPL", min_score=8
+        )
+
+    def test_min_score_out_of_range_rejected(self, api_client):
+        # Query(ge=1, le=10) should reject 0 and 11.
+        with patch("routes.calls._ticker_exists", return_value=True):
+            response = api_client.get("/api/calls/AAPL/qa-forensics?min_score=0")
+        assert response.status_code == 422
+
+    def test_dominant_excludes_none_type(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            # Three exchanges with 'none', one with 'reframe' — reframe should win
+            # because 'none' is filtered out before the count.
+            MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.return_value = [
+                ("e1", "A", "t1", "q1", "a1", "concern1", 5, "expl1", "none"),
+                ("e2", "B", "t2", "q2", "a2", "concern2", 5, "expl2", "none"),
+                ("e3", "C", "t3", "q3", "a3", "concern3", 5, "expl3", "none"),
+                ("e4", "D", "t4", "q4", "a4", "concern4", 5, "expl4", "reframe"),
+            ]
+            response = api_client.get("/api/calls/AAPL/qa-forensics")
+
+        assert response.status_code == 200
+        assert response.json()["dominant_evasion_type"] == "reframe"
+
+    def test_dominant_null_when_all_unclassified(self, api_client):
+        with (
+            patch("routes.calls._ticker_exists", return_value=True),
+            patch("routes.calls.AnalysisRepository") as MockAnalysisRepo,
+        ):
+            # All rows have 'none' or null evasion_type — backfill scenario.
+            MockAnalysisRepo.return_value.get_qa_forensics_for_ticker.return_value = [
+                ("e1", "A", "t1", "q1", "a1", "concern1", 5, "expl1", "none"),
+                ("e2", "B", "t2", "q2", "a2", "concern2", 5, "expl2", None),
+            ]
+            response = api_client.get("/api/calls/AAPL/qa-forensics")
+
+        assert response.status_code == 200
+        assert response.json()["dominant_evasion_type"] is None
+
+
 class TestGetCallStrategicShifts:
     def test_404_for_unknown_ticker(self, api_client):
         with patch("routes.calls._ticker_exists", return_value=False):


### PR DESCRIPTION
## Summary

Phase 2 of Q&A Forensics mode — the API surface that Phase 3's UI will consume. Exposes filtered, ranked Q&A evasion exchanges plus a precomputed `dominant_evasion_type` so the wrap-up screen has something to say without a second roundtrip.

## Endpoint

```
GET /api/calls/{ticker}/qa-forensics?min_score=5
```

- `min_score` (query, int 1–10, default 5): defensiveness threshold. Out-of-range values rejected with 422.
- Filters: `defensiveness_score >= min_score`; excludes rows where both `question_text` and `answer_text` are NULL (unusable for the learning surface).
- Ordering: `defensiveness_score DESC`, then `transcript_chunks.sequence_order ASC` — most-evasive first, ties broken by chronological call order.
- Cache-Control headers match `/evasion` (5 min cache + stale-while-revalidate).

## Response shape

```json
{
  "exchanges": [
    {
      "id": "uuid",
      "analyst_name": "Jane Doe",
      "question_topic": "China revenue",
      "question_text": "Can you break out China specifically?",
      "answer_text": "International overall is strong...",
      "analyst_concern": "Avoiding regional disclosure",
      "defensiveness_score": 8,
      "evasion_explanation": "Reframed China as international.",
      "evasion_type": "reframe"
    }
  ],
  "total": 1,
  "dominant_evasion_type": "reframe"
}
```

`evasion_explanation` ships in the same payload — withholding it from the user until the "reveal" step is purely a frontend rendering concern (avoids a second roundtrip per exchange).

## Changes

- **Repo** (`db/repositories/analysis.py`): new `get_qa_forensics_for_ticker(ticker, min_score=5)` method, placed alongside the existing evasion readers.
- **Route** (`api/routes/calls.py`): new `QAForensicsExchange` and `QAForensicsResponse` Pydantic models; new `get_qa_forensics` route handler; new `_dominant_evasion_type` helper that returns the most common non-`none` category and falls back to `None` when all rows are `none` or unclassified.
- **Tests** (`tests/unit/api/test_calls.py`): `TestGetQAForensics` covering 404 unknown ticker, populated response, empty state, `min_score` passthrough, out-of-range rejection (422), dominant excludes `none`, dominant null when all unclassified.

## Backfill behavior

Calls ingested before Phase 1 have `evasion_type = NULL`. The dominant calculation handles this — null rows are filtered out alongside `none` rows, so the wrap-up screen will show `dominant_evasion_type: null` for un-re-ingested calls. The exchanges themselves still surface (with null `evasion_type` tags); the UI can render those as "uncategorized" if needed.

## What this unblocks

- **Phase 3**: `/calls/[ticker]/qa-forensics` route in `web/`, plus `QAForensicsShell`, `QAExchangeCard`, `QAJudgmentPrompt`, `QARevealPanel`, `QAForensicsWrapUp` components. The shell calls this endpoint once on page load and walks the user through the exchanges client-side.
- **Phase 4**: cleanup of inline evasion icons on the transcript view.

## Validation

- All three Python files pass `py_compile`.
- Tests not run locally because the `.venv` Python interpreter symlinks to a removed pyenv install (flagged in PR #416). Once the venv is rebuilt, this branch's six new tests should be runnable alongside the existing suite.

## Test plan

- [ ] Rebuild `.venv` and run `pytest tests/unit/api/test_calls.py::TestGetQAForensics -v` — all six tests should pass.
- [ ] Hit `GET /api/calls/{ticker}/qa-forensics` against a re-ingested call from Phase 1 and confirm `evasion_type` and `dominant_evasion_type` populate.
- [ ] Hit the same endpoint on a pre-Phase-1 call and confirm exchanges surface with `evasion_type: null` and `dominant_evasion_type: null`.
- [ ] Try `?min_score=0` and `?min_score=11` — both should return 422.
- [ ] Confirm cache headers match `/evasion`.