### PR TITLE
fix: chat panel scroll + clear between Q&A Forensics exchanges

### DIFF
--- a/web/components/learn/ChatPanel.tsx
+++ b/web/components/learn/ChatPanel.tsx
@@ -98,7 +98,7 @@ export function ChatPanel({ ticker, context, onClose }: ChatPanelProps) {
           </Button>
         </div>
       </header>
-      <div className="flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col">
         <ChatThread messages={messages} streamingContent={streamingContent} />
       </div>
       <div className="p-4">

--- a/web/components/qa-forensics/QAForensicsClient.tsx
+++ b/web/components/qa-forensics/QAForensicsClient.tsx
@@ -57,6 +57,11 @@ export function QAForensicsClient({ ticker, data }: QAForensicsClientProps) {
   }, [currentExchange, currentJudgment, updateJudgment]);
 
   const handleNext = useCallback(() => {
+    // Close chat when moving on so the previous exchange's discussion doesn't
+    // bleed into the next one. The `key` on <ChatPanel /> below resets internal
+    // state on remount as a belt-and-suspenders.
+    setChatOpen(false);
+    setChatContext(null);
     setCurrentIndex((i) => i + 1);
   }, []);
 
@@ -163,7 +168,12 @@ export function QAForensicsClient({ ticker, data }: QAForensicsClientProps) {
             className="flex-1 bg-black/30 lg:hidden"
           />
           <div className="h-full w-full bg-background lg:w-[400px] lg:border-l">
-            <ChatPanel ticker={ticker} context={chatContext} onClose={handleCloseChat} />
+            <ChatPanel
+              key={currentExchange?.id ?? "no-exchange"}
+              ticker={ticker}
+              context={chatContext}
+              onClose={handleCloseChat}
+            />
           </div>
         </div>
       ) : null}


### PR DESCRIPTION
## Summary

Two small fixes from initial use of the Q&A Forensics mode shipped in #418. Targeted scope — the bigger redesign (linearity, chip discoverability, parroting) is queued separately as PR B.

## Fix 1 — Chat panel scroll

**Repro:** open the Feynman chat in either the Transcript view or the Q&A Forensics view, send 5+ messages until the thread overflows the panel height. Observe: thread is silently clipped, no scrollbar.

**Cause:** `ChatPanel`'s body wrapper at `web/components/learn/ChatPanel.tsx:101` was `<div className="flex-1 overflow-hidden">`. `ChatThread` already has its own scroll container (`flex flex-1 flex-col gap-4 overflow-y-auto` on the div with `scrollContainerRef`), but the wrapper wasn't a flex container, so `ChatThread`'s `flex-1` had no parent to grow into — `ChatThread` rendered at content height, and the wrapper's `overflow-hidden` clipped anything beyond.

**Fix:** wrapper becomes `<div className="flex min-h-0 flex-1 flex-col">`. `ChatThread`'s `flex-1` now activates, its `overflow-y-auto` triggers when content exceeds the available height, and the existing `scrollContainerRef` auto-scroll-to-bottom keeps working.

The bug existed before PR #418 — same `ChatPanel` is used by `GuidedAnalysisView` — but only became annoying enough to notice once people actually used the chat for a few back-and-forth turns.

## Fix 2 — Chat clears between Q&A Forensics exchanges

**Repro:** start Q&A Forensics, discuss exchange 1 with Feynman, click "Next exchange →". Open chat for exchange 2 — the previous discussion is still there. Continuing to send messages would extend the same `learning_sessions` row from exchange 1.

**Cause:** `QAForensicsClient` only managed `chatOpen`/`chatContext` at the shell. `ChatPanel`'s own state (`messages`, `sessionId`, `streamingContent`, `abortRef` — all confirmed local to the component, no module-level globals) survived across exchanges because the component never unmounted.

**Fix (two-part, belt-and-suspenders):**
- `handleNext` now also calls `setChatOpen(false)` and `setChatContext(null)` so chat closes and the seed context resets when moving on.
- `<ChatPanel>` is now keyed by `currentExchange?.id` so React unmounts and remounts the component when the index advances, fully resetting all internal state — even if the user manages to keep chat open across the transition.

## Files changed

- `web/components/learn/ChatPanel.tsx` — one-line className change.
- `web/components/qa-forensics/QAForensicsClient.tsx` — close+clear in `handleNext`, `key` on ChatPanel.

## Verification

- [ ] `pnpm install && pnpm dev` in `web/`, hit `/calls/[ticker]` (transcript view), use Feynman chat, send 5+ messages — confirm scrollbar appears, thread auto-scrolls to bottom on new messages.
- [ ] Same on `/calls/[ticker]/qa-forensics` — confirm scroll works there too.
- [ ] In Q&A Forensics, walk through exchange 1, discuss with Feynman (send a message, wait for response). Click "Next exchange →". Confirm:
  - Chat panel closes.
  - Re-opening chat for exchange 2 shows an empty thread, no leaked sessionId.
- [ ] No regressions on Transcript view chat (messages, streaming, abort, layer toggles).

## Out of scope

- **Issue #1** (Forensics flow too linear, system parrots user's text back) → PR B redesign.
- **Issue #4** (broader Feynman chip discoverability, like the old `/learn` empty-state chips) → PR B for forensics-specific chips, possibly separate PR for the general empty-state.

Once you've confirmed these two fixes feel right, I'll spec PR B's redesign before writing it.