### PR TITLE
feat: Q&A Forensics UI mode

### DIFF
--- a/web/app/calls/[ticker]/CallTabs.tsx
+++ b/web/app/calls/[ticker]/CallTabs.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface CallTabsProps {
+  ticker: string;
+}
+
+interface TabDef {
+  href: string;
+  label: string;
+}
+
+/** Sub-navigation between transcript view and Q&A Forensics mode for a single call.
+ *  Active state derives from the URL so deep links land on the right tab. */
+export function CallTabs({ ticker }: CallTabsProps) {
+  const pathname = usePathname();
+  const tabs: TabDef[] = [
+    { href: `/calls/${ticker}`, label: "Transcript" },
+    { href: `/calls/${ticker}/qa-forensics`, label: "Q&A Forensics" },
+  ];
+
+  return (
+    <nav
+      aria-label="Call sections"
+      className="flex shrink-0 items-center gap-1 border-b bg-background px-4 py-2"
+    >
+      {tabs.map((tab) => {
+        const isActive =
+          tab.href === `/calls/${ticker}`
+            ? pathname === tab.href
+            : pathname?.startsWith(tab.href);
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              isActive
+                ? "bg-muted text-foreground"
+                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {tab.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/app/calls/[ticker]/GuidedAnalysisView.tsx
+++ b/web/app/calls/[ticker]/GuidedAnalysisView.tsx
@@ -138,7 +138,7 @@ export function GuidedAnalysisView({ call, adjacent, initialTopic }: GuidedAnaly
   const totalPages = spans ? Math.max(1, Math.ceil(spans.total / spans.page_size)) : 1;
 
   return (
-    <div className="flex h-[calc(100dvh-var(--nav-height))] w-full overflow-hidden">
+    <div className="flex h-full w-full overflow-hidden">
       <section
         className={
           chatOpen

--- a/web/app/calls/[ticker]/layout.tsx
+++ b/web/app/calls/[ticker]/layout.tsx
@@ -1,0 +1,21 @@
+import { CallTabs } from "./CallTabs";
+
+/** Shared layout for /calls/[ticker] and its sub-routes. Provides the section
+ *  tab nav (Transcript / Q&A Forensics) and a flex-1 wrapper so child views
+ *  fill the remaining viewport. */
+export default async function CallLayout({
+  params,
+  children,
+}: {
+  params: Promise<{ ticker: string }>;
+  children: React.ReactNode;
+}) {
+  const { ticker } = await params;
+  const upperTicker = ticker.toUpperCase();
+  return (
+    <div className="flex h-[calc(100dvh-var(--nav-height))] min-h-0 w-full flex-col">
+      <CallTabs ticker={upperTicker} />
+      <div className="min-h-0 flex-1">{children}</div>
+    </div>
+  );
+}

--- a/web/app/calls/[ticker]/qa-forensics/page.tsx
+++ b/web/app/calls/[ticker]/qa-forensics/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { QAForensicsClient } from "@/components/qa-forensics/QAForensicsClient";
+import type { QAForensicsResponse } from "@/components/transcript/types";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+async function fetchQAForensics(ticker: string): Promise<QAForensicsResponse | null> {
+  if (!API_URL) throw new Error("NEXT_PUBLIC_API_URL is not configured");
+
+  const res = await fetch(`${API_URL}/api/calls/${ticker}/qa-forensics`, {
+    next: { revalidate: 300 },
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    const msg = await res.text().catch(() => res.statusText);
+    throw new Error(`API error ${res.status}: ${msg}`);
+  }
+
+  return res.json() as Promise<QAForensicsResponse>;
+}
+
+/** Q&A Forensics learning mode for a single call. */
+export default async function QAForensicsPage({
+  params,
+}: {
+  params: Promise<{ ticker: string }>;
+}) {
+  const { ticker } = await params;
+  const upperTicker = ticker.toUpperCase();
+  const data = await fetchQAForensics(upperTicker);
+
+  if (!data) {
+    return (
+      <div className="mx-auto w-full max-w-7xl px-6 py-12">
+        <p className="text-sm text-muted-foreground">
+          No transcript found for{" "}
+          <span className="font-semibold uppercase">{ticker}</span>.{" "}
+          <Link href="/" className="underline hover:text-foreground">
+            Back to library
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return <QAForensicsClient ticker={upperTicker} data={data} />;
+}

--- a/web/components/learn/ChatPanel.tsx
+++ b/web/components/learn/ChatPanel.tsx
@@ -121,6 +121,10 @@ function contextToPrompt(context: ChatContext): string {
       return `Explain "${context.text}" in context${context.metadata ? `: ${context.metadata}` : ""}.`;
     case "guidance":
       return `What should I take away from this guidance point? ${context.text}`;
+    case "qa-forensics":
+      // Seed is fully constructed by QAForensicsClient — pass through verbatim
+      // so Stage 1 of the Feynman flow gets the user's own judgment as context.
+      return context.text;
     default:
       return context.text;
   }

--- a/web/components/learn/types.ts
+++ b/web/components/learn/types.ts
@@ -12,7 +12,7 @@ export const DEFAULT_LAYERS: AnnotationLayers = {
 };
 
 export interface ChatContext {
-  type: "evasion" | "term" | "guidance";
+  type: "evasion" | "term" | "guidance" | "qa-forensics";
   text: string;
   metadata?: string;
 }

--- a/web/components/qa-forensics/QAExchangeCard.tsx
+++ b/web/components/qa-forensics/QAExchangeCard.tsx
@@ -1,0 +1,58 @@
+import { Card } from "@/components/ui/card";
+import type { QAForensicsExchange } from "./types";
+
+interface QAExchangeCardProps {
+  exchange: QAForensicsExchange;
+  index: number;
+  total: number;
+}
+
+/** STAKES → QUESTION → ANSWER blocks. The exchange itself, no verdict shown yet. */
+export function QAExchangeCard({ exchange, index, total }: QAExchangeCardProps) {
+  const analystLabel = [exchange.analyst_name, exchange.question_topic]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <Card className="space-y-5 px-5 py-5">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="uppercase tracking-wide">Q&amp;A Forensics</span>
+        <span>
+          Exchange {index + 1} of {total}
+        </span>
+      </div>
+
+      <section aria-label="Stakes">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Stakes
+        </p>
+        <p className="mt-1 text-sm text-foreground">
+          {analystLabel ? <span className="font-medium">{analystLabel}.</span> : null}{" "}
+          {exchange.analyst_concern}
+        </p>
+      </section>
+
+      {exchange.question_text ? (
+        <section aria-label="The question">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            The question
+          </p>
+          <blockquote className="mt-1 border-l-2 border-border pl-3 text-sm text-foreground">
+            {exchange.question_text}
+          </blockquote>
+        </section>
+      ) : null}
+
+      {exchange.answer_text ? (
+        <section aria-label="The answer">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            The answer
+          </p>
+          <blockquote className="mt-1 border-l-2 border-border pl-3 text-sm text-foreground">
+            {exchange.answer_text}
+          </blockquote>
+        </section>
+      ) : null}
+    </Card>
+  );
+}

--- a/web/components/qa-forensics/QAForensicsClient.tsx
+++ b/web/components/qa-forensics/QAForensicsClient.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import Link from "next/link";
+import { ChatPanel } from "@/components/learn/ChatPanel";
+import { Card } from "@/components/ui/card";
+import { useFlag } from "@/lib/useFlag";
+import type { ChatContext } from "@/components/learn/types";
+import type { QAForensicsResponse } from "@/components/transcript/types";
+import { QAExchangeCard } from "./QAExchangeCard";
+import { QAJudgmentPrompt } from "./QAJudgmentPrompt";
+import { QARevealPanel } from "./QARevealPanel";
+import { QAForensicsWrapUp } from "./QAForensicsWrapUp";
+import {
+  evasionTypeLabel,
+  JUDGMENT_LABELS,
+  type Judgment,
+  type QAForensicsExchange,
+} from "./types";
+
+interface QAForensicsClientProps {
+  ticker: string;
+  data: QAForensicsResponse;
+}
+
+const EMPTY_JUDGMENT: Judgment = { choice: null, text: "", revealed: false };
+
+/** Stateful shell for the Q&A Forensics learning mode. Walks the user through
+ *  each exchange one at a time, gating reveal behind a judgment commitment,
+ *  then hands off to the existing Feynman chat seeded with the user's reasoning. */
+export function QAForensicsClient({ ticker, data }: QAForensicsClientProps) {
+  const chatEnabled = useFlag("chat_enabled", true);
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [judgments, setJudgments] = useState<Record<string, Judgment>>({});
+  const [chatContext, setChatContext] = useState<ChatContext | null>(null);
+  const [chatOpen, setChatOpen] = useState(false);
+
+  const exchanges = data.exchanges;
+  const total = data.total;
+  const isComplete = total > 0 && currentIndex >= total;
+  const currentExchange = !isComplete ? exchanges[currentIndex] : null;
+  const currentJudgment = currentExchange
+    ? judgments[currentExchange.id] ?? EMPTY_JUDGMENT
+    : EMPTY_JUDGMENT;
+
+  const updateJudgment = useCallback(
+    (exchangeId: string, next: Judgment) => {
+      setJudgments((prev) => ({ ...prev, [exchangeId]: next }));
+    },
+    [],
+  );
+
+  const handleReveal = useCallback(() => {
+    if (!currentExchange) return;
+    updateJudgment(currentExchange.id, { ...currentJudgment, revealed: true });
+  }, [currentExchange, currentJudgment, updateJudgment]);
+
+  const handleNext = useCallback(() => {
+    setCurrentIndex((i) => i + 1);
+  }, []);
+
+  const handleRestart = useCallback(() => {
+    setCurrentIndex(0);
+    setJudgments({});
+  }, []);
+
+  const handleDiscuss = useCallback(() => {
+    if (!currentExchange) return;
+    setChatContext({
+      type: "qa-forensics",
+      text: buildSeedMessage(currentExchange, currentJudgment),
+    });
+    setChatOpen(true);
+  }, [currentExchange, currentJudgment]);
+
+  const handleCloseChat = useCallback(() => {
+    setChatOpen(false);
+  }, []);
+
+  const wrapUp = useMemo(
+    () =>
+      isComplete ? (
+        <QAForensicsWrapUp
+          total={total}
+          dominantEvasionType={data.dominant_evasion_type}
+          ticker={ticker}
+          onRestart={handleRestart}
+        />
+      ) : null,
+    [isComplete, total, data.dominant_evasion_type, ticker, handleRestart],
+  );
+
+  if (total === 0) {
+    return (
+      <div className="mx-auto w-full max-w-3xl px-4 py-8">
+        <Card className="space-y-3 px-6 py-6">
+          <h2 className="text-lg font-semibold text-foreground">No forensics-ready exchanges</h2>
+          <p className="text-sm text-muted-foreground">
+            This call has no Q&amp;A exchanges meeting the defensiveness threshold yet.
+            Either the executives answered analysts directly, or this call hasn&apos;t
+            been re-ingested with the new evasion taxonomy.
+          </p>
+          <Link
+            href={`/calls/${ticker}`}
+            className="inline-flex w-fit text-sm text-primary hover:underline"
+          >
+            ← Back to transcript
+          </Link>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full overflow-hidden">
+      <section
+        className={
+          chatOpen
+            ? "hidden min-w-0 flex-1 lg:flex lg:flex-col"
+            : "flex min-w-0 flex-1 flex-col"
+        }
+        aria-label="Q&A Forensics"
+      >
+        <div className="flex-1 overflow-y-auto">
+          <div className="mx-auto w-full max-w-3xl space-y-5 px-4 py-6">
+            {currentExchange ? (
+              <>
+                <QAExchangeCard
+                  exchange={currentExchange}
+                  index={currentIndex}
+                  total={total}
+                />
+                {currentJudgment.revealed ? (
+                  <QARevealPanel
+                    exchange={currentExchange}
+                    judgment={currentJudgment}
+                    onDiscuss={handleDiscuss}
+                    onNext={handleNext}
+                    isLast={currentIndex === total - 1}
+                  />
+                ) : (
+                  <QAJudgmentPrompt
+                    judgment={currentJudgment}
+                    onChange={(next) => updateJudgment(currentExchange.id, next)}
+                    onReveal={handleReveal}
+                  />
+                )}
+              </>
+            ) : (
+              wrapUp
+            )}
+          </div>
+        </div>
+      </section>
+
+      {chatEnabled && chatOpen ? (
+        <div className="fixed inset-0 z-40 flex lg:static lg:z-auto lg:inset-auto">
+          <button
+            type="button"
+            aria-label="Close chat overlay"
+            onClick={handleCloseChat}
+            className="flex-1 bg-black/30 lg:hidden"
+          />
+          <div className="h-full w-full bg-background lg:w-[400px] lg:border-l">
+            <ChatPanel ticker={ticker} context={chatContext} onClose={handleCloseChat} />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function buildSeedMessage(
+  exchange: QAForensicsExchange,
+  judgment: Judgment,
+): string {
+  const choiceLabel = judgment.choice ? JUDGMENT_LABELS[judgment.choice] : "—";
+  const typeLabel = evasionTypeLabel(exchange.evasion_type);
+  const topic = exchange.question_topic ? ` about ${exchange.question_topic}` : "";
+
+  const lines = [
+    `I just read this Q&A exchange${topic}:`,
+    "",
+    `Q: ${exchange.question_text ?? "(question text not available)"}`,
+    "",
+    `A: ${exchange.answer_text ?? "(answer text not available)"}`,
+    "",
+    `My judgment: "${choiceLabel}" — ${judgment.text || "(no reasoning provided)"}`,
+    "",
+    `The system flagged this as: ${typeLabel}.`,
+    "",
+    `Help me understand the gap between what I noticed and what was actually happening here.`,
+  ];
+  return lines.join("\n");
+}

--- a/web/components/qa-forensics/QAForensicsWrapUp.tsx
+++ b/web/components/qa-forensics/QAForensicsWrapUp.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { evasionTypeLabel } from "./types";
+
+interface QAForensicsWrapUpProps {
+  total: number;
+  dominantEvasionType: string | null;
+  ticker: string;
+  onRestart: () => void;
+}
+
+/** End-of-mode summary: count, dominant pattern (when known), and a transferable
+ *  pattern-recognition cue for the next call the user reads. */
+export function QAForensicsWrapUp({
+  total,
+  dominantEvasionType,
+  ticker,
+  onRestart,
+}: QAForensicsWrapUpProps) {
+  const dominantLabel = dominantEvasionType ? evasionTypeLabel(dominantEvasionType) : null;
+
+  return (
+    <Card className="space-y-5 px-6 py-6">
+      <div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Q&amp;A Forensics complete
+        </p>
+        <h2 className="mt-1 text-xl font-semibold text-foreground">
+          You worked through {total} {total === 1 ? "exchange" : "exchanges"}.
+        </h2>
+      </div>
+
+      {dominantLabel ? (
+        <section className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Dominant pattern
+          </p>
+          <p className="text-sm text-foreground">
+            The most common evasion pattern in this call was{" "}
+            <span className="font-semibold">{dominantLabel}</span>.
+          </p>
+        </section>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          The exchanges in this call weren&apos;t classified into a clear dominant
+          pattern. (Older calls may not have evasion type tags yet.)
+        </p>
+      )}
+
+      <section className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          For your next call
+        </p>
+        <p className="text-sm text-foreground">
+          {dominantLabel
+            ? `Watch for "${dominantLabel}" specifically. The pattern repeats across companies — once you can name it, you can spot it unaided.`
+            : "Keep practicing the judgment hinge: read the question, read the answer, decide for yourself before reading any analysis."}
+        </p>
+      </section>
+
+      <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+        <Button variant="outline" onClick={onRestart}>
+          Restart this call
+        </Button>
+        <Link href={`/calls/${ticker}`} className={buttonVariants({ variant: "default" })}>
+          Back to transcript
+        </Link>
+      </div>
+    </Card>
+  );
+}

--- a/web/components/qa-forensics/QAJudgmentPrompt.tsx
+++ b/web/components/qa-forensics/QAJudgmentPrompt.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { JUDGMENT_LABELS, type Judgment, type JudgmentChoice } from "./types";
+
+interface QAJudgmentPromptProps {
+  judgment: Judgment;
+  onChange: (next: Judgment) => void;
+  onReveal: () => void;
+}
+
+const CHOICES: JudgmentChoice[] = ["yes", "partial", "no"];
+
+/** Active-learning hinge: user commits to an answer before seeing the system's verdict. */
+export function QAJudgmentPrompt({ judgment, onChange, onReveal }: QAJudgmentPromptProps) {
+  const canReveal = judgment.choice !== null && judgment.text.trim().length > 0;
+
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-muted/40 px-5 py-5">
+      <div>
+        <p className="text-sm font-semibold text-foreground">Your turn</p>
+        <p className="text-xs text-muted-foreground">
+          Commit to a judgment before the system shows its analysis. This is the
+          point of the exercise.
+        </p>
+      </div>
+
+      <fieldset className="space-y-2">
+        <legend className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Did the executive answer the question?
+        </legend>
+        <div className="flex flex-wrap gap-2">
+          {CHOICES.map((choice) => {
+            const selected = judgment.choice === choice;
+            return (
+              <label
+                key={choice}
+                className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                  selected
+                    ? "border-primary bg-primary/10 text-foreground"
+                    : "border-border text-muted-foreground hover:bg-muted"
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="judgment-choice"
+                  value={choice}
+                  checked={selected}
+                  onChange={() => onChange({ ...judgment, choice })}
+                  className="sr-only"
+                />
+                <span>{JUDGMENT_LABELS[choice]}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor="judgment-reasoning"
+          className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        >
+          In your own words, why? (1–2 sentences)
+        </label>
+        <Textarea
+          id="judgment-reasoning"
+          value={judgment.text}
+          onChange={(e) => onChange({ ...judgment, text: e.target.value })}
+          placeholder="What did you notice? What did they avoid?"
+          className="min-h-20"
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <Button onClick={onReveal} disabled={!canReveal}>
+          Reveal system analysis →
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/qa-forensics/QARevealPanel.tsx
+++ b/web/components/qa-forensics/QARevealPanel.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { MessageCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  defensivenessBand,
+  evasionTypeLabel,
+  JUDGMENT_LABELS,
+  type Judgment,
+  type QAForensicsExchange,
+} from "./types";
+
+interface QARevealPanelProps {
+  exchange: QAForensicsExchange;
+  judgment: Judgment;
+  onDiscuss: () => void;
+  onNext: () => void;
+  isLast: boolean;
+}
+
+/** Reveal step: shows the system's verdict, comparison to the user's judgment,
+ *  and the two paths forward (deepen via Feynman or move to next exchange). */
+export function QARevealPanel({
+  exchange,
+  judgment,
+  onDiscuss,
+  onNext,
+  isLast,
+}: QARevealPanelProps) {
+  const band = defensivenessBand(exchange.defensiveness_score);
+  const typeLabel = evasionTypeLabel(exchange.evasion_type);
+  const userChoiceLabel = judgment.choice ? JUDGMENT_LABELS[judgment.choice] : null;
+
+  return (
+    <div className="space-y-4 rounded-xl border border-amber-500/40 bg-amber-50/40 px-5 py-5 dark:bg-amber-500/5">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-md bg-amber-500/15 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-200">
+          {band.label}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Defensiveness {exchange.defensiveness_score}/10
+        </span>
+        {exchange.evasion_type ? (
+          <span className="rounded-md border border-border bg-background px-2 py-0.5 text-xs font-medium text-foreground">
+            {typeLabel}
+          </span>
+        ) : null}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{band.description}.</p>
+
+      <section aria-label="System analysis">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          What the system flagged
+        </p>
+        <p className="mt-1 text-sm text-foreground">{exchange.evasion_explanation}</p>
+      </section>
+
+      {userChoiceLabel ? (
+        <section aria-label="Your judgment">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Your judgment
+          </p>
+          <p className="mt-1 text-sm text-foreground">
+            <span className="font-medium">{userChoiceLabel}.</span>{" "}
+            {judgment.text}
+          </p>
+        </section>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-end gap-2 pt-1">
+        <Button variant="outline" onClick={onDiscuss}>
+          <MessageCircle className="mr-1 h-4 w-4" aria-hidden />
+          Discuss further with Feynman
+        </Button>
+        <Button onClick={onNext}>
+          {isLast ? "Finish →" : "Next exchange →"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/qa-forensics/types.ts
+++ b/web/components/qa-forensics/types.ts
@@ -1,0 +1,43 @@
+/** Local types for the Q&A Forensics learning mode. */
+
+import type { QAForensicsExchange } from "@/components/transcript/types";
+
+export type JudgmentChoice = "yes" | "partial" | "no";
+
+export interface Judgment {
+  choice: JudgmentChoice | null;
+  text: string;
+  revealed: boolean;
+}
+
+export const JUDGMENT_LABELS: Record<JudgmentChoice, string> = {
+  yes: "Yes, fully",
+  partial: "Partially",
+  no: "No, they avoided it",
+};
+
+export const EVASION_TYPE_LABELS: Record<string, string> = {
+  deflect_to_forward_looking: "Deflect to forward-looking",
+  reframe: "Reframe the question",
+  verbose_non_answer: "Verbose non-answer",
+  redirect_to_different_metric: "Redirect to a different metric",
+  partial_answer: "Partial answer",
+  run_out_clock: "Run out the clock",
+  none: "Direct answer",
+};
+
+export function evasionTypeLabel(type: string | null | undefined): string {
+  if (!type) return "Uncategorized";
+  return EVASION_TYPE_LABELS[type] ?? type;
+}
+
+export function defensivenessBand(score: number): {
+  label: string;
+  description: string;
+} {
+  if (score >= 8) return { label: "Heavy evasion", description: "Strong dodge — the answer barely engages the question" };
+  if (score >= 6) return { label: "Notable evasion", description: "The answer steers away from what was asked" };
+  return { label: "Mild evasion", description: "Some pivoting, but partly responsive" };
+}
+
+export type { QAForensicsExchange };

--- a/web/components/transcript/types.ts
+++ b/web/components/transcript/types.ts
@@ -140,6 +140,25 @@ export interface QAEvasionItem {
   analyst_concern: string;
   defensiveness_score: number;
   evasion_explanation: string;
+  evasion_type: string | null;
+}
+
+export interface QAForensicsExchange {
+  id: string;
+  analyst_name: string | null;
+  question_topic: string | null;
+  question_text: string | null;
+  answer_text: string | null;
+  analyst_concern: string;
+  defensiveness_score: number;
+  evasion_explanation: string;
+  evasion_type: string | null;
+}
+
+export interface QAForensicsResponse {
+  exchanges: QAForensicsExchange[];
+  total: number;
+  dominant_evasion_type: string | null;
 }
 
 export interface LearnAnnotationsResponse {


### PR DESCRIPTION
## Summary

Phase 3 of Q&A Forensics — the actual UI mode. New `/calls/[ticker]/qa-forensics` route plus a shared `CallTabs` nav so users can switch between the existing transcript view and the dedicated forensics flow.

The pedagogical inversion is the point: every exchange shows the question and answer **first**, requires the user to commit to a judgment (radio + free-text reasoning), and only then reveals the system's defensiveness score, evasion type, and explanation. "Discuss further" hands off to the existing Feynman chat **seeded with the user's own judgment** so Stage 1 of the working chat loop has rich context.

## User flow

```
Land on /calls/AAPL/qa-forensics
  ↓
[STAKES]  Adam Levine (Citi) was worried about gross margin pressure.
[QUESTION] "Can you walk us through how Q4 gross margin guidance reconciles..."
[ANSWER]   "We feel really good about our margin trajectory..."
  ↓
[YOUR TURN]
  ○ Yes, fully    ○ Partially    ○ No, they avoided it
  Reasoning: [textarea — at least one char required to enable Reveal]
  ↓ [Reveal system analysis →]
  ↓
[SYSTEM ANALYSIS]
  Heavy evasion · Defensiveness 8/10 · Deflect to forward-looking
  "What the system flagged: …"
  Your judgment: "No, they avoided it" — your reasoning shown back
  ↓
  [Discuss further with Feynman]   →  opens existing ChatPanel,
                                      seeded with full context
  [Next exchange →]
  ↓
[WRAP-UP]  You worked through 3 exchanges. Dominant pattern: reframe.
           Watch for it next call.
```

## Architecture

- **`web/app/calls/[ticker]/layout.tsx`** (new): shared flex-column layout that hosts `CallTabs` above a `flex-1 min-h-0` wrapper. Both `/calls/[ticker]` and `/calls/[ticker]/qa-forensics` nest inside.
- **`web/app/calls/[ticker]/CallTabs.tsx`** (new): URL-driven sub-nav (Link + `usePathname`). Two tabs: Transcript / Q&A Forensics. Deep links land on the correct tab.
- **`web/app/calls/[ticker]/qa-forensics/page.tsx`** (new): server component. Fetches `/api/calls/{ticker}/qa-forensics` with `revalidate: 300`. Returns 404 messaging if the ticker doesn't exist.
- **`web/components/qa-forensics/`** (new): five mode components plus shell.
  - `QAExchangeCard` — stakes/question/answer blocks (verdict-free)
  - `QAJudgmentPrompt` — radio + textarea + Reveal (button disabled until both filled)
  - `QARevealPanel` — defensiveness band + type tag + explanation + user comparison + action buttons
  - `QAForensicsWrapUp` — count + dominant pattern + transferable cue + restart/back
  - `QAForensicsClient` — stateful shell, manages `currentIndex`, judgment state per exchange (keyed by exchange id), chat panel open/close, builds the seed message
- **`web/components/learn/ChatPanel.tsx`**: extended `contextToPrompt` with a `qa-forensics` case that passes `text` verbatim. The seed is fully owned by the mode.
- **`web/components/learn/types.ts`**: ChatContext union extended with `qa-forensics`.
- **`web/components/transcript/types.ts`**: added `QAForensicsExchange` and `QAForensicsResponse` interfaces; `QAEvasionItem` gets `evasion_type` for forward consistency.
- **`web/app/calls/[ticker]/GuidedAnalysisView.tsx`**: outer `h-[calc(100dvh-var(--nav-height))]` becomes `h-full` so it nests inside the new layout.

## Chat seed format

When the user clicks "Discuss further", the chat panel opens with this prefilled message (user can edit before sending):

```
I just read this Q&A exchange about [question_topic]:

Q: [question_text]

A: [answer_text]

My judgment: "[choice]" — [free_text_reasoning]

The system flagged this as: [evasion_type_label].

Help me understand the gap between what I noticed and what was actually happening here.
```

This gives Stage 1 of the Feynman flow a much richer starting context than the previous "Help me understand this evasion: …" prompt — the model can echo back what the user noticed, identify the gap, and ground its analogy.

## Edge cases handled

- **No exchanges meeting threshold** (older calls without re-ingestion, or genuinely non-evasive calls): empty-state Card with explanation and a back-link.
- **`evasion_type` is null** (pre-Phase-1 calls): the type tag in the reveal panel is omitted; wrap-up falls back to "patterns weren't classified" copy.
- **`dominant_evasion_type` is null** (all rows are `none` or unclassified): wrap-up explains and suggests practicing the judgment hinge generally.
- **`question_text` or `answer_text` is null**: the field renders "(question text not available)" / "(answer text not available)" in both the card and the chat seed. The API endpoint already filters out rows where both are null.

## What this PR intentionally does NOT do

- **Inline evasion icons on the transcript view stay.** Phase 4 will remove them now that Q&A forensics has its own surface.
- **`LayerToggle` still has the 'evasion' boolean.** Phase 4 will drop it.
- **No web tests yet.** The pedagogical UX needs human evaluation before locking it in with Vitest assertions. Once you've validated the flow against a few real calls, I'd add tests for: judgment hinge gating, reveal flow, chat seed construction, empty state, dominant fallback.

## Validation

- Imports audited for path correctness.
- Reused existing patterns: `api.get<T>()` not raw fetch in client components, async `params` Promise in server components, `"use client"` only where needed (state/handlers/`usePathname`).
- `node_modules` not installed locally so couldn't run `tsc --noEmit`. Component logic has been carefully checked but real verification needs `pnpm install` then `pnpm dev`.

## Test plan

- [ ] `pnpm install && pnpm dev` in `web/`, hit `/calls/AAPL/qa-forensics` (or any re-ingested call).
- [ ] Walk through one full exchange: confirm radio + textarea required for Reveal, reveal shows score/type/explanation, chat opens with rich seed when "Discuss further" clicked.
- [ ] Click through to wrap-up, confirm dominant pattern + transferable cue.
- [ ] Restart from wrap-up, confirm state resets.
- [ ] Hit `/calls/[ticker]/qa-forensics` for a pre-Phase-1 call (no `evasion_type` data), confirm graceful degradation (no type tags, fallback wrap-up copy).
- [ ] Hit `/calls/UNKNOWN/qa-forensics`, confirm 404 messaging.
- [ ] Tab nav: switch between Transcript ↔ Q&A Forensics, confirm active state highlights correctly and deep links land on the right tab.
- [ ] Mobile: chat panel overlay should cover the full viewport when open.